### PR TITLE
The first character of the enum should be lower case to match the schema

### DIFF
--- a/Templates/ObjC/Models/EnumType.m.tt
+++ b/Templates/ObjC/Models/EnumType.m.tt
@@ -63,7 +63,7 @@ foreach (var member in entity.Members.OrderBy(x => x.Value))
     {
 #>
         case <#=GetObjCEnumMember(entity,member)#>:
-            return [<#=typeName#> <#=member.Name#>];
+            return [<#=typeName#> <#=member.Name.ToLowerFirstChar()#>];
 <#
     }
 #>
@@ -111,7 +111,7 @@ foreach (var member in entity.Members.OrderBy(x => x.Value))
     {
     #>if([self isEqualToString:@"<#=member.Name#>"])
     {
-          return [<#=typeName#> <#=member.Name#>];
+          return [<#=typeName#> <#=member.Name.ToLowerFirstChar()#>];
     }
     else <#
     }


### PR DESCRIPTION
The enum is lowercase in the metadata and the enum definition. member.Name has the first character in upper case. This causes a build break.