### PR TITLE
Qualify Task return type + cleanup

### DIFF
--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -58,7 +58,7 @@ public void AppendMethodHeaderToPostAsyncMethod(string propertyType, string sani
     stringBuilder.Append("        /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <param name=\"{0}\">The {1} to add.</param>", sanitizedPropertyName, propertyType);
-    
+
     if (includeSendParameters)
     {
         stringBuilder.Append(Environment.NewLine);
@@ -72,40 +72,40 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
     {
         var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
         var propertyType = this.GetPropertyTypeName(odcmProperty);
-        
+
         var templateWriterHost = (CustomT4Host)Host;
         var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 
         var stringBuilder = new StringBuilder();
-        
+
         stringBuilder.Append(Environment.NewLine);
         this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder, false);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", propertyType);
         stringBuilder.Append(Environment.NewLine);
-        stringBuilder.AppendFormat("        public Task<{0}> AddAsync({0} {1})", propertyType, sanitizedPropertyName);
+        stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> AddAsync({0} {1})", propertyType, sanitizedPropertyName);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        {");
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("            return this.AddAsync({0}, CancellationToken.None);", sanitizedPropertyName);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        }");
-        
+
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append(Environment.NewLine);
-        
+
         this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder, true);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", propertyType);
         stringBuilder.Append(Environment.NewLine);
-        stringBuilder.AppendFormat("        public Task<{0}> AddAsync({0} {1}, CancellationToken cancellationToken)", propertyType, sanitizedPropertyName);
+        stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> AddAsync({0} {1}, CancellationToken cancellationToken)", propertyType, sanitizedPropertyName);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        {");
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("            this.ContentType = \"{0}\";", templateWriter.jsonContentType);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("            this.Method = \"POST\";");
-        
+
         var entity = odcmProperty.Projection.Type.AsOdcmClass();
 
         if (entity != null && entity.IsAbstract)
@@ -113,16 +113,16 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.AppendFormat("            {0}.ODataType = string.Concat(\"#\", StringHelper.ConvertTypeToLowerCamelCase({0}.GetType().FullName));", sanitizedPropertyName);
         }
-        
+
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("            return this.SendAsync<{0}>({1}, cancellationToken);", propertyType, sanitizedPropertyName);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        }");
         stringBuilder.Append(Environment.NewLine);
-        
+
         return stringBuilder.ToString();
     }
-    
+
     return string.Empty;
 }
 
@@ -130,35 +130,35 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 {
     var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
     var propertyType = this.GetPropertyTypeName(odcmProperty);
-        
+
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
-    
+
     var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType();
 
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append(Environment.NewLine);
     this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The task to await.</returns>", propertyType);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public Task AddAsync({0} {1})", propertyType, sanitizedPropertyName);
+    stringBuilder.AppendFormat("        public System.Threading.Tasks.Task AddAsync({0} {1})", propertyType, sanitizedPropertyName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("            return this.AddAsync({0}, CancellationToken.None);", sanitizedPropertyName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        }");
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The task to await.</returns>", propertyType);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public Task AddAsync({0} {1}, CancellationToken cancellationToken)", propertyType, sanitizedPropertyName);
+    stringBuilder.AppendFormat("        public System.Threading.Tasks.Task AddAsync({0} {1}, CancellationToken cancellationToken)", propertyType, sanitizedPropertyName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
@@ -182,7 +182,7 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        }");
     stringBuilder.Append(Environment.NewLine);
-        
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/CollectionRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequestBuilder.Base.template.tt
@@ -82,7 +82,7 @@ public string GetCollectionReferencesRequestBuilder(OdcmProperty odcmProperty)
     {
         var stringBuilder = new StringBuilder();
         var entityReferencesRequestBuilder = this.GetPropertyCollectionReferencesRequestBuilderName(odcmProperty);
-        
+
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <summary>");
         stringBuilder.Append(Environment.NewLine);
@@ -108,7 +108,7 @@ public string GetCollectionReferencesRequestBuilder(OdcmProperty odcmProperty)
 
         return stringBuilder.ToString();
     }
-    
+
     return string.Empty;
 }
 
@@ -122,7 +122,7 @@ public string GetCollectionIndexRequestBuilder(OdcmProperty odcmProperty)
     var stringBuilder = new StringBuilder();
     var propTypeName = string.Concat(this.GetEntityNameString(odcmProperty.Class), this.GetPropertyTypeName(odcmProperty));
     var entityRequestBuilder = this.GetPropertyTypeRequestBuilderName(odcmProperty);
-        
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets an <see cref=\"I{0}\"/> for the specified {1}.", entityRequestBuilder, propTypeName);
@@ -140,12 +140,12 @@ public string GetCollectionIndexRequestBuilder(OdcmProperty odcmProperty)
             get
             {
 ");
-        
+
     stringBuilder.AppendFormat("                return new {0}(this.AppendSegmentToRequestUrl(id), this.Client);", entityRequestBuilder);
     stringBuilder.Append(@"
             }
         }");
-        
+
     return stringBuilder.ToString();
 }
 
@@ -156,7 +156,7 @@ public string GetCollectionWithReferencesIndexRequestBuilder(OdcmProperty odcmPr
 
     var propTypeName = string.Concat(this.GetEntityNameString(odcmProperty.Class), this.GetPropertyTypeName(odcmProperty));
     var entityRequestBuilder = this.GetPropertyTypeWithReferenceRequestBuilderName(odcmProperty);
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets an <see cref=\"I{0}\"/> for the specified {1}.", entityRequestBuilder, propTypeName);
@@ -179,7 +179,7 @@ public string GetCollectionWithReferencesIndexRequestBuilder(OdcmProperty odcmPr
             }
         }
 ");
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/EntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequest.Base.template.tt
@@ -49,19 +49,19 @@ public void AppendDeleteAsyncHeader(string deleteTargetString, StringBuilder str
     {
         stringBuilder.AppendFormat("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Deletes the specified {0}.", deleteTargetString);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// </summary>");
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// <returns>The task to await.</returns>");
 }
@@ -72,17 +72,17 @@ public string GetDeleteAsyncMethod(string deleteTargetString, string deleteTarge
 
     this.AppendDeleteAsyncHeader(deleteTargetString, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append("        public Task DeleteAsync()");
+    stringBuilder.Append("        public System.Threading.Tasks.Task DeleteAsync()");
     stringBuilder.Append(@"
         {
             return this.DeleteAsync(CancellationToken.None);
         }");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendDeleteAsyncHeader(deleteTargetString, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append("        public async Task DeleteAsync(CancellationToken cancellationToken)");
+    stringBuilder.Append("        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)");
     stringBuilder.Append(@"
         {
             this.Method = ""DELETE"";");
@@ -90,7 +90,7 @@ public string GetDeleteAsyncMethod(string deleteTargetString, string deleteTarge
     stringBuilder.AppendFormat("            await this.SendAsync<{0}>(null, cancellationToken).ConfigureAwait(false);", deleteTargetType);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -106,7 +106,7 @@ public void AppendCreateAsyncHeader(string entityName, string lowerCaseEntityNam
     {
         stringBuilder.AppendFormat("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Creates the specified {0} using PUT.", entityName);
@@ -114,14 +114,14 @@ public void AppendCreateAsyncHeader(string entityName, string lowerCaseEntityNam
     stringBuilder.Append("        /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <param name=\"{0}ToCreate\">The {1} to create.</param>", lowerCaseEntityName, entityName);
-    
-    
+
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", entityName);
 }
@@ -129,28 +129,28 @@ public void AppendCreateAsyncHeader(string entityName, string lowerCaseEntityNam
 public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
     var entityName = this.GetEntityNameString(odcmClass);
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
-    
+
     this.AppendCreateAsyncHeader(entityName, lowerCaseEntityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public Task<{0}> CreateAsync({0} {1}ToCreate)", entityName, lowerCaseEntityName);
+    stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> CreateAsync({0} {1}ToCreate)", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("            return this.CreateAsync({0}ToCreate, CancellationToken.None);", lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        }");
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendCreateAsyncHeader(entityName, lowerCaseEntityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public async Task<{0}> CreateAsync({0} {1}ToCreate, CancellationToken cancellationToken)", entityName, lowerCaseEntityName);
+    stringBuilder.AppendFormat("        public async System.Threading.Tasks.Task<{0}> CreateAsync({0} {1}ToCreate, CancellationToken cancellationToken)", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
@@ -164,7 +164,7 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 @"            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -174,20 +174,20 @@ public void AppendGetAsyncHeader(string entityName, StringBuilder stringBuilder,
     {
         stringBuilder.AppendFormat("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the specified {0}.", entityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// </summary>");
-    
-    
+
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The {0}.</returns>", entityName);
 }
@@ -195,38 +195,38 @@ public void AppendGetAsyncHeader(string entityName, StringBuilder stringBuilder,
 public string GetEntityGetAsyncMethod(OdcmClass odcmClass, bool initializeCollectionProperties = true)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var entityName = this.GetEntityNameString(odcmClass);
-    
+
     this.AppendGetAsyncHeader(entityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public Task<{0}> GetAsync()", entityName);
+    stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> GetAsync()", entityName);
     stringBuilder.Append(@"
         {
             return this.GetAsync(CancellationToken.None);
         }");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendGetAsyncHeader(entityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public async Task<{0}> GetAsync(CancellationToken cancellationToken)", entityName);
+    stringBuilder.AppendFormat("        public async System.Threading.Tasks.Task<{0}> GetAsync(CancellationToken cancellationToken)", entityName);
     stringBuilder.Append(@"
         {
             this.Method = ""GET"";");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("            var retrievedEntity = await this.SendAsync<{0}>(null, cancellationToken).ConfigureAwait(false);", entityName);
-    
+
     if (initializeCollectionProperties)
     {
         stringBuilder.Append(@"
             this.InitializeCollectionProperties(retrievedEntity);");
     }
-    
+
     stringBuilder.Append(@"
             return retrievedEntity;
         }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -236,7 +236,7 @@ public void AppendUpdateAsyncHeader(string entityName, string lowerCaseEntityNam
     {
         stringBuilder.AppendFormat("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Updates the specified {0} using PATCH.", entityName);
@@ -244,13 +244,13 @@ public void AppendUpdateAsyncHeader(string entityName, string lowerCaseEntityNam
     stringBuilder.Append("        /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <param name=\"{0}ToUpdate\">The {1} to update.</param>", lowerCaseEntityName, entityName);
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The updated {0}.</returns>", entityName);
 }
@@ -258,16 +258,16 @@ public void AppendUpdateAsyncHeader(string entityName, string lowerCaseEntityNam
 public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var entityName = this.GetEntityNameString(odcmClass);
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
-    
+
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
-    
+
     this.AppendUpdateAsyncHeader(entityName, lowerCaseEntityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public Task<{0}> UpdateAsync({0} {1}ToUpdate)", entityName, lowerCaseEntityName);
+    stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> UpdateAsync({0} {1}ToUpdate)", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
@@ -276,10 +276,10 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
     stringBuilder.Append("        }");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendUpdateAsyncHeader(entityName, lowerCaseEntityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        public async Task<{0}> UpdateAsync({0} {1}ToUpdate, CancellationToken cancellationToken)", entityName, lowerCaseEntityName);
+    stringBuilder.AppendFormat("        public async System.Threading.Tasks.Task<{0}> UpdateAsync({0} {1}ToUpdate, CancellationToken cancellationToken)", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);
@@ -293,7 +293,7 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
 @"            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -324,14 +324,14 @@ public string GetSelectMethod(string requestType)
             this.QueryOptions.Add(new QueryOption(""$select"", value));
             return this;
         }");
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetExpandMethod(string requestType)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append(
       @"/// <summary>
         /// Adds the specified expand value to the request.
@@ -345,7 +345,7 @@ public string GetExpandMethod(string requestType)
             this.QueryOptions.Add(new QueryOption(""$expand"", value));
             return this;
         }");
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/EntityRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequestBuilder.Base.template.tt
@@ -54,7 +54,7 @@ public string GetEntityReferenceRequestBuilderProperty(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
     var requestBuilderTypeName = this.GetEntityReferenceRequestBuilderName(odcmClass);
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for the reference of the {0}.", this.GetEntityNameString(odcmClass).ToLowerFirstChar());
@@ -115,7 +115,7 @@ public string GetRequestBuilderProperty(string propertyName, string requestBuild
 public string GetRequestBuilderProperty(string propertyName, string urlValue, string requestBuilderTypeName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for {0}.", propertyName);
@@ -174,7 +174,7 @@ public string GetMethodRequestBuilderMethod(
 {
     var requestBuilderTypeName = this.GetRequestBuilderString(requestBuilderBaseString);
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for {0}.", requestBuilderBaseString);
@@ -208,7 +208,7 @@ public string GetNavigationProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         if (prop.IsCollection())
         {
             stringBuilder.Append(this.GetCollectionPropertyRequestBuilderProperty(this.GetEntityNameString(entity), prop));
@@ -218,7 +218,7 @@ public string GetNavigationProperties(OdcmClass entity)
             stringBuilder.Append(this.GetNonCollectionRequestBuilderProperty(prop));
         }
     }
-    
+
     return stringBuilder.ToString();
 }
 
@@ -235,18 +235,18 @@ public string GetStreamProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         var propName = this.GetPropertyName(prop);
         if (propName.Equals("Content"))
         {
             contentStreamFound = true;
         }
-        
+
         var propRequestBuilder = this.GetRequestBuilderString(propName);
-        
+
         stringBuilder.Append(this.GetRequestBuilderProperty(propName, string.Concat(this.GetEntityNameString(entity), propRequestBuilder)));
     }
-    
+
     if (entity.Kind == OdcmClassKind.MediaEntity && !contentStreamFound)
     {
         if (stringBuilder.Length > 0)
@@ -255,10 +255,10 @@ public string GetStreamProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         stringBuilder.Append(this.GetRequestBuilderProperty("Content", "$value", string.Concat(this.GetEntityNameString(entity), "ContentRequestBuilder")));
     }
-    
+
     return stringBuilder.ToString();
 }
 
@@ -294,12 +294,12 @@ public string GetMethodProperties(OdcmClass entity)
         {
             var requiredParameters = method.Parameters.Where(param => !param.IsNullable);
             var optionalParameters = method.Parameters.Where(param => param.IsNullable);
-            
+
             foreach (var param in requiredParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
-                
+
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -313,12 +313,12 @@ public string GetMethodProperties(OdcmClass entity)
                 builderInitializerStringBuilder.Append("                ");
                 builderInitializerStringBuilder.AppendFormat("{0},", paramVariableName);
             }
-            
+
             foreach (var param in optionalParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
-                
+
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -339,16 +339,16 @@ public string GetMethodProperties(OdcmClass entity)
 
             paramStringBuilder.Remove(paramStringBuilder.Length - 1, 1);
         }
-        
+
         builderInitializerStringBuilder.Remove(builderInitializerStringBuilder.Length - 1, 1);
-        
+
         if (methodPropertiesStringBuilder.Length > 0)
         {
             methodPropertiesStringBuilder.Append(Environment.NewLine);
             methodPropertiesStringBuilder.Append(Environment.NewLine);
             methodPropertiesStringBuilder.Append("        ");
         }
-        
+
         methodPropertiesStringBuilder.Append(
             this.GetMethodRequestBuilderMethod(
                 methodName,
@@ -356,7 +356,7 @@ public string GetMethodProperties(OdcmClass entity)
                 paramStringBuilder.ToString(),
                 builderInitializerStringBuilder.ToString()));
     }
-    
+
     return methodPropertiesStringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -50,33 +50,33 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty)
     {
         var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
         var propertyType = this.GetPropertyTypeName(odcmProperty);
-        
+
         var templateWriterHost = (CustomT4Host)Host;
         var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 
         var stringBuilder = new StringBuilder();
-        
+
         stringBuilder.Append(Environment.NewLine);
         this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", propertyType);
         stringBuilder.Append(Environment.NewLine);
-        stringBuilder.AppendFormat("        Task<{0}> AddAsync({0} {1});", propertyType, sanitizedPropertyName);
-        
+        stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> AddAsync({0} {1});", propertyType, sanitizedPropertyName);
+
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append(Environment.NewLine);
-        
+
         this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder);
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", propertyType);
         stringBuilder.Append(Environment.NewLine);
-        stringBuilder.AppendFormat("        Task<{0}> AddAsync({0} {1}, CancellationToken cancellationToken);", propertyType, sanitizedPropertyName);
-        
+        stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> AddAsync({0} {1}, CancellationToken cancellationToken);", propertyType, sanitizedPropertyName);
+
         return stringBuilder.ToString();
     }
-    
+
     return string.Empty;
 }
 
@@ -84,25 +84,25 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 {
     var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
     var propertyType = this.GetPropertyTypeName(odcmProperty);
-    
+
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task AddAsync({0} {1});", propertyType, sanitizedPropertyName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task AddAsync({0} {1});", propertyType, sanitizedPropertyName);
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task AddAsync({0} {1}, CancellationToken cancellationToken);", propertyType, sanitizedPropertyName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task AddAsync({0} {1}, CancellationToken cancellationToken);", propertyType, sanitizedPropertyName);
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/ICollectionRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/ICollectionRequestBuilder.Base.template.tt
@@ -26,7 +26,7 @@ public string GetCollectionIndexRequestBuilder(OdcmProperty odcmProperty)
 {
     var propTypeName = this.GetPropertyTypeName(odcmProperty);
     var entityRequestBuilder = this.GetPropertyTypeRequestBuilderName(odcmProperty);
-    
+
     return this.GetIndexRequestBuilder(propTypeName, entityRequestBuilder);
 }
 
@@ -88,7 +88,7 @@ public string GetIndexRequestBuilder(string propertyName, string requestBuilderT
     stringBuilder.AppendFormat("        /// <returns>The <see cref=\"I{0}\"/>.</returns>", requestBuilderTypeName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        I{0} this[string id] {{ get; }}", requestBuilderTypeName);
-    
+
     return stringBuilder.ToString();
 }
 
@@ -100,7 +100,7 @@ public string GetCollectionReferencesRequestBuilder(OdcmProperty odcmProperty)
     {
         var stringBuilder = new StringBuilder();
         var collectionReferencesRequestBuilder = this.GetPropertyCollectionReferencesRequestBuilderName(odcmProperty);
-        
+
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <summary>");
         stringBuilder.Append(Environment.NewLine);
@@ -112,10 +112,10 @@ public string GetCollectionReferencesRequestBuilder(OdcmProperty odcmProperty)
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("        I{0} References {{ get; }}", collectionReferencesRequestBuilder);
         stringBuilder.Append(Environment.NewLine);
-        
+
         return stringBuilder.ToString();
     }
-    
+
     return string.Empty;
 }
 
@@ -124,7 +124,7 @@ public string GetCollectionWithReferencesIndexRequestBuilder(OdcmProperty odcmPr
 {
     var propTypeName = this.GetPropertyTypeName(odcmProperty);
     var entityRequestBuilder = this.GetPropertyTypeWithReferenceRequestBuilderName(odcmProperty);
-    
+
     return this.GetIndexRequestBuilder(propTypeName, entityRequestBuilder);
 }
 

--- a/Templates/CSharp/Base/IEntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequest.Base.template.tt
@@ -40,7 +40,7 @@ public void AppendEntityCreateAsyncMethodHeader(string entityName, string lowerC
     {
         stringBuilder.Append("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Creates the specified {0} using PUT.", entityName);
@@ -48,13 +48,13 @@ public void AppendEntityCreateAsyncMethodHeader(string entityName, string lowerC
     stringBuilder.Append("        /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <param name=\"{0}ToCreate\">The {1} to create.</param>", lowerCaseEntityName, entityName);
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", entityName);
 }
@@ -62,18 +62,18 @@ public void AppendEntityCreateAsyncMethodHeader(string entityName, string lowerC
 public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var entityName = this.GetEntityNameString(odcmClass);
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
-    
+
     this.AppendEntityCreateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> CreateAsync({0} {1}ToCreate);", entityName, lowerCaseEntityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> CreateAsync({0} {1}ToCreate);", entityName, lowerCaseEntityName);
+
     this.AppendEntityCreateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> CreateAsync({0} {1}ToCreate, CancellationToken cancellationToken);", entityName, lowerCaseEntityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> CreateAsync({0} {1}ToCreate, CancellationToken cancellationToken);", entityName, lowerCaseEntityName);
+
     return stringBuilder.ToString();
 }
 
@@ -89,13 +89,13 @@ public void AppendDeleteAsyncMethodHeader(string deleteTargetString, StringBuild
     stringBuilder.AppendFormat("        /// Deletes the specified {0}.", deleteTargetString);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// </summary>");
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// <returns>The task to await.</returns>");
 }
@@ -106,15 +106,15 @@ public string GetDeleteAsyncMethod(string deleteTargetString)
 
     this.AppendDeleteAsyncMethodHeader(deleteTargetString, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append("        Task DeleteAsync();");
-    
+    stringBuilder.Append("        System.Threading.Tasks.Task DeleteAsync();");
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendDeleteAsyncMethodHeader(deleteTargetString, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append("        Task DeleteAsync(CancellationToken cancellationToken);");
-    
+    stringBuilder.Append("        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);");
+
     return stringBuilder.ToString();
 }
 
@@ -129,19 +129,19 @@ public void AppendGetAsyncMethodHeader(string entityName, StringBuilder stringBu
     {
         stringBuilder.Append("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the specified {0}.", entityName);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// </summary>");
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The {0}.</returns>", entityName);
 }
@@ -149,20 +149,20 @@ public void AppendGetAsyncMethodHeader(string entityName, StringBuilder stringBu
 public string GetEntityGetAsyncMethod(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var entityName = this.GetEntityNameString(odcmClass);
-    
+
     this.AppendGetAsyncMethodHeader(entityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> GetAsync();", entityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> GetAsync();", entityName);
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendGetAsyncMethodHeader(entityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> GetAsync(CancellationToken cancellationToken);", entityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> GetAsync(CancellationToken cancellationToken);", entityName);
+
     return stringBuilder.ToString();
 }
 
@@ -172,7 +172,7 @@ public void AppendUpdateAsyncMethodHeader(string entityName, string lowerCaseEnt
     {
         stringBuilder.Append("        ");
     }
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Updates the specified {0} using PATCH.", entityName);
@@ -180,35 +180,35 @@ public void AppendUpdateAsyncMethodHeader(string entityName, string lowerCaseEnt
     stringBuilder.Append("        /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <param name=\"{0}ToUpdate\">The {1} to update.</param>", lowerCaseEntityName, entityName);
-    
+
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
     }
 
-    stringBuilder.Append(Environment.NewLine);    
+    stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// <returns>The updated {0}.</returns>", entityName);
 }
 
 public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
-    
+
     var entityName = this.GetEntityNameString(odcmClass);
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
-    
+
     this.AppendUpdateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> UpdateAsync({0} {1}ToUpdate);", entityName, lowerCaseEntityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> UpdateAsync({0} {1}ToUpdate);", entityName, lowerCaseEntityName);
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    
+
     this.AppendUpdateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, true);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("        Task<{0}> UpdateAsync({0} {1}ToUpdate, CancellationToken cancellationToken);", entityName, lowerCaseEntityName);
-    
+    stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> UpdateAsync({0} {1}ToUpdate, CancellationToken cancellationToken);", entityName, lowerCaseEntityName);
+
     return stringBuilder.ToString();
 }
 
@@ -220,7 +220,7 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
 public string GetExpandMethod(string entityRequest)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append(
       @"/// <summary>
         /// Adds the specified expand value to the request.
@@ -229,14 +229,14 @@ public string GetExpandMethod(string entityRequest)
         /// <returns>The request object to send.</returns>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        I{0} Expand(string value);", entityRequest);
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetSelectMethod(string entityRequest)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append(
       @"/// <summary>
         /// Adds the specified select value to the request.
@@ -245,7 +245,7 @@ public string GetSelectMethod(string entityRequest)
         /// <returns>The request object to send.</returns>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        I{0} Select(string value);", entityRequest);
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/IEntityRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequestBuilder.Base.template.tt
@@ -44,7 +44,7 @@ public string GetEntityReferenceRequestBuilderProperty(OdcmClass odcmClass)
 {
     var stringBuilder = new StringBuilder();
     var requestBuilderTypeName = this.GetEntityReferenceRequestBuilderName(odcmClass);
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for the reference of the {0}.", this.GetEntityNameString(odcmClass).ToLowerFirstChar());
@@ -84,7 +84,7 @@ public string GetEntityWithReferenceRequestMethodWithOptions(OdcmClass odcmClass
 public string GetRequestBuilderProperty(string propertyName, string requestBuilderTypeName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for {0}.", propertyName);
@@ -130,7 +130,7 @@ public string GetMethodRequestBuilderMethod(
 {
     var requestBuilderTypeName = this.GetRequestBuilderString(requestBuilderBaseString);
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Gets the request builder for {0}.", requestBuilderBaseString);
@@ -155,7 +155,7 @@ public string GetNavigationProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         if (prop.IsCollection())
         {
             stringBuilder.Append(this.GetCollectionPropertyRequestBuilderProperty(this.GetEntityNameString(entity), prop));
@@ -165,7 +165,7 @@ public string GetNavigationProperties(OdcmClass entity)
             stringBuilder.Append(this.GetNonCollectionRequestBuilderProperty(prop));
         }
     }
-    
+
     return stringBuilder.ToString();
 }
 
@@ -182,18 +182,18 @@ public string GetStreamProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         var propName = this.GetPropertyName(prop);
         if (propName.Equals("Content"))
         {
             contentStreamFound = true;
         }
-        
+
         var propRequestBuilder = this.GetRequestBuilderString(propName);
-        
+
         stringBuilder.Append(this.GetRequestBuilderProperty(propName, string.Concat(this.GetEntityNameString(entity), propRequestBuilder)));
     }
-    
+
     if (entity.Kind == OdcmClassKind.MediaEntity && !contentStreamFound)
     {
         if (stringBuilder.Length > 0)
@@ -202,10 +202,10 @@ public string GetStreamProperties(OdcmClass entity)
             stringBuilder.Append(Environment.NewLine);
             stringBuilder.Append("        ");
         }
-        
+
         stringBuilder.Append(this.GetRequestBuilderProperty("Content", string.Concat(this.GetEntityNameString(entity), "ContentRequestBuilder")));
     }
-    
+
     return stringBuilder.ToString();
 }
 
@@ -233,12 +233,12 @@ public string GetMethodProperties(OdcmClass entity)
         {
             var requiredParameters = method.Parameters.Where(param => !param.IsNullable);
             var optionalParameters = method.Parameters.Where(param => param.IsNullable);
-            
+
             foreach (var param in requiredParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
-                
+
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -248,12 +248,12 @@ public string GetMethodProperties(OdcmClass entity)
                 paramStringBuilder.Append("            ");
                 paramStringBuilder.AppendFormat("{0} {1},", paramTypeString, paramVariableName);
             }
-            
+
             foreach (var param in optionalParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
-                
+
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -270,21 +270,21 @@ public string GetMethodProperties(OdcmClass entity)
 
             paramStringBuilder.Remove(paramStringBuilder.Length - 1, 1);
         }
-        
+
         if (methodPropertiesStringBuilder.Length > 0)
         {
             methodPropertiesStringBuilder.Append(Environment.NewLine);
             methodPropertiesStringBuilder.Append(Environment.NewLine);
             methodPropertiesStringBuilder.Append("        ");
         }
-        
+
         methodPropertiesStringBuilder.Append(
             this.GetMethodRequestBuilderMethod(
                 methodName,
                 baseName,
                 paramStringBuilder.ToString()));
     }
-    
+
     return methodPropertiesStringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/IRequest.Base.template.tt
+++ b/Templates/CSharp/Base/IRequest.Base.template.tt
@@ -6,7 +6,7 @@
 public string GetInterfaceDefinition(string interfaceName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The interface I{0}.", interfaceName);
@@ -14,7 +14,7 @@ public string GetInterfaceDefinition(string interfaceName)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial interface I{0} : IBaseRequest", interfaceName);
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
@@ -7,7 +7,7 @@ public string GetEntityInterfaceDefinition(OdcmClass entity)
 {
     string typeDeclaration = null;
     var className = this.GetEntityRequestBuilderName(entity);
-    
+
     if (entity.Base == null)
     {
         typeDeclaration = string.Format("I{0} : IBaseRequestBuilder", className);
@@ -16,9 +16,9 @@ public string GetEntityInterfaceDefinition(OdcmClass entity)
     {
         typeDeclaration = string.Format("I{0} : I{1}RequestBuilder", className, entity.Base.Name.ToCheckedCase());
     }
-    
+
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The interface I{0}.", className);
@@ -26,14 +26,14 @@ public string GetEntityInterfaceDefinition(OdcmClass entity)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial interface {0}", typeDeclaration);
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetInterfaceDefinition(string interfaceName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The interface I{0}.", interfaceName);
@@ -41,7 +41,7 @@ public string GetInterfaceDefinition(string interfaceName)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial interface I{0}", interfaceName);
-    
+
     return stringBuilder.ToString();
 }
 
@@ -50,7 +50,7 @@ public string GetRequestMethod(string requestTypeName, bool includeNewKeyword = 
     var stringBuilder = new StringBuilder();
     stringBuilder.Append(this.GetRequestMethodHeader());
     stringBuilder.Append(Environment.NewLine);
-    
+
     if (includeNewKeyword)
     {
         stringBuilder.AppendFormat("        new I{0} Request();", requestTypeName);
@@ -59,16 +59,16 @@ public string GetRequestMethod(string requestTypeName, bool includeNewKeyword = 
     {
         stringBuilder.AppendFormat("        I{0} Request();", requestTypeName);
     }
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetRequestMethodWithOptions(string requestTypeName, bool includeNewKeyword = false)
 {
     var stringBuilder = new StringBuilder();
-    stringBuilder.Append(this.GetRequestMethodWithOptionsHeader());     
+    stringBuilder.Append(this.GetRequestMethodWithOptionsHeader());
     stringBuilder.Append(Environment.NewLine);
-    
+
     if (includeNewKeyword)
     {
         stringBuilder.AppendFormat("        new I{0} Request(IEnumerable<Option> options);", requestTypeName);
@@ -77,7 +77,7 @@ public string GetRequestMethodWithOptions(string requestTypeName, bool includeNe
     {
         stringBuilder.AppendFormat("        I{0} Request(IEnumerable<Option> options);", requestTypeName);
     }
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/Request.Base.template.tt
+++ b/Templates/CSharp/Base/Request.Base.template.tt
@@ -6,7 +6,7 @@
 public string GetClassDefinition(string className)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The type {0}.", className);
@@ -14,14 +14,14 @@ public string GetClassDefinition(string className)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial class {0} : BaseRequest, I{0}", className);
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetConstructor(string instanceTypeName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Constructs a new {0}.", instanceTypeName);
@@ -31,7 +31,7 @@ public string GetConstructor(string instanceTypeName)
         /// <param name=""requestUrl"">The URL for the built request.</param>
         /// <param name=""client"">The <see cref=""IBaseClient""/> for handling requests.</param>
         /// <param name=""options"">Query and header option name value pairs for the request.</param>");
-        
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        public {0}(", instanceTypeName);
     stringBuilder.Append(Environment.NewLine);
@@ -42,7 +42,7 @@ public string GetConstructor(string instanceTypeName)
             : base(requestUrl, client, options)
         {
         }");
-    
+
     return stringBuilder.ToString();
 }
 

--- a/Templates/CSharp/Base/RequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/RequestBuilder.Base.template.tt
@@ -6,7 +6,7 @@
 public string GetClassDefinition(string className)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The type {0}.", className);
@@ -14,7 +14,7 @@ public string GetClassDefinition(string className)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial class {0} : BaseRequestBuilder, I{0}", className);
-    
+
     return stringBuilder.ToString();
 }
 
@@ -22,7 +22,7 @@ public string GetEntityClassDefinition(OdcmClass entity)
 {
     string typeDeclaration = null;
     var className = this.GetEntityRequestBuilderName(entity);
-    
+
     if (entity.Base != null)
     {
         typeDeclaration = string.Format("{0} : {1}RequestBuilder, I{0}", className, entity.Base.Name.ToCheckedCase());
@@ -31,9 +31,9 @@ public string GetEntityClassDefinition(OdcmClass entity)
     {
         typeDeclaration = string.Format("{0} : BaseRequestBuilder, I{0}", className);
     }
-    
+
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    /// The type {0}.", className);
@@ -41,14 +41,14 @@ public string GetEntityClassDefinition(OdcmClass entity)
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("    public partial class {0}", typeDeclaration);
-    
+
     return stringBuilder.ToString();
 }
 
 public string GetConstructor(string instanceTypeName)
 {
     var stringBuilder = new StringBuilder();
-    
+
     stringBuilder.Append("/// <summary>");
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        /// Constructs a new {0}.", instanceTypeName);
@@ -57,7 +57,7 @@ public string GetConstructor(string instanceTypeName)
 @"        /// </summary>
         /// <param name=""requestUrl"">The URL for the built request.</param>
         /// <param name=""client"">The <see cref=""IBaseClient""/> for handling requests.</param>");
-        
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        public {0}(", instanceTypeName);
     stringBuilder.Append(Environment.NewLine);
@@ -67,7 +67,7 @@ public string GetConstructor(string instanceTypeName)
             : base(requestUrl, client)
         {
         }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -76,7 +76,7 @@ public string GetRequestMethod(string requestTypeName, bool includeNewKeyword = 
     var stringBuilder = new StringBuilder();
     stringBuilder.Append(this.GetRequestMethodHeader());
     stringBuilder.Append(Environment.NewLine);
-    
+
     if (includeNewKeyword)
     {
         stringBuilder.AppendFormat("        public new I{0} Request()", requestTypeName);
@@ -85,13 +85,13 @@ public string GetRequestMethod(string requestTypeName, bool includeNewKeyword = 
     {
         stringBuilder.AppendFormat("        public I{0} Request()", requestTypeName);
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(
 @"        {
             return this.Request(null);
         }");
-    
+
     return stringBuilder.ToString();
 }
 
@@ -99,9 +99,9 @@ public string GetRequestMethodWithOptions(string requestTypeName, bool includeNe
 {
     var stringBuilder = new StringBuilder();
 
-    stringBuilder.Append(this.GetRequestMethodWithOptionsHeader());     
+    stringBuilder.Append(this.GetRequestMethodWithOptionsHeader());
     stringBuilder.Append(Environment.NewLine);
-    
+
     if (includeNewKeyword)
     {
         stringBuilder.AppendFormat("        public new I{0} Request(IEnumerable<Option> options)", requestTypeName);
@@ -110,7 +110,7 @@ public string GetRequestMethodWithOptions(string requestTypeName, bool includeNe
     {
         stringBuilder.AppendFormat("        public I{0} Request(IEnumerable<Option> options)", requestTypeName);
     }
-    
+
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        {");
     stringBuilder.Append(Environment.NewLine);

--- a/Templates/CSharp/Base/SharedCSharp.template.tt
+++ b/Templates/CSharp/Base/SharedCSharp.template.tt
@@ -2,7 +2,7 @@
 <#@ template debug="true" hostspecific="true" language="C#" #>
 <#
 
-CustomT4Host host   = (CustomT4Host)Host; 
+CustomT4Host host   = (CustomT4Host)Host;
 OdcmModel model     = host.CurrentModel;
 var writer          = (CodeWriterCSharp)host.CodeWriter;
 #>

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -42,7 +42,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     <#=attributeStringBuilder.ToString()#>
     public <#=classType#> <#=typeDeclaration#>
     {
-    <# 
+    <#
         foreach(var property in complex.Properties)
         {
 
@@ -50,7 +50,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
             var propertyName = isMethodResponse
                 ? property.Name.Substring(property.Name.IndexOf('.') + 1).ToCheckedCase()
                 : property.Name.ToCheckedCase().GetSanitizedPropertyName();
-                
+
             var attributeDefinition = string.Format("[DataMember(Name = \"{0}\", EmitDefaultValue = false, IsRequired = false)]", property.Name);
 
             if (property.IsTypeNullable() || property.IsCollection)

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -51,7 +51,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         }
     <#
         }
-        
+
         foreach(var property in entity.Properties)
         {
             var propertyType = property.IsTypeNullable() || property.IsCollection()
@@ -60,7 +60,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
 
             var propertyName = property.Name.ToCheckedCase();
             var propertyCollectionPage = property.IsReference() ? string.Concat(entityName, propertyName, "CollectionWithReferencesPage") : string.Concat(entityName, propertyName, "CollectionPage");
-            
+
             var attributeDefinition = string.Format("[DataMember(Name = \"{0}\", EmitDefaultValue = false, IsRequired = false)]", property.Name);
 
             if (property.IsCollection())
@@ -100,7 +100,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
     <#
             }
         }
-        
+
     // Only include @odata.type and AdditionalData in the base classes.
     if (entity.Base == null)
     {
@@ -111,7 +111,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// </summary>
         [DataMember(Name = "@odata.type", EmitDefaultValue = false, IsRequired = false)]
         public string ODataType { get; set; }
-        
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>

--- a/Templates/CSharp/Model/EnumType.cs.tt
+++ b/Templates/CSharp/Model/EnumType.cs.tt
@@ -10,7 +10,7 @@ var enumName = enumT.Name.ToCheckedCase();
 namespace <#=enumT.Namespace.GetNamespaceName()#>
 {
     using Newtonsoft.Json;
-    
+
     /// <summary>
     /// The enum <#=enumName#>.
     /// </summary>
@@ -21,7 +21,7 @@ namespace <#=enumT.Namespace.GetNamespaceName()#>
         foreach(var value in enumT.Members)
         {
     #>
-    
+
         /// <summary>
         /// <#=value.Name.SplitCamelCase()#>
         /// </summary>
@@ -29,6 +29,6 @@ namespace <#=enumT.Namespace.GetNamespaceName()#>
     <#
         }
     #>
-    
+
     }
 }

--- a/Templates/CSharp/Model/MethodRequestBody.cs.tt
+++ b/Templates/CSharp/Model/MethodRequestBody.cs.tt
@@ -29,10 +29,10 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     public partial class <#=requestBody#>
     {
     <#
-    foreach (var param in method.Parameters)  
+    foreach (var param in method.Parameters)
     {
         var paramTypeString = param.Type.GetTypeString();
-        
+
         if (param.IsCollection)
         {
             paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -41,7 +41,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         {
             paramTypeString = string.Format("{0}?", paramTypeString);
         }
-        
+
         var paramName = param.Name.ToCheckedCase().GetSanitizedPropertyName();
     #>
 

--- a/Templates/CSharp/Requests/EntityCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionPage.cs.tt
@@ -3,7 +3,7 @@
 <#@ include file="SharedCSharp.template.tt"#>
 <#
 
-var prop = host.CurrentType.AsOdcmProperty(); 
+var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity is OdcmPrimitiveType ? innerEntity.GetTypeString() : innerEntity.Name.ToCheckedCase();
 var entityCollectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionRequest");
@@ -14,7 +14,7 @@ var entityCollectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.N
 namespace <#=prop.Class.AsOdcmClass().Namespace.GetNamespaceName()#>
 {
     using System;
-    
+
     /// <summary>
     /// The type <#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/EntityCollectionReferencesRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionReferencesRequest.cs.tt
@@ -13,7 +13,6 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionReferencesClassDefinition(prop)#>
     {

--- a/Templates/CSharp/Requests/EntityCollectionReferencesRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionReferencesRequestBuilder.cs.tt
@@ -13,7 +13,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
 
     <#=this.GetCollectionReferencesClassDefinition(prop)#>
     {
-    
+
         <#=this.GetCollectionReferencesRequestBuilderConstructor(prop)#>
 
         <#=this.GetCollectionReferencesRequestMethod(prop)#>

--- a/Templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -17,27 +17,26 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionClassDefinition(prop)#>
     {
         <#=GetCollectionRequestConstructor(prop)#>
-        <#=GetPostAsyncMethod(prop)#>  
+        <#=GetPostAsyncMethod(prop)#>
         /// <summary>
         /// Gets the collection page.
         /// </summary>
         /// <returns>The collection page.</returns>
-        public Task<I<#=collectionPage#>> GetAsync()
+        public System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
-        
+
         /// <summary>
         /// Gets the collection page.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The collection page.</returns>
-        public async Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken)
         {
             this.Method = "GET";
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
@@ -56,7 +55,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
                             this.Client,
                             nextPageLinkString);
                     }
-                    
+
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/Templates/CSharp/Requests/EntityCollectionRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionRequestBuilder.cs.tt
@@ -12,7 +12,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
 
     <#=this.GetCollectionClassDefinition(prop)#>
-    {  
+    {
         <#=this.GetCollectionRequestBuilderConstructor(prop)#>
 
         <#=this.GetCollectionRequestMethod(prop)#>

--- a/Templates/CSharp/Requests/EntityCollectionWithReferencesPage.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionWithReferencesPage.cs.tt
@@ -3,7 +3,7 @@
 <#@ include file="SharedCSharp.template.tt"#>
 <#
 
-var prop = host.CurrentType.AsOdcmProperty(); 
+var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity is OdcmPrimitiveType ? innerEntity.GetTypeString() : innerEntity.Name.ToCheckedCase();
 var entityCollectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionWithReferencesRequest");
@@ -14,7 +14,7 @@ var entityCollectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.N
 namespace <#=prop.Class.AsOdcmClass().Namespace.GetNamespaceName()#>
 {
     using System;
-    
+
     /// <summary>
     /// The type <#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -20,7 +20,6 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionWithReferencesClassDefinition(prop)#>
     {
@@ -30,17 +29,17 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
         /// Gets the collection page.
         /// </summary>
         /// <returns>The collection page.</returns>
-        public Task<I<#=collectionPage#>> GetAsync()
+        public System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
-        
+
         /// <summary>
         /// Gets the collection page.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The collection page.</returns>
-        public async Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken)
         {
             this.Method = "GET";
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
@@ -59,7 +58,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
                             this.Client,
                             nextPageLinkString);
                     }
-                    
+
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/Templates/CSharp/Requests/EntityCollectionWithReferencesRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionWithReferencesRequestBuilder.cs.tt
@@ -19,7 +19,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
         <#=this.GetCollectionWithReferencesRequestMethod(prop)#>
 
         <#=this.GetCollectionWithReferencesRequestMethodWithOptions(prop)#>
-        
+
         <#=this.GetCollectionWithReferencesIndexRequestBuilder(prop)#>
         <#=this.GetCollectionReferencesRequestBuilder(prop)#>
     }

--- a/Templates/CSharp/Requests/EntityReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityReferenceRequest.cs.tt
@@ -15,7 +15,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityReferenceRequestClassDefinition(entity)#>
     {

--- a/Templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityRequest.cs.tt
@@ -17,7 +17,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityRequestClassDefinition(entity)#>
     {
@@ -83,7 +82,7 @@ namespace <#=this.GetNamespaceName(entity)#>
             {
                 var propertyName = property.Name.ToCheckedCase().GetSanitizedPropertyName();
                 var propertyType = property.GetTypeString();
-                
+
                 if (propertyType.IsComplex())
                 {
 #>

--- a/Templates/CSharp/Requests/EntityRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/EntityRequestBuilder.cs.tt
@@ -25,7 +25,7 @@ namespace <#=this.GetNamespaceName(entity)#>
     if (entity.NavigationProperties().Any())
     {
     #>
-    
+
         <#=this.GetNavigationProperties(entity)#>
     <#
     }
@@ -41,7 +41,7 @@ namespace <#=this.GetNamespaceName(entity)#>
     if(entity.Methods.Any())
     {
     #>
-    
+
         <#=this.GetMethodProperties(entity)#>
     <#
     }

--- a/Templates/CSharp/Requests/EntityWithReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityWithReferenceRequest.cs.tt
@@ -17,7 +17,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityWithReferenceRequestClassDefinition(entity)#>
     {

--- a/Templates/CSharp/Requests/IEntityClient.cs.tt
+++ b/Templates/CSharp/Requests/IEntityClient.cs.tt
@@ -33,7 +33,7 @@ namespace <#=entityContainer.Namespace.GetNamespaceName()#>
         }
         else
         {
-        
+
         var propType = prop.Projection.Type.Name.ToCheckedCase();
     #>
 

--- a/Templates/CSharp/Requests/IEntityCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionPage.cs.tt
@@ -3,7 +3,7 @@
 <#@ include file="SharedCSharp.template.tt"#>
 <#
 
-var prop = host.CurrentType.AsOdcmProperty(); 
+var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity is OdcmPrimitiveType ? innerEntity.GetTypeString() : innerEntity.Name.ToCheckedCase();
 var entityCollectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionRequest");
@@ -14,9 +14,9 @@ var entityCollectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.N
 namespace <#=prop.Class.AsOdcmClass().Namespace.GetNamespaceName()#>
 {
     using System;
-    
+
     using Newtonsoft.Json;
-    
+
     /// <summary>
     /// The interface I<#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/IEntityCollectionReferencesRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionReferencesRequest.cs.tt
@@ -13,7 +13,6 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionReferencesInterfaceDefinition(prop)#>
     {

--- a/Templates/CSharp/Requests/IEntityCollectionRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionRequest.cs.tt
@@ -18,7 +18,6 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionInterfaceDefinition(prop)#>
     {
@@ -27,14 +26,14 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
         /// Gets the collection page.
         /// </summary>
         /// <returns>The collection page.</returns>
-        Task<I<#=collectionPage#>> GetAsync();
-        
+        System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync();
+
         /// <summary>
         /// Gets the collection page.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The collection page.</returns>
-        Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken);
 
 <# if (features.CanExpand) { #>
         /// <summary>

--- a/Templates/CSharp/Requests/IEntityCollectionWithReferencesPage.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionWithReferencesPage.cs.tt
@@ -3,7 +3,7 @@
 <#@ include file="SharedCSharp.template.tt"#>
 <#
 
-var prop = host.CurrentType.AsOdcmProperty(); 
+var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity.Name.ToCheckedCase();
 var entityCollectionRequest = this.GetPropertyCollectionWithReferencesRequestName(prop);
@@ -14,9 +14,9 @@ var entityCollectionPage = string.Concat(this.GetEntityNameString(prop.Class), p
 namespace <#=prop.Class.AsOdcmClass().Namespace.GetNamespaceName()#>
 {
     using System;
-    
+
     using Newtonsoft.Json;
-    
+
     /// <summary>
     /// The interface I<#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/IEntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionWithReferencesRequest.cs.tt
@@ -15,7 +15,6 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetCollectionWithReferencesInterfaceDefinition(prop)#>
     {
@@ -23,14 +22,14 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
         /// Gets the collection page.
         /// </summary>
         /// <returns>The collection page.</returns>
-        Task<I<#=collectionPage#>> GetAsync();
-        
+        System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync();
+
         /// <summary>
         /// Gets the collection page.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The collection page.</returns>
-        Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<I<#=collectionPage#>> GetAsync(CancellationToken cancellationToken);
 
 <# if (features.CanExpand) { #>
         /// <summary>

--- a/Templates/CSharp/Requests/IEntityCollectionWithReferencesRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionWithReferencesRequestBuilder.cs.tt
@@ -16,7 +16,7 @@ namespace <#=this.GetNamespaceName(prop.Class.AsOdcmClass())#>
         <#=this.GetCollectionWithReferencesRequestMethod(prop)#>
 
         <#=this.GetCollectionWithReferencesRequestMethodWithOptions(prop)#>
-        
+
         <#=this.GetCollectionWithReferencesIndexRequestBuilder(prop)#>
         <#=this.GetCollectionReferencesRequestBuilder(prop)#>
     }

--- a/Templates/CSharp/Requests/IEntityReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityReferenceRequest.cs.tt
@@ -14,7 +14,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityReferenceRequestInterfaceDefinition(entity)#>
     {

--- a/Templates/CSharp/Requests/IEntityRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityRequest.cs.tt
@@ -15,7 +15,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityRequestInterfaceDefinition(entity)#>
     {

--- a/Templates/CSharp/Requests/IEntityRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/IEntityRequestBuilder.cs.tt
@@ -25,7 +25,7 @@ namespace <#=this.GetNamespaceName(entity)#>
     if (entity.NavigationProperties().Any())
     {
     #>
-    
+
         <#=this.GetNavigationProperties(entity)#>
     <#
     }
@@ -41,7 +41,7 @@ namespace <#=this.GetNamespaceName(entity)#>
     if(entity.Methods.Any())
     {
     #>
-    
+
         <#=this.GetMethodProperties(entity)#>
     <#
     }

--- a/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
@@ -15,7 +15,6 @@ namespace <#=this.GetNamespaceName(entity)#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     <#=this.GetEntityWithReferenceRequestInterfaceDefinition(entity)#>
     {

--- a/Templates/CSharp/Requests/IEntityWithReferenceRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/IEntityWithReferenceRequestBuilder.cs.tt
@@ -17,7 +17,7 @@ namespace <#=this.GetNamespaceName(entity)#>
         <#=this.GetEntityWithReferenceRequestMethod(entity)#>
 
         <#=this.GetEntityWithReferenceRequestMethodWithOptions(entity)#>
-        
+
         <#=this.GetEntityReferenceRequestBuilderProperty(entity)#>
 
     }

--- a/Templates/CSharp/Requests/IMethodAsyncMonitor.cs.tt
+++ b/Templates/CSharp/Requests/IMethodAsyncMonitor.cs.tt
@@ -12,7 +12,7 @@ var isCollection = method.IsCollection || method.LongDescriptionContains("specia
 var returnEntityType = method.ReturnType.Name.ToCheckedCase();
 var returnType = isCollection ? "I" + entityName + methodName + "CollectionPage" : returnEntityType;
 bool isAsync = method.LongDescriptionContains("async");
-var asyncString = isCollection ? "async " : " ";
+var asyncString = isCollection ? "async " : "";
 
 #>
 
@@ -20,8 +20,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
 {
     using System;
     using System.Threading;
-    using System.Threading.Tasks;
-    
+
     /// <summary>
     /// The interface I<#=monitorType#>.
     /// </summary>
@@ -30,6 +29,6 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// <summary>
         /// Polls until the async operation is complete and returns the resulting <#=returnType#>.
         /// </summary>
-        <#=asyncString#>Task<<#=returnType#>> CompleteOperationAsync(IProgress<AsyncOperationStatus> progress, CancellationToken cancellationToken);
+        <#=asyncString#>System.Threading.Tasks.Task<<#=returnType#>> CompleteOperationAsync(IProgress<AsyncOperationStatus> progress, CancellationToken cancellationToken);
     }
 }

--- a/Templates/CSharp/Requests/IMethodCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/IMethodCollectionPage.cs.tt
@@ -17,7 +17,7 @@ var entityCollectionPage = responseNamePrefix + "CollectionPage";
 namespace <#=method.Namespace.GetNamespaceName()#>
 {
     using Newtonsoft.Json;
-    
+
     /// <summary>
     /// The interface I<#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/IMethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/IMethodRequest.cs.tt
@@ -17,15 +17,15 @@ var isCollection = method.IsCollection;
 var sendAsyncReturnType = isCollection
     ? "I" + entityName + methodName + "CollectionPage"
     : returnEntityType;
-        
+
 var methodReturnType = sendAsyncReturnType == null
-    ? "Task"
-    : "Task<" + sendAsyncReturnType + ">";
-    
+    ? "System.Threading.Tasks.Task"
+    : "System.Threading.Tasks.Task<" + sendAsyncReturnType + ">";
+
 var methodReturnTag = sendAsyncReturnType == null
     ? "The task to await."
     : string.Concat("The", sendAsyncReturnType);
-        
+
 bool hasParameters = method.Parameters != null && method.Parameters.Any();
 bool returnsStream = string.Equals(sendAsyncReturnType, "Stream");
 
@@ -40,8 +40,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
-    
+
     /// <summary>
     /// The interface I<#=requestType#>.
     /// </summary>

--- a/Templates/CSharp/Requests/IStreamRequest.cs.tt
+++ b/Templates/CSharp/Requests/IStreamRequest.cs.tt
@@ -34,7 +34,6 @@ namespace <#=namespaceValue#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// The interface I<#=propRequest#>.
@@ -45,29 +44,29 @@ namespace <#=namespaceValue#>
         /// Gets the stream.
         /// </summary>
         /// <returns>The stream.</returns>
-        Task<Stream> GetAsync();
-        
+        System.Threading.Tasks.Task<Stream> GetAsync();
+
         /// <summary>
         /// Gets the stream.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The stream.</returns>
-        Task<Stream> GetAsync(CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead);
+        System.Threading.Tasks.Task<Stream> GetAsync(CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead);
 
 <#
         if (prop != null)
         {
     #>
-    
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
         /// <typeparam name="T">The type returned by the PUT call.</typeparam>
         /// <param name="<#=propName#>">The stream to PUT.</param>
         /// <returns>The object returned by the PUT call.</returns>
-        Task<T> PutAsync<T>(Stream <#=propName#>) where T : <#=propClass#>;
-        
+        System.Threading.Tasks.Task<T> PutAsync<T>(Stream <#=propName#>) where T : <#=propClass#>;
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
@@ -76,20 +75,20 @@ namespace <#=namespaceValue#>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The object returned by the PUT call.</returns>
-        Task<T> PutAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>;
+        System.Threading.Tasks.Task<T> PutAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>;
     <#
         }
         else
         {
     #>
-    
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
         /// <param name="<#=propName#>">The stream to PUT.</param>
         /// <returns>The updated stream.</returns>
-        Task<Stream> PutAsync(Stream <#=propName#>);
-        
+        System.Threading.Tasks.Task<Stream> PutAsync(Stream <#=propName#>);
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
@@ -97,7 +96,7 @@ namespace <#=namespaceValue#>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The updated stream.</returns>
-        Task<Stream> PutAsync(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead);
+        System.Threading.Tasks.Task<Stream> PutAsync(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead);
     <#
         }
     #>

--- a/Templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -24,7 +24,6 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     using System;
     using System.Collections.Generic;
     using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// The type <#=monitorType#>.
@@ -42,28 +41,28 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     {
         methodParameter = "this.RequestBody";
     }
-    
-    var asyncString = isCollection ? "async " : " ";
-    
+
+    var asyncString = isCollection ? "async " : "";
+
     #>
 
         /// <summary>
         /// Polls until the async operation is complete and returns the resulting <#=returnType#>.
         /// </summary>
-        public <#=asyncString#>Task<<#=returnType#>> CompleteOperationAsync(IProgress<AsyncOperationStatus> progress, CancellationToken cancellationToken)
+        public <#=asyncString#>System.Threading.Tasks.Task<<#=returnType#>> CompleteOperationAsync(IProgress<AsyncOperationStatus> progress, CancellationToken cancellationToken)
         {
         <#
         if (isCollection)
         {
         #>
-        
+
             var response = await this.PollForOperationCompletionAsync(progress, cancellationToken);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
                 if (response.AdditionalData != null)
                 {
                     response.Value.AdditionalData = response.AdditionalData;
-                        
+
                     object nextPageLink;
                     response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
 
@@ -102,12 +101,12 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         else
         {
         #>
-        
+
             return this.PollForOperationCompletionAsync(progress, cancellationToken);
         <#
         }
         #>
-        
+
         }
     }
 }

--- a/Templates/CSharp/Requests/MethodCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/MethodCollectionPage.cs.tt
@@ -14,7 +14,7 @@ var entityCollectionPage = responseNamePrefix + "CollectionPage";
 #>
 
 namespace <#=method.Namespace.GetNamespaceName()#>
-{   
+{
     /// <summary>
     /// The type <#=entityCollectionPage#>.
     /// </summary>

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -18,18 +18,18 @@ var isCollection = method.IsCollection;
 var sendAsyncReturnType = isCollection
     ? "I" + entityName + methodName + "CollectionPage"
     : returnEntityType;
-        
+
 var methodReturnType = sendAsyncReturnType == null
-    ? "Task"
-    : "Task<" + sendAsyncReturnType + ">";
+    ? "System.Threading.Tasks.Task"
+    : "System.Threading.Tasks.Task<" + sendAsyncReturnType + ">";
 
 string methodOverloadReturnType = methodReturnType;
-    
+
 if (isCollection)
 {
     methodReturnType = string.Concat("async ", methodReturnType);
 }
-        
+
 bool hasParameters = method.Parameters != null && method.Parameters.Any();
 bool includeRequestBody = hasParameters && isAction;
 bool returnsStream = string.Equals(sendAsyncReturnType, "Stream");
@@ -45,7 +45,6 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// The type <#=requestType#>.
@@ -92,7 +91,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         {
             return this.<#=httpMethod.ToLower().ToCheckedCase()#>Async(CancellationToken.None);
         }
-        
+
         /// <summary>
         /// Issues the <#=httpMethod#> request.
         /// </summary>
@@ -135,7 +134,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
                 if (response.AdditionalData != null)
                 {
                     response.Value.AdditionalData = response.AdditionalData;
-                    
+
                     object nextPageLink;
                     response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
 
@@ -170,7 +169,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     else
     {
 #>
-            return this.SendAsync(<#=methodParameter#>, cancellationToken); 
+            return this.SendAsync(<#=methodParameter#>, cancellationToken);
 <#
     }
 #>

--- a/Templates/CSharp/Requests/StreamRequest.cs.tt
+++ b/Templates/CSharp/Requests/StreamRequest.cs.tt
@@ -34,7 +34,6 @@ namespace <#=namespaceValue#>
     using System.IO;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// The type <#=propRequest#>.
@@ -59,18 +58,18 @@ namespace <#=namespaceValue#>
         /// Gets the stream.
         /// </summary>
         /// <returns>The stream.</returns>
-        public Task<Stream> GetAsync()
+        public System.Threading.Tasks.Task<Stream> GetAsync()
         {
             return this.GetAsync(CancellationToken.None);
         }
-        
+
         /// <summary>
         /// Gets the stream.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The stream.</returns>
-        public Task<Stream> GetAsync(CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+        public System.Threading.Tasks.Task<Stream> GetAsync(CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             this.Method = "GET";
             return this.SendStreamRequestAsync(null, cancellationToken, completionOption);
@@ -79,18 +78,18 @@ namespace <#=namespaceValue#>
         if (prop != null)
         {
     #>
-    
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
         /// <typeparam name="T">The type returned by the PUT call.</typeparam>
         /// <param name="<#=propName#>">The stream to PUT.</param>
         /// <returns>The object returned by the PUT call.</returns>
-        public Task<T> PutAsync<T>(Stream <#=propName#>) where T : <#=propClass#>
+        public System.Threading.Tasks.Task<T> PutAsync<T>(Stream <#=propName#>) where T : <#=propClass#>
         {
             return this.PutAsync<T>(<#=propName#>, CancellationToken.None);
         }
-        
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
@@ -99,7 +98,7 @@ namespace <#=namespaceValue#>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The object returned by the PUT call.</returns>
-        public Task<T> PutAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>
+        public System.Threading.Tasks.Task<T> PutAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>
         {
             this.ContentType = "application/octet-stream";
             this.Method = "PUT";
@@ -110,17 +109,17 @@ namespace <#=namespaceValue#>
         else
         {
     #>
-    
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
         /// <param name="<#=propName#>">The stream to PUT.</param>
         /// <returns>The updated stream.</returns>
-        public Task<Stream> PutAsync(Stream <#=propName#>)
+        public System.Threading.Tasks.Task<Stream> PutAsync(Stream <#=propName#>)
         {
             return this.PutAsync(<#=propName#>, CancellationToken.None);
         }
-        
+
         /// <summary>
         /// PUTs the specified stream.
         /// </summary>
@@ -128,7 +127,7 @@ namespace <#=namespaceValue#>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <param name="completionOption">The <see cref="HttpCompletionOption"/> to pass to the <see cref="IHttpProvider"/> on send.</param>
         /// <returns>The updated stream.</returns>
-        public Task<Stream> PutAsync(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+        public System.Threading.Tasks.Task<Stream> PutAsync(Stream <#=propName#>, CancellationToken cancellationToken, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             this.ContentType = "application/octet-stream";
             this.Method = "PUT";


### PR DESCRIPTION
Fully qualifying Task return type on methods, removing using clause for System.Threading.Tasks, fixing up some random extra spaces in files.