### PR TITLE
Introduce MSTimeOfDate for Edm.TimeOfDay and bug fixes

### DIFF
--- a/Templates/ObjC/Base/SharedObjC.template.tt
+++ b/Templates/ObjC/Base/SharedObjC.template.tt
@@ -105,6 +105,13 @@ private string GetJsonToObjCExpressionConversion(string expr,OdcmProperty prop)
             expr);
     }
 
+	if(GetObjCTypeIdentifier(prop,true)=="MSTimeOfDay")
+    {
+        return String.Format(@"[{0} ms_timeFromString: {1}]",
+            GetObjCTypeIdentifier(prop,true),
+            expr);
+    }
+
     if(prop.IsEnum())
     {
         return String.Format(

--- a/Templates/ObjC/Models/Models.h.tt
+++ b/Templates/ObjC/Models/Models.h.tt
@@ -3,6 +3,7 @@
 <#@ include file="SharedObjC.template.tt"#>
 
 #import "MSDate.h"
+#import "MSTimeOfDay.h"
 <#		
 var enums = model.GetEnumTypes();
 foreach(var e in enums)

--- a/src/GraphODataTemplateWriter/CodeHelpers/ObjC/TypeHelperObjC.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/ObjC/TypeHelperObjC.cs
@@ -108,12 +108,18 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.ObjC
                     return "NSDate";
                 case "Date":
                     return "MSDate";
+                case "TimeOfDay":
+                    return "MSTimeOfDay";
                 case "Binary":
                     return "NSString";
                 case "Boolean":
                     return "BOOL";
                 case "Stream":
                     return "NSStream";
+                case "Duration":
+                    return "Duration";
+                case "NSDictionary":
+                    return "NSDictionary";
                 default:
                     return Prefix + type.Name.ToUpperFirstChar();
             }
@@ -128,7 +134,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.ObjC
         {
             string t = GetTypeString(type);
             return
-                !(t.Contains("int") || t == "BOOL" || t == "Byte" || t == "CGFloat");
+                !(t == "int32_t" || t == "int64_t" || t == "int16_t" || t == "BOOL" || t == "Byte" || t == "CGFloat");
         }
 
         public static bool IsComplex(this OdcmProperty property) 


### PR DESCRIPTION
- Create the class 'MSTimeOfDay' to handle Edm.TimeOfDay. I will checkin this class to the ios graph sdk.
- For IsComplex(..), we should not do a Contains("int"). This results in incorrect return values for types that just have "int" in their names like 'timeConstraint' or 'interval'.
- For Duration & NSDictionary, return the types without appending.