### PR TITLE
Many changes, needs review

### DIFF
--- a/Templates/CSharp/Base/EntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequest.Base.template.tt
@@ -197,8 +197,16 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
+
     var entityName = this.GetEntityNameString(odcmClass);
-    var lowerCaseEntityName = entityName.ToLowerFirstChar();
+    
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
+	var lowerCaseEntityName = entityName.ToLowerFirstChar();
 
     this.AppendCreateAsyncHeader(entityName, lowerCaseEntityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
@@ -235,6 +243,13 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 
 public void AppendGetAsyncHeader(string entityName, StringBuilder stringBuilder, bool includeSendParams)
 {
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.AppendFormat("        ");
@@ -297,6 +312,12 @@ public string GetEntityGetAsyncMethod(OdcmClass odcmClass, bool initializeCollec
 
 public void AppendUpdateAsyncHeader(string entityName, string lowerCaseEntityName, StringBuilder stringBuilder, bool includeSendParams)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.AppendFormat("        ");
@@ -325,6 +346,13 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
     var stringBuilder = new StringBuilder();
 
     var entityName = this.GetEntityNameString(odcmClass);
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
 
     var templateWriterHost = (CustomT4Host)Host;
@@ -395,6 +423,13 @@ public string GetSelectMethod(string requestType)
 
 public string GetSelectExpressionMethod(string requestType, string underlyingType)
 {
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (underlyingType.EndsWith("Request"))
+	{
+		underlyingType = String.Concat(underlyingType, "Object");
+	}
+
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append(
@@ -429,6 +464,13 @@ public string GetSelectExpressionMethod(string requestType, string underlyingTyp
 
 public string GetExpandExpressionMethod(string requestType, string underlyingType)
 {
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (underlyingType.EndsWith("Request"))
+	{
+		underlyingType = String.Concat(underlyingType, "Object");
+	}
+
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append(

--- a/Templates/CSharp/Base/EntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequest.Base.template.tt
@@ -278,6 +278,12 @@ public string GetEntityGetAsyncMethod(OdcmClass odcmClass, bool initializeCollec
 
     var entityName = this.GetEntityNameString(odcmClass);
 
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     this.AppendGetAsyncHeader(entityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        public System.Threading.Tasks.Task<{0}> GetAsync()", entityName);

--- a/Templates/CSharp/Base/IEntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequest.Base.template.tt
@@ -314,6 +314,13 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
 
 public string GetExpandExpressionMethod(string requestType, string underlyingType)
 {
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (underlyingType.EndsWith("Request"))
+	{
+		underlyingType = String.Concat(underlyingType, "Object");
+	}
+
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append(
@@ -346,6 +353,13 @@ public string GetExpandMethod(string entityRequest)
 
 public string GetSelectExpressionMethod(string requestType, string underlyingType)
 {
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (underlyingType.EndsWith("Request"))
+	{
+		underlyingType = String.Concat(underlyingType, "Object");
+	}
+
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append(
@@ -380,13 +394,6 @@ public string GetSelectMethod(string entityRequest)
 public string GetEntityExpandMethods(OdcmClass odcmClass)
 {
     string entityName = this.GetEntityNameString(odcmClass);
-
-	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
-	if (entityName.EndsWith("Request"))
-	{
-		entityName = String.Concat(entityName, "Object");
-	}
-
     return this.GetExpandMethod(this.GetRequestString(entityName)) +
     Environment.NewLine + Environment.NewLine + "        " +
     this.GetExpandExpressionMethod(this.GetRequestString(entityName), entityName);
@@ -395,13 +402,6 @@ public string GetEntityExpandMethods(OdcmClass odcmClass)
 public string GetEntitySelectMethods(OdcmClass odcmClass)
 {
     string entityName = this.GetEntityNameString(odcmClass);
-
-	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
-	if (entityName.EndsWith("Request"))
-	{
-		entityName = String.Concat(entityName, "Object");
-	}
-
     return this.GetSelectMethod(this.GetRequestString(entityName)) +
     Environment.NewLine + Environment.NewLine + "        " +
     this.GetSelectExpressionMethod(this.GetRequestString(entityName), entityName);

--- a/Templates/CSharp/Base/IEntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequest.Base.template.tt
@@ -40,6 +40,12 @@ public string GetEntityRequestInterfaceDefinition(OdcmClass odcmClass)
 // -------------------------------------------------------------
 public void AppendEntityCreateAsyncMethodHeader(string entityName, string lowerCaseEntityName, StringBuilder stringBuilder, bool includeSendParams)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.Append("        ");
@@ -68,6 +74,13 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
     var stringBuilder = new StringBuilder();
 
     var entityName = this.GetEntityNameString(odcmClass);
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
 
     this.AppendEntityCreateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, false);
@@ -83,6 +96,12 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
 
 public void AppendDeleteAsyncMethodHeader(string deleteTargetString, StringBuilder stringBuilder, bool includeSendParams)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (deleteTargetString.EndsWith("Request"))
+	{
+		deleteTargetString = String.Concat(deleteTargetString, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.Append("        ");
@@ -106,6 +125,12 @@ public void AppendDeleteAsyncMethodHeader(string deleteTargetString, StringBuild
 
 public string GetDeleteAsyncMethod(string deleteTargetString)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (deleteTargetString.EndsWith("Request"))
+	{
+		deleteTargetString = String.Concat(deleteTargetString, "Object");
+	}
+
     var stringBuilder = new StringBuilder();
 
     this.AppendDeleteAsyncMethodHeader(deleteTargetString, stringBuilder, false);
@@ -170,6 +195,12 @@ public string GetEntityDeleteAsyncMethod(OdcmClass odcmClass)
 
 public void AppendGetAsyncMethodHeader(string entityName, StringBuilder stringBuilder, bool includeSendParams)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.Append("        ");
@@ -197,6 +228,12 @@ public string GetEntityGetAsyncMethod(OdcmClass odcmClass)
 
     var entityName = this.GetEntityNameString(odcmClass);
 
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     this.AppendGetAsyncMethodHeader(entityName, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        System.Threading.Tasks.Task<{0}> GetAsync();", entityName);
@@ -213,6 +250,12 @@ public string GetEntityGetAsyncMethod(OdcmClass odcmClass)
 
 public void AppendUpdateAsyncMethodHeader(string entityName, string lowerCaseEntityName, StringBuilder stringBuilder, bool includeSendParams)
 {
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     if (includeSendParams)
     {
         stringBuilder.Append("        ");
@@ -241,6 +284,13 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
     var stringBuilder = new StringBuilder();
 
     var entityName = this.GetEntityNameString(odcmClass);
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     var lowerCaseEntityName = entityName.ToLowerFirstChar();
 
     this.AppendUpdateAsyncMethodHeader(entityName, lowerCaseEntityName, stringBuilder, false);
@@ -330,6 +380,13 @@ public string GetSelectMethod(string entityRequest)
 public string GetEntityExpandMethods(OdcmClass odcmClass)
 {
     string entityName = this.GetEntityNameString(odcmClass);
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     return this.GetExpandMethod(this.GetRequestString(entityName)) +
     Environment.NewLine + Environment.NewLine + "        " +
     this.GetExpandExpressionMethod(this.GetRequestString(entityName), entityName);
@@ -338,6 +395,13 @@ public string GetEntityExpandMethods(OdcmClass odcmClass)
 public string GetEntitySelectMethods(OdcmClass odcmClass)
 {
     string entityName = this.GetEntityNameString(odcmClass);
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		entityName = String.Concat(entityName, "Object");
+	}
+
     return this.GetSelectMethod(this.GetRequestString(entityName)) +
     Environment.NewLine + Environment.NewLine + "        " +
     this.GetSelectExpressionMethod(this.GetRequestString(entityName), entityName);

--- a/Templates/CSharp/Base/SharedCSharp.template.tt
+++ b/Templates/CSharp/Base/SharedCSharp.template.tt
@@ -5,7 +5,7 @@
 CustomT4Host host   = (CustomT4Host)Host;
 OdcmModel model     = host.CurrentModel;
 var writer          = (CodeWriterCSharp)host.CodeWriter;
-bool logTemplateSrc = false;
+bool logTemplateSrc = true;
 
 #>
 <#=writer.WriteHeader()#>

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -49,7 +49,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
             var propertyType = property.IsCollection ? string.Format("IEnumerable<{0}>", property.GetTypeString()) : property.GetTypeString();
             var propertyName = isMethodResponse
                 ? property.Name.Substring(property.Name.IndexOf('.') + 1).ToCheckedCase()
-                : property.Name.ToCheckedCase().GetSanitizedPropertyName();
+                : property.Name.ToCheckedCase().GetSanitizedPropertyName(property);
 
             var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Required.Default)]", property.Name);
 

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -51,7 +51,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
                 ? property.Name.Substring(property.Name.IndexOf('.') + 1).ToCheckedCase()
                 : property.Name.ToCheckedCase().GetSanitizedPropertyName(property);
 
-            var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Required.Default)]", property.Name);
+            var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Newtonsoft.Json.Required.Default)]", property.Name);
 
             if (property.IsTypeNullable() || property.IsCollection)
             {

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -96,7 +96,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
         /// </summary>
         <#=attributeDefinition#>
-        public <#=propertyType#> <#=propertyName.GetSanitizedPropertyName()#> { get; set; }
+        public <#=propertyType#> <#=propertyName.GetSanitizedPropertyName(property)#> { get; set; }
     <#
             }
         }

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -8,6 +8,18 @@ var entityName = entity.Name.ToCheckedCase();
 
 var typeDeclaration = entityName;
 
+// In the case a entity type name ends with "Request", we will have a collision with the Request objects
+// when we generate. For example, there are entities named EventMessage and EventMessageRequest. Those entities 
+// lead to the generation of an EventMessageRequest and EventMessageRequestRequest request objects in the same 
+// namespace as the entities. We add 'Object' to the end of the name to disambiguate the entity.
+// This change needs to sync with changes for the *Request templates.
+
+if (typeDeclaration.EndsWith("Request"))
+{
+	typeDeclaration = String.Concat(typeDeclaration, "Object");
+}
+
+
 if (entity.Base != null)
 {
     typeDeclaration = string.Format("{0} : {1}", typeDeclaration, entity.Base.Name.ToCheckedCase());

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -61,7 +61,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
             var propertyName = property.Name.ToCheckedCase();
             var propertyCollectionPage = property.IsReference() ? string.Concat(entityName, propertyName, "CollectionWithReferencesPage") : string.Concat(entityName, propertyName, "CollectionPage");
 
-            var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Required.Default)]", property.Name);
+            var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Newtonsoft.Json.Required.Default)]", property.Name);
 
             if (property.IsCollection())
             {
@@ -109,7 +109,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// <summary>
         /// Gets or sets @odata.type.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Required.Default)]
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
         public string ODataType { get; set; }
 
         /// <summary>

--- a/Templates/CSharp/Model/EnumType.cs.tt
+++ b/Templates/CSharp/Model/EnumType.cs.tt
@@ -15,19 +15,26 @@ namespace <#=enumT.Namespace.GetNamespaceName()#>
     /// The enum <#=enumName#>.
     /// </summary>
     [JsonConverter(typeof(EnumConverter))]
+<#  if (enumT.IsFlags == true)
+    {
+#>
+	[System.Flags]
+<#
+		}
+#>
     public enum <#=enumName#>
     {
     <#
-        foreach(var value in enumT.Members)
+        foreach(var emumMember in enumT.Members)
         {
     #>
 
         /// <summary>
-        /// <#=value.Name.SplitCamelCase()#>
+        /// <#=emumMember.Name.SplitCamelCase()#>
         /// </summary>
-        <#=value.Name.ToCheckedCase().GetSanitizedPropertyName()#>,
-    <#
-        }
+        <#=emumMember.Name.ToCheckedCase().GetSanitizedPropertyName()#> = <#=emumMember.Value#>,
+	<#
+		}
     #>
 
     }

--- a/Templates/CSharp/Model/MethodRequestBody.cs.tt
+++ b/Templates/CSharp/Model/MethodRequestBody.cs.tt
@@ -46,7 +46,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         }
 
         var paramName = param.Name.ToCheckedCase().GetSanitizedPropertyName();
-		var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Required.Default)]", param.Name);
+		var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Newtonsoft.Json.Required.Default)]", param.Name);
     #>
 
         /// <summary>

--- a/Templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -31,7 +31,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// <summary>
         /// Gets or sets the <see cref="I<#=collectionPage#>"/> value.
         /// </summary>
-		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="value", Required = Required.Default)]
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="value", Required = Newtonsoft.Json.Required.Default)]
         public I<#=collectionPage#> Value { get; set; }
 
         /// <summary>

--- a/Templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -31,7 +31,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// <summary>
         /// Gets or sets the <see cref="I<#=collectionPage#>"/> value.
         /// </summary>
-		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="value", Required = Required.Default)]
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="value", Required = Newtonsoft.Json.Required.Default)]
         public I<#=collectionPage#> Value { get; set; }
 
         /// <summary>

--- a/Templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityRequest.cs.tt
@@ -62,12 +62,26 @@ namespace <#=this.GetNamespaceName(entity)#>
         Write(this.GetEntitySelectMethods(entity));
         Write("\n\n");
     }
+
+	// This change supports the scenario where we have an entity based model whose name ends with "Request".
+	// This will disambiguate with Request objects that are created for models.
+	var thisEntity_Name = entity.Name;
+	var thisEntityName = entityName;
+
+	// Special case for when an entity name ends with "Request". Associated with the change in EntityType.cs.tt
+	if (entityName.EndsWith("Request"))
+	{
+		thisEntity_Name = String.Concat(entity.Name, "Object");
+		thisEntityName = String.Concat(entityName, "Object");
+	}
+
+
 #>
         /// <summary>
         /// Initializes any collection properties after deserialization, like next requests for paging.
         /// </summary>
-        /// <param name="<#=entity.Name#>ToInitialize">The <see cref="<#=entityName#>"/> with the collection properties to initialize.</param>
-        private void InitializeCollectionProperties(<#=entityName#> <#=entity.Name#>ToInitialize)
+        /// <param name="<#=thisEntity_Name#>ToInitialize">The <see cref="<#=thisEntityName#>"/> with the collection properties to initialize.</param>
+        private void InitializeCollectionProperties(<#=thisEntityName#> <#=thisEntity_Name#>ToInitialize)
         {
 <#
         var navigationCollectionProperties = entity.Properties.Where(property => property.IsCollection() && property.IsNavigation());
@@ -76,7 +90,7 @@ namespace <#=this.GetNamespaceName(entity)#>
         {
 #>
 
-            if (<#=entity.Name#>ToInitialize != null && <#=entity.Name#>ToInitialize.AdditionalData != null)
+            if (<#=thisEntity_Name#>ToInitialize != null && <#=thisEntity_Name#>ToInitialize.AdditionalData != null)
             {
 <#
             foreach(var property in navigationCollectionProperties)
@@ -88,17 +102,17 @@ namespace <#=this.GetNamespaceName(entity)#>
                 {
 #>
 
-                if (<#=entity.Name#>ToInitialize.<#=propertyName#> != null && <#=entity.Name#>ToInitialize.<#=propertyName#>.CurrentPage != null)
+                if (<#=thisEntity_Name#>ToInitialize.<#=propertyName#> != null && <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.CurrentPage != null)
                 {
-                    <#=entity.Name#>ToInitialize.<#=propertyName#>.AdditionalData = <#=entity.Name#>ToInitialize.AdditionalData;
+                    <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.AdditionalData = <#=thisEntity_Name#>ToInitialize.AdditionalData;
 
                     object nextPageLink;
-                    <#=entity.Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out nextPageLink);
+                    <#=thisEntity_Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out nextPageLink);
                     var nextPageLinkString = nextPageLink as string;
 
                     if (!string.IsNullOrEmpty(nextPageLinkString))
                     {
-                        <#=entity.Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
+                        <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
                             this.Client,
                             nextPageLinkString);
                     }

--- a/Templates/CSharp/Requests/IMethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/IMethodRequest.cs.tt
@@ -13,7 +13,7 @@ var isComposable = method.IsComposable;
 var methodName = method.Name.Substring(method.Name.IndexOf('.') + 1).ToCheckedCase();
 var requestType = entityName + methodName + "Request";
 
-var returnEntityType = method.ReturnType == null ? null : method.ReturnType.Name.GetTypeString().ToCheckedCase();
+var returnEntityType = method.ReturnType == null ? null : method.ReturnType.Name.GetTypeString();
 var returnEntityParameter = string.Empty;
 if (returnEntityType != null) {returnEntityParameter = returnEntityType.ToLower();}
 var returnTypeObject = method.ReturnType == null ? null : method.ReturnType.AsOdcmClass();

--- a/Templates/CSharp/Requests/MethodCollectionResponse.cs.tt
+++ b/Templates/CSharp/Requests/MethodCollectionResponse.cs.tt
@@ -44,7 +44,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// <summary>
         /// Gets or sets the <#=propertyName#>.
         /// </summary>
-		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="<#=property.Name#>", Required = Required.Default)]
+		[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName ="<#=property.Name#>", Required = Newtonsoft.Json.Required.Default)]
         public <#=propertyType#> <#=propertyName#> { get; set; }
         <#
                 }

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -13,7 +13,7 @@ var isComposable = method.IsComposable;
 var methodName = method.Name.Substring(method.Name.IndexOf('.') + 1).ToCheckedCase();
 var requestType = entityName + methodName + "Request";
 
-var returnEntityType = method.ReturnType == null ? null : method.ReturnType.Name.GetTypeString().ToCheckedCase();
+var returnEntityType = method.ReturnType == null ? null : method.ReturnType.Name.GetTypeString();
 var returnEntityParameter = string.Empty;
 if (returnEntityType != null) {returnEntityParameter = returnEntityType.ToLower();}
 

--- a/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
+++ b/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
@@ -1,6 +1,6 @@
 ﻿{
     "AvailableLanguages": [ "Android", "ObjC", "CSharp", "PHP", "Python", "TypeScript", "GraphEndpointList" ],
-    "TargetLanguage": "Android",
+    "TargetLanguage": "CSharp",
     "Plugins": [ ],
     "PrimaryNamespaceName": "com",
     "NamespacePrefix": "com",

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
         public static bool IsTypeNullable(this OdcmType type)
         {
             var t = type.GetTypeString();
-            return type is OdcmClass || t == "Date" || t == "Stream" || t == "string" || t == "byte[]";
+            return type is OdcmClass || t == "Date" || t == "Stream" || t == "string" || t == "byte[]" || t == "TimeOfDay" || t == "Duration";
         }
 
         public static bool IsByteArray(this OdcmProperty property)

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -206,11 +206,43 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 
         public static string GetSanitizedPropertyName(this string property, string prefix = null)
         {
+            return GetSanitizedPropertyName(property, null, prefix);
+        }
+
+        /// <summary>
+        /// Sanitizes a property name for the following conditions: 
+        /// 1) a property has the same name as a C# keyword. Prefix @ to the property name to make it valid. 
+        /// 2) a property has the same name as the class. First we'll try to change the property name to the
+        /// return type name. If the return type name is the same as the class name, then we'll append 
+        /// "Property" to the property name.
+        /// </summary>
+        /// <param name="property">The string that called this extension.</param>
+        /// <param name="odcmProperty">An OdcmProperty. Use the property that you want to sanitize.</param>
+        /// <param name="prefix">The prefix to use on this property.</param>
+        /// <returns></returns>
+        public static string GetSanitizedPropertyName(this string property, OdcmProperty odcmProperty, string prefix = null)
+        {
             if (GetReservedNames().Contains(property))
             {
                 var reservedPrefix = string.IsNullOrEmpty(prefix) ? DefaultReservedPrefix : prefix;
 
                 return string.Concat(reservedPrefix, property.ToUpperFirstChar());
+            }
+
+            // Check whether the propertyObject is null (means they called the extension from a string).
+            // Check whether the property name is the same as the class name.
+            // Only constructor members may be named the same as the class name.
+            if (odcmProperty != null && property == odcmProperty.Class.Name.ToUpperFirstChar())
+            {
+                // Check whether the property type is the same as the class name.
+                if (odcmProperty.Projection.Type.Name.ToUpperFirstChar() == odcmProperty.Class.Name.ToUpperFirstChar())
+                {
+                    // Name the property: {metadataName} + "Property"
+                    return string.Concat(property, "Property");
+                }
+
+                // Name the property by its type. Sanitize it in case the type is a reserved name.  
+                return odcmProperty.Projection.Type.Name.ToUpperFirstChar().GetSanitizedPropertyName();
             }
 
             return property;

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             // Instead, take the properties that we know are references and not collections and grab the appropriate entity type
             // for each, returning those.
             var entityTypes = model.GetEntityTypes();
-            var referencePropertyTypes = model.GetProperties().Where(prop => prop.IsReference() && !prop.IsCollection).Select(prop => prop.Projection.Type).Distinct();
+
+            // Removed the !IsCollection condition as that was removing expected entity references from the collection.
+            var referencePropertyTypes = model.GetProperties().Where(prop => prop.IsReference()).Select(prop => prop.Projection.Type).Distinct();
 
             var referenceEntityTypes = new List<OdcmClass>();
             foreach (var referencePropertyType in referencePropertyTypes)


### PR DESCRIPTION
[53036e5](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/53036e5bd49ec52a98821ec1be8ab0c99a2b7d38) - Turned on logging for template src, set default to config to .Net, and made change a change in OdcmModelExtensions, GetEntityReferenceTypes around filtering out reference collections. This last one has the great opportunity to impact generation and needs another set of eyes in case we see downstream impacts at generation.

[c7a70ec](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/c7a70eca601af2577eb8cdff6948e58816e35b7d) - Add overload to GetSanitizedPropertyName in case we generate a property name that collides with the name of the type.

6be8c55 - JsonProperty attribute, changed the Required property to FQN form to avoid collisions with property named Required.

cdd7ef9 - Fixed issue where Edm.Boolean was generated into Bool instead of bool.

[9850b83](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/9850b8342e0d7649ab4a6ae69ce197dc2f0dd2a6) - Fixed scenario where we generated collisions when there were entities whose name ended with "Request". The collision occurred for EventMessage and **EventMessageRequest** entities. A request object is generated for both of them, as well as matching models. This led to the generation of request objects called **EventMessageRequest** and EventMessageRequestRequest. The bold entity and request object names collided with each other.

[88582s1](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/88582d1bbbfbab4e6feb94e865246c52602679ec) - we now support the generation of enum flags. 