### PR TITLE
Specify default base URL in config

### DIFF
--- a/Templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/CSharp/Requests/EntityClient.cs.tt
@@ -22,14 +22,14 @@ namespace <#=entityContainer.Namespace.GetNamespaceName()#>
         public <#=clientName#>(
             IAuthenticationProvider authenticationProvider,
             IHttpProvider httpProvider = null)
-            : this("https://graph.microsoft.com/v1.0", authenticationProvider, httpProvider)
+            : this(<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>, authenticationProvider, httpProvider)
         {
         }
 
         /// <summary>
         /// Instantiates a new <#=clientName#>.
         /// </summary>
-        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0."</param>
+        /// <param name="baseUrl">The base service URL. For example, "<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>"</param>
         /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.</param>
         /// <param name="httpProvider">The <see cref="IHttpProvider"/> for sending requests.</param>
         public <#=clientName#>(

--- a/Templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/CSharp/Requests/EntityClient.cs.tt
@@ -22,14 +22,14 @@ namespace <#=entityContainer.Namespace.GetNamespaceName()#>
         public <#=clientName#>(
             IAuthenticationProvider authenticationProvider,
             IHttpProvider httpProvider = null)
-            : this(<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>, authenticationProvider, httpProvider)
+            : this("<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>", authenticationProvider, httpProvider)
         {
         }
 
         /// <summary>
         /// Instantiates a new <#=clientName#>.
         /// </summary>
-        /// <param name="baseUrl">The base service URL. For example, "<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>"</param>
+        /// <param name="baseUrl">The base service URL. For example, "<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>".</param>
         /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.</param>
         /// <param name="httpProvider">The <see cref="IHttpProvider"/> for sending requests.</param>
         public <#=clientName#>(

--- a/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
+++ b/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
@@ -10,6 +10,7 @@
     "TemplatesDirectory": "../../../../Templates",
     "DefaultFileCasing": "UpperCamel",
     "CustomFlags": [ "python2" ],
+    "DefaultBaseEndpointUrl":  "https://graph.microsoft.com/v1.0",
     "LicenseHeader": [
         "Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information."
     ],

--- a/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
+++ b/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
             this.TemplatesDirectory = null;
             this.DefaultFileCasing = "UpperCamel";
             this.CustomFlags = new List<string>();
+            this.DefaultBaseEndpointUrl = "https://graph.microsoft.com/v1.0";
         }
 
         public void CopyPropertiesFromMainSettings()
@@ -75,6 +76,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
         /// The default casing method to be used for file names when a casing method ins't specified.
         /// </summary>
         public string DefaultFileCasing;
+
+        public string DefaultBaseEndpointUrl { get; set; }
 
         public IList<string> CustomFlags { get; set; }
 


### PR DESCRIPTION
The default base URL for a client is hard-coded in the template right now. Set it in config instead.