### PR TITLE
Remove duplicate capabilities from the list to prevent crashes.

### DIFF
--- a/src/GraphODataTemplateWriter/Extensions/FeatureExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/FeatureExtensions.cs
@@ -1,7 +1,43 @@
 ﻿using Vipr.Core.CodeModel;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Vipr.Core.CodeModel.Vocabularies.Capabilities;
 
 namespace Microsoft.Graph.ODataTemplateWriter.Extensions
 {
+
+    class CapabilityComparer : IEqualityComparer<OdcmCapability>
+    {
+        // Products are equal if their names and product numbers are equal.
+        public bool Equals(OdcmCapability x, OdcmCapability y)
+        {
+            //Check whether the compared objects reference the same data.
+            if (Object.ReferenceEquals(x, y)) return true;
+
+            //Check whether any of the compared objects is null.
+            if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
+                return false;
+
+            return x.TermName.Equals(y.TermName);
+        }
+
+        // If Equals() returns true for a pair of objects 
+        // then GetHashCode() must return the same value for these objects.
+
+        public int GetHashCode(OdcmCapability capability)
+        {
+            //Check whether the object is null
+            if (Object.ReferenceEquals(capability, null)) return 0;
+
+            //Get hash code for the Term Name field if it is not null.
+            int hashCapabilityName = capability.TermName == null ? 0 : capability.TermName.GetHashCode();
+
+            return hashCapabilityName;
+        }
+
+    }
+
     public sealed class Features
     {
         private readonly OdcmProjection _projection;
@@ -9,6 +45,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
         internal Features(OdcmProjection projection)
         {
             _projection = projection;
+
+            // Remove duplicate capabilities.
+            var capabilities = _projection.Capabilities.Distinct(new CapabilityComparer());
+            _projection.Capabilities = capabilities.ToList();            
         }
 
         public bool CanCreate { get { return _projection.SupportsInsert(); } }


### PR DESCRIPTION
For some entities, the Capabilities element has duplicates of the same annotation. This causes a crash in Vipr. Remove the duplication annotations before iterating though them.