### PR TITLE
Update TS name to match library

### DIFF
--- a/src/GraphODataTemplateWriter/.config/TypeScriptSettings.json
+++ b/src/GraphODataTemplateWriter/.config/TypeScriptSettings.json
@@ -1,7 +1,7 @@
 {
     "TemplateMapping": {
       "TypeScript": [
-          { "Template": "entity_types", "SubProcessor": "Other", "Name": "entity_types" }
+          { "Template": "entity_types", "SubProcessor": "Other", "Name": "microsoft-graph.d" }
       ]
     }
 }

--- a/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
+++ b/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
         /// <summary>
         /// The default casing method to be used for file names when a casing method ins't specified.
         /// </summary>
-        public string DefaultFileCasing;
+        public string DefaultFileCasing { get; set; }
 
         public string DefaultBaseEndpointUrl { get; set; }
 


### PR DESCRIPTION
This enables us to generate and then copy-paste into the TS library. This also fixes a bug where DefaultFileCasing was not writeable.