### PR TITLE
Add the DerivedTypeConverter to base class for Complex Types

### DIFF
--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -18,8 +18,8 @@ var classType = complex.IsAbstract ? "abstract partial class" : "partial class";
 var attributeStringBuilder = new StringBuilder();
 attributeStringBuilder.Append("[JsonObject(MemberSerialization = MemberSerialization.OptIn)]");
 
-// We only want to add the derived type converter to the concrete class at the top of the inheritance hierarchy
-if (!complex.IsAbstract && complex.Derived != null && (complex.Base == null || complex.Base.IsAbstract))
+// We only want to add the derived type converter to the class at the top of the inheritance hierarchy
+if (complex.Derived != null && complex.Base == null)
 {
     attributeStringBuilder.Append(Environment.NewLine);
     attributeStringBuilder.Append("    ");


### PR DESCRIPTION
Change the logic for when the [JsonConverter(typeof(DerivedTypeConverter))] attribute is applied on Complex Types to match the logic used for entities.

This resolves issue where an entity references an abstract complex type