### PR TITLE
Removing inheritance hierarchy from Requests & RequestBuilders

### DIFF
--- a/Templates/Android/generated/BaseEntityRequest.java.tt
+++ b/Templates/Android/generated/BaseEntityRequest.java.tt
@@ -12,7 +12,7 @@ var canUseTop = projection.BooleanValueOf("TopSupported") != false;
 <#=writer.WriteHeader()#>
 <#=CreatePackageDef(host)#>
 
-<#=CreateClassDef(BaseTypeRequest(c), c.AsOdcmClass().Base != null ? TypeRequest(BaseClass(c)) : "BaseRequest", IBaseTypeRequest(c))#>
+<#=CreateClassDef(BaseTypeRequest(c), "BaseRequest", IBaseTypeRequest(c))#>
 
     /**
      * The request for the <#=TypeName(c)#>

--- a/Templates/Android/generated/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Android/generated/BaseEntityRequestBuilder.java.tt
@@ -6,11 +6,7 @@
 <#=writer.WriteHeader()#>
 <#=CreatePackageDef(host)#>
 
-<# if (c.BaseClass() != null) { #>
-<#=CreateClassDef(BaseTypeRequestBuilder(c), TypeRequestBuilder(c.BaseClass()), IBaseTypeRequestBuilder(c))#>
-<# } else { #>
 <#=CreateClassDef(BaseTypeRequestBuilder(c), "BaseRequestBuilder", IBaseTypeRequestBuilder(c))#>
-<# } #>
 
     /**
      * The request builder for the <#=TypeName(c)#>

--- a/Templates/Android/generated/IBaseEntityRequest.java.tt
+++ b/Templates/Android/generated/IBaseEntityRequest.java.tt
@@ -12,7 +12,7 @@ var canUseTop = projection.BooleanValueOf("TopSupported") != false;
 <#=writer.WriteHeader()#>
 <#=CreatePackageDef(host)#>
 
-<#=CreateInterfaceDef(IBaseTypeRequest(c), c.AsOdcmClass().Base != null ? ITypeRequest(BaseClass(c)) : "IHttpRequest")#>
+<#=CreateInterfaceDef(IBaseTypeRequest(c), "IHttpRequest")#>
 
 <#  if (c.AsOdcmClass().IsAbstract && c.AsOdcmClass().Base == null)
     {

--- a/Templates/Android/generated/IBaseEntityRequestBuilder.java.tt
+++ b/Templates/Android/generated/IBaseEntityRequestBuilder.java.tt
@@ -6,11 +6,7 @@
 <#=writer.WriteHeader()#>
 <#=CreatePackageDef(host)#>
 
-<# if (c.BaseClass() != null) { #>
-<#=CreateInterfaceDef(IBaseTypeRequestBuilder(c), ITypeRequestBuilder(c.BaseClass()))#>
-<# } else { #>
 <#=CreateInterfaceDef(IBaseTypeRequestBuilder(c), "IRequestBuilder")#>
-<# } #>
     /**
      * Creates the request
      */


### PR DESCRIPTION
These changes modify the `Request` and `RequestBuilder` inheritance structure such that they no longer modeled after `Entity` hierarchies