### PR TITLE
Allow passing options collection to Request method for stream requests

### DIFF
--- a/Templates/CSharp/Requests/IStreamRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/IStreamRequestBuilder.cs.tt
@@ -44,7 +44,8 @@ namespace <#=namespaceValue#>
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        I<#=propRequest#> Request();
+        I<#=propRequest#> Request(IEnumerable<Option> options = null);
     }
 }

--- a/Templates/CSharp/Requests/StreamRequestBuilder.cs.tt
+++ b/Templates/CSharp/Requests/StreamRequestBuilder.cs.tt
@@ -56,10 +56,11 @@ namespace <#=namespaceValue#>
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        public I<#=propRequest#> Request()
+        public I<#=propRequest#> Request(IEnumerable<Option> options = null)
         {
-            return new <#=propRequest#>(this.RequestUrl, this.Client, null);
+            return new <#=propRequest#>(this.RequestUrl, this.Client, options);
         }
     }
 }


### PR DESCRIPTION
This is needed in order to add things like the nameConflictBehavior query param when building the request. Also, would allow adding custom headers, etc.