### PR TITLE
Javadoc cleanup

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -386,6 +386,15 @@
         }
         return "Void";
     }
+
+	public string MethodParametersJavadocSignature(OdcmMethod method) {
+		var parameterSignatureBuilder = new StringBuilder();
+        foreach (var p in method.Parameters)
+        {
+            parameterSignatureBuilder.AppendFormat("\r\n     * @param {0} The {0}", ParamName(p));
+        }
+        return parameterSignatureBuilder.ToString();
+	}
     
     public string MethodParametersSignature(OdcmMethod method) {
         var parameterSignatureBuilder = new StringBuilder();

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -669,7 +669,7 @@ public {1} {2}{3}{4} {{";
                 property.Name,
                 propertyType,
                 property.Name.SanitizePropertyName(property).ToLowerFirstChar(),
-				property.LongDescription);
+				ReplaceInvalidCharacters(property.LongDescription));
         }
         return sb.ToString();
     }
@@ -693,7 +693,7 @@ public {1} {2}{3}{4} {{";
             sb.AppendFormat(
                 format,
                 ParamName(p).SplitCamelCase(),
-				p.LongDescription,
+				ReplaceInvalidCharacters(p.LongDescription),
                 ParamName(p),
                 ParamType(p),
                 ParamName(p).SanitizePropertyName(p).ToLowerFirstChar()
@@ -833,5 +833,16 @@ public {1} {2}{3}{4} {{";
 		//This seems to be a requirement of the template builder
 		//Specifying a return type of "void" throws an error
 	   return string.Empty;
+	}
+
+	/**
+	* Replaces invalid Javadoc characters with HTML
+	*/
+	public string ReplaceInvalidCharacters(string inputString)
+	{
+		if (inputString != null) {
+			return inputString.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+		}
+		return null;
 	}
 #>

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -391,7 +391,7 @@
 		var parameterSignatureBuilder = new StringBuilder();
         foreach (var p in method.Parameters)
         {
-            parameterSignatureBuilder.AppendFormat("\r\n     * @param {0} The {0}", ParamName(p));
+            parameterSignatureBuilder.AppendFormat("\r\n     * @param {0} the {0}", ParamName(p));
         }
         return parameterSignatureBuilder.ToString();
 	}
@@ -716,6 +716,7 @@ public {1} {2}{3}{4} {{";
 
     /**
      * Gets the raw representation of this class
+     *
      * @return the raw representation of this class
      */
     public JsonObject getRawObject() {
@@ -724,6 +725,7 @@ public {1} {2}{3}{4} {{";
 
     /**
      * Gets serializer
+     *
      * @return the serializer
      */
     protected ISerializer getSerializer() {
@@ -731,10 +733,10 @@ public {1} {2}{3}{4} {{";
     }
 
     /**
-     * Sets the raw json object
+     * Sets the raw JSON object
      *
-     * @param serializer The serializer
-     * @param json The json object to set this object to
+     * @param serializer the serializer
+     * @param json the JSON object to set this object to
      */
     public void setRawObject(final ISerializer serializer, final JsonObject json) {
         this.serializer = serializer;

--- a/Templates/Java/models_generated/IBaseClient.java.tt
+++ b/Templates/Java/models_generated/IBaseClient.java.tt
@@ -15,17 +15,17 @@ foreach (var prop in model.EntityContainer.Properties)
 #>
 
     /**
-     * Gets the collection of <#=propertyName#> objects.
+     * Gets the collection of <#=propertyName#> objects
      *
-     * @return The request builder for the collection of <#=propertyName#> objects
+     * @return the request builder for the collection of <#=propertyName#> objects
      */
     <#=ITypeCollectionRequestBuilder(prop)#> <#=prop.Name#>();
 
     /**
-     * Gets a single <#=propertyName#>.
+     * Gets a single <#=propertyName#>
      *
-     * @param id The id of the <#=propertyName#> to retrieve.
-     * @return The request builder for the <#=propertyName#> object
+     * @param id the id of the <#=propertyName#> to retrieve
+     * @return the request builder for the <#=propertyName#> object
      */
     <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>(final String id);
 <#
@@ -35,9 +35,9 @@ foreach (var prop in model.EntityContainer.Properties)
 #>
 
     /**
-     * Gets <#=TypeRequestBuilder(c)#>.
+     * Gets the <#=TypeRequestBuilder(c)#>
      *
-     * @return the <#=prop.Projection.Type.GetTypeString()#>.
+     * @return the <#=prop.Projection.Type.GetTypeString()#>
      */
     <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>();
 <#

--- a/Templates/Java/requests_extensions/Client.java.tt
+++ b/Templates/Java/requests_extensions/Client.java.tt
@@ -28,7 +28,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Sets the serializer
-         * @param serializer The serializer
+         * @param serializer the serializer
          * @return the instance of this builder
          */
         public Builder serializer(final ISerializer serializer) {
@@ -38,7 +38,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Sets the httpProvider
-         * @param httpProvider The httpProvider
+         * @param httpProvider the httpProvider
          * @return the instance of this builder
          */
         public Builder httpProvider(final IHttpProvider httpProvider) {
@@ -48,7 +48,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Sets the authentication provider
-         * @param authenticationProvider The authentication provider
+         * @param authenticationProvider the authentication provider
          * @return the instance of this builder
          */
         public Builder authenticationProvider(final IAuthenticationProvider authenticationProvider) {
@@ -58,7 +58,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Sets the executors
-         * @param executors The executors
+         * @param executors the executors
          * @return the instance of this builder
          */
         public Builder executors(final IExecutors executors) {
@@ -68,7 +68,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Sets the logger
-         * @param logger The logger
+         * @param logger the logger
          * @return the instance of this builder
          */
         public Builder logger(final ILogger logger) {
@@ -78,7 +78,7 @@ import <#=host.CurrentModel.NamespaceName()#>.logger.*;
 
         /**
          * Set this builder based on the client configuration
-         * @param clientConfig The client configuration
+         * @param clientConfig the client configuration
          * @return the instance of this builder
          */
         public Builder fromConfig(final IClientConfig clientConfig) {

--- a/Templates/Java/requests_extensions/EntityCollectionPage.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionPage.java.tt
@@ -10,8 +10,8 @@
     /**
      * A collection page for <#=ClassTypeName(c)#>.
      *
-     * @param response The serialized <#=BaseTypeCollectionResponse(c)#> from the service
-     * @param builder The request builder for the next collection page
+     * @param response the serialized <#=BaseTypeCollectionResponse(c)#> from the service
+     * @param builder the request builder for the next collection page
      */
     public <#=TypeCollectionPage(c)#>(final <#=BaseTypeCollectionResponse(c)#> response, final <#=ITypeCollectionRequestBuilder(c)#> builder) {
         super(response, builder);

--- a/Templates/Java/requests_extensions/EntityCollectionReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionReferenceRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param options The options for this request
+     * @param requestUrl the request URL
+     * @param client     the service client
+     * @param options    the options for this request
      */
     public <#=TypeCollectionReferenceRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> options) {
         super(requestUrl, client, options);

--- a/Templates/Java/requests_extensions/EntityCollectionReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionReferenceRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionReferenceRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityCollectionWithReferencesPage.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionWithReferencesPage.java.tt
@@ -10,8 +10,8 @@
     /**
      * A collection page for <#=ClassTypeName(c)#>.
      *
-     * @param response The serialized <#=BaseTypeCollectionResponse(c)#> from the service
-     * @param builder The request builder for the next collection page
+     * @param response the serialized <#=BaseTypeCollectionResponse(c)#> from the service
+     * @param builder  the request builder for the next collection page
      */
     public <#=TypeCollectionWithReferencesPage(c)#>(final <#=BaseTypeCollectionResponse(c)#> response, final <#=ITypeCollectionWithReferencesRequestBuilder(c)#> builder) {
         super(response, builder);

--- a/Templates/Java/requests_extensions/EntityCollectionWithReferencesRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionWithReferencesRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionWithReferencesRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityCollectionWithReferencesRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityCollectionWithReferencesRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionWithReferencesRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityReferenceRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeReferenceRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityReferenceRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeReferenceRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityRequest.java.tt
@@ -12,10 +12,10 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request URL
-     * @param client The service client
-     * @param requestOptions The options for this request
-     * @param responseClass The class of the response
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     * @param responseClass  the class of the response
      */
     public <#=TypeRequest(c)#>(final String requestUrl,
             final <#=IBaseClientType()#> client,
@@ -28,9 +28,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request URL
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=ClassTypeName(c)#>.class);

--- a/Templates/Java/requests_extensions/EntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityStreamRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityStreamRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeStreamRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=ClassTypeName(c)#>.class);

--- a/Templates/Java/requests_extensions/EntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityStreamRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeStreamRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/EntityWithReferenceRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeWithReferencesRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/EntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/EntityWithReferenceRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeWithReferencesRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/MethodCollectionPage.java.tt
+++ b/Templates/Java/requests_extensions/MethodCollectionPage.java.tt
@@ -11,8 +11,8 @@
     /**
      * A collection page for <#=ClassTypeName(c)#>.
      *
-     * @param response The serialized <#=BaseTypeCollectionResponse(c)#> from the service
-     * @param builder The request builder for the next collection page
+     * @param response the serialized <#=BaseTypeCollectionResponse(c)#> from the service
+     * @param builder  the request builder for the next collection page
      */
     public <#=TypeCollectionPage(c)#>(final <#=BaseTypeCollectionResponse(c)#> response, final <#=ITypeCollectionRequestBuilder(c)#> builder) {
         super(response, builder);

--- a/Templates/Java/requests_extensions/MethodCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/MethodCollectionRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeCollectionRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/MethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/MethodCollectionRequestBuilder.java.tt
@@ -14,7 +14,7 @@
      *
      * @param requestUrl The request url
      * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=TypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions<#=MethodParametersValues(method)#>);

--- a/Templates/Java/requests_extensions/MethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/MethodCollectionRequestBuilder.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=TypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions<#=MethodParametersValues(method)#>);

--- a/Templates/Java/requests_extensions/MethodRequest.java.tt
+++ b/Templates/Java/requests_extensions/MethodRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=TypeRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_extensions/MethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/MethodRequestBuilder.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=TypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions<#=MethodParametersValues(method)#>);

--- a/Templates/Java/requests_extensions/MethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/MethodRequestBuilder.java.tt
@@ -14,7 +14,7 @@
      *
      * @param requestUrl The request url
      * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=TypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions<#=MethodParametersValues(method)#>);

--- a/Templates/Java/requests_generated/BaseClient.java.tt
+++ b/Templates/Java/requests_generated/BaseClient.java.tt
@@ -38,19 +38,19 @@ foreach (var prop in model.EntityContainer.Properties)
 #>
 
     /**
-     * Gets the collection of <#=propertyName#> objects.
+     * Gets the collection of <#=propertyName#> objects
      *
-     * @return The request builder for the collection of <#=propertyName#> objects
+     * @return the request builder for the collection of <#=propertyName#> objects
      */
     public <#=ITypeCollectionRequestBuilder(prop)#> <#=prop.Name#>() {
         return new <#=TypeCollectionRequestBuilder(prop)#>(getServiceRoot() + "/<#=prop.Name#>", (<#=IClientType(c)#>)this, null);
     }
 
     /**
-     * Gets a single <#=propertyName#>.
+     * Gets a single <#=propertyName#>
      *
-     * @param id The id of the <#=propertyName#> to retrieve.
-     * @return The request builder for the <#=propertyName#> object
+     * @param id the id of the <#=propertyName#> to retrieve
+     * @return the request builder for the <#=propertyName#> object
      */
     public <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>(final String id) {
         return new <#=TypeRequestBuilder(prop)#>(getServiceRoot() + "/<#=prop.Name#>/" + id, (<#=IClientType(c)#>)this, null);
@@ -62,9 +62,9 @@ foreach (var prop in model.EntityContainer.Properties)
 #>
 
     /**
-     * Gets <#=TypeRequestBuilder(c)#>.
+     * Gets the <#=TypeRequestBuilder(c)#>
      *
-     * @return the <#=prop.Projection.Type.GetTypeString()#>.
+     * @return the <#=prop.Projection.Type.GetTypeString()#>
      */
     public <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>() {
         return new <#=TypeRequestBuilder(prop)#>(getServiceRoot() + "/<#=prop.Name#>", (<#=IClientType(c)#>)this, null);

--- a/Templates/Java/requests_generated/BaseEntityCollectionPage.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionPage.java.tt
@@ -15,10 +15,10 @@ String s = TypeName(c);
 #>
 
     /**
-     * A collection page for <#=TypeName(c)#>.
+     * A collection page for <#=TypeName(c)#>
      *
-     * @param response The serialized <#=BaseTypeCollectionResponse(c)#> from the service
-     * @param builder The request builder for the next collection page
+     * @param response the serialized <#=BaseTypeCollectionResponse(c)#> from the service
+     * @param builder  the request builder for the next collection page
      */
     public <#=BaseTypeCollectionPage(c)#>(final <#=BaseTypeCollectionResponse(c)#> response, final <#=ITypeCollectionRequestBuilder(c)#> builder) {
         super(response.value, builder);

--- a/Templates/Java/requests_generated/BaseEntityCollectionReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionReferenceRequest.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this collection of <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionReferenceRequest(c)#>(final String requestUrl, <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=BaseTypeCollectionResponse(c)#>.class, <#=ITypeCollectionPage(c)#>.class);
@@ -52,8 +52,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeCollectionReferenceRequest(c)#> expand(final String value) {
         addQueryOption(new QueryOption("$expand", value));
@@ -65,8 +65,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeCollectionReferenceRequest(c)#> select(final String value) {
         addQueryOption(new QueryOption("$select", value));
@@ -78,8 +78,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=ITypeCollectionReferenceRequest(c)#> top(final int value) {
         addQueryOption(new QueryOption("$top", value + ""));

--- a/Templates/Java/requests_generated/BaseEntityCollectionReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionReferenceRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionReferenceRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionRequest.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this collection of <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionRequest(c)#>(final String requestUrl, <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=BaseTypeCollectionResponse(c)#>.class, <#=ITypeCollectionPage(c)#>.class);
@@ -57,8 +57,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> expand(final String value) {
         addQueryOption(new QueryOption("$expand", value));
@@ -70,8 +70,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> select(final String value) {
         addQueryOption(new QueryOption("$select", value));
@@ -83,8 +83,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> top(final int value) {
         addQueryOption(new QueryOption("$top", value + ""));

--- a/Templates/Java/requests_generated/BaseEntityCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityCollectionResponse.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionResponse.java.tt
@@ -20,7 +20,7 @@ import com.google.gson.annotations.*;
     public java.util.List<<#=TypeName(c)#>> value;
 
     /**
-     * The url to the next page of this collection, or null
+     * The URL to the next page of this collection, or null
      */
     @SerializedName("@odata.nextLink")
     @Expose(serialize = false)

--- a/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesPage.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesPage.java.tt
@@ -12,10 +12,10 @@ import com.google.gson.annotations.*;
 <#=CreateClassDef(BaseTypeCollectionWithReferencesPage(c), "BaseCollectionPage" + CollectionPageWithReferencesGeneric(c), IBaseTypeCollectionWithReferencesPage(c))#>
 
     /**
-     * A collection page for <#=TypeName(c)#>.
+     * A collection page for <#=TypeName(c)#>
      *
-     * @param response The serialized <#=BaseTypeCollectionResponse(c)#> from the service
-     * @param builder The request builder for the next collection page
+     * @param response the serialized <#=BaseTypeCollectionResponse(c)#> from the service
+     * @param builder  the request builder for the next collection page
      */
     public <#=BaseTypeCollectionWithReferencesPage(c)#>(final <#=BaseTypeCollectionResponse(c)#> response, final <#=ITypeCollectionWithReferencesRequestBuilder(c)#> builder) {
         super(response.value, builder);

--- a/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesRequest.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this collection of <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionWithReferencesRequest(c)#>(final String requestUrl, <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=BaseTypeCollectionResponse(c)#>.class, <#=ITypeCollectionPage(c)#>.class);

--- a/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionWithReferencesRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityReferenceRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeReferenceRequest(c)#>(String requestUrl, <#=IBaseClientType()#> client, java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=ClassTypeName(c)#>.class);
@@ -31,8 +31,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeReferenceRequest(c)#> select(final String value) {
         getQueryOptions().add(new QueryOption("$select", value));
@@ -44,8 +44,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeReferenceRequest(c)#> expand(final String value) {
         getQueryOptions().add(new QueryOption("$expand", value));
@@ -56,8 +56,8 @@
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=TypeName(c)#> The <#=TypeName(c)#> reference to PUT
-     * @param callback The callback to be called after success or failure
+     * @param src<#=TypeName(c)#> the <#=TypeName(c)#> reference to PUT
+     * @param callback the callback to be called after success or failure
      */
     public void put(<#=TypeName(c)#> src<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback) {
         send(HttpMethod.PUT, callback, src<#=TypeName(c)#>);
@@ -66,9 +66,9 @@
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=TypeName(c)#> The <#=TypeName(c)#> reference to PUT
-     * @return The <#=TypeName(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=TypeName(c)#> the <#=TypeName(c)#> reference to PUT
+     * @return the <#=TypeName(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public <#=TypeName(c)#> put(<#=TypeName(c)#> src<#=TypeName(c)#>) throws ClientException {
         return send(HttpMethod.PUT, src<#=TypeName(c)#>);

--- a/Templates/Java/requests_generated/BaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityReferenceRequestBuilder.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeReferenceRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);
@@ -32,8 +32,8 @@
     /**
      * Creates the request with specific requestOptions instead of the existing requestOptions
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeReferenceRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeReferenceRequest(c)#> instance
      */
     public <#=ITypeReferenceRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeReferenceRequest(c)#>(getRequestUrl(), getClient(), requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityReferenceRequestBuilder.java.tt
@@ -22,6 +22,8 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeReferenceRequest(c)#> instance
      */
     public <#=ITypeReferenceRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -29,6 +31,9 @@
 
     /**
      * Creates the request with specific requestOptions instead of the existing requestOptions
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeReferenceRequest(c)#> instance
      */
     public <#=ITypeReferenceRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeReferenceRequest(c)#>(getRequestUrl(), getClient(), requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityRequest.java.tt
@@ -19,10 +19,10 @@ classDeclaration += TypeName(c);
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request URL
-     * @param client The service client
-     * @param requestOptions The options for this request
-     * @param responseClass The class of the response
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     * @param responseClass  the class of the response
      */
     public <#=BaseTypeRequest(c)#>(final String requestUrl,
             final <#=IBaseClientType()#> client,
@@ -65,8 +65,8 @@ classDeclaration += TypeName(c);
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
      public <#=ITypeRequest(c)#> select(final String value) {
          getQueryOptions().add(new QueryOption("$select", value));
@@ -78,8 +78,8 @@ classDeclaration += TypeName(c);
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
      public <#=ITypeRequest(c)#> expand(final String value) {
          getQueryOptions().add(new QueryOption("$expand", value));
@@ -92,8 +92,8 @@ classDeclaration += TypeName(c);
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
      public <#=ITypeRequest(c)#> top(final int value) {
          getQueryOptions().add(new QueryOption("$top", value+""));
@@ -108,15 +108,17 @@ classDeclaration += TypeName(c);
         var odcmObject = c.AsOdcmClass();
         var formatString =
 @"    /**
-     * Delete this item from the service.
-     * @param callback The callback when the deletion action has completed
+     * Delete this item from the service
+     *
+     * @param callback the callback when the deletion action has completed
      */
     public void delete(final ICallback<Void> callback) {{
         send(HttpMethod.DELETE, callback, null);
     }}
 
     /**
-     * Delete this item from the service.
+     * Delete this item from the service
+     *
      * @throws ClientException if there was an exception during the delete operation
      */
     public void delete() throws ClientException {{
@@ -132,7 +134,8 @@ classDeclaration += TypeName(c);
         var formatString =
 @"    /**
      * Gets the {0} from the service
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param callback the callback to be called after success or failure
      */
     public void get(final ICallback<{0}> callback) {{
         send(HttpMethod.GET, callback, null);
@@ -140,8 +143,9 @@ classDeclaration += TypeName(c);
 
     /**
      * Gets the {0} from the service
-     * @return The {0} from the request.
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @return the {0} from the request
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     public {0} get() throws ClientException {{
        return send(HttpMethod.GET, null);
@@ -156,8 +160,9 @@ classDeclaration += TypeName(c);
         var formatString =
 @"    /**
      * Patches this {0} with a source
-     * @param source{0} The source object with updates
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param source{0} the source object with updates
+     * @param callback the callback to be called after success or failure
      */
     public void patch(final {0} source{0}, final ICallback<{0}> callback) {{
         send(HttpMethod.PATCH, callback, source{0});
@@ -165,9 +170,10 @@ classDeclaration += TypeName(c);
 
     /**
      * Patches this {0} with a source
-     * @param source{0} The source object with updates
-     * @return The updated {0}
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @param source{0} the source object with updates
+     * @return the updated {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     public {0} patch(final {0} source{0}) throws ClientException {{
         return send(HttpMethod.PATCH, source{0});
@@ -182,8 +188,9 @@ classDeclaration += TypeName(c);
         var formatString =
 @"    /**
      * Creates a {0} with a new object
-     * @param new{0} The new object to create
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param new{0} the new object to create
+     * @param callback the callback to be called after success or failure
      */
     public void post(final {0} new{0}, final ICallback<{0}> callback) {{
         send(HttpMethod.POST, callback, new{0});
@@ -191,9 +198,10 @@ classDeclaration += TypeName(c);
 
     /**
      * Creates a {0} with a new object
-     * @param new{0} The new object to create
-     * @return The created {0}
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @param new{0} the new object to create
+     * @return the created {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     public {0} post(final {0} new{0}) throws ClientException {{
         return send(HttpMethod.POST, new{0});

--- a/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
@@ -21,6 +21,8 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -28,6 +30,9 @@
 
     /**
      * Creates the request with specific requestOptions instead of the existing requestOptions
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeRequest(c)#>(getRequestUrl(), getClient(), requestOptions);
@@ -56,6 +61,8 @@ if (c.AsOdcmClass() != null)
 
     /**
      * Gets the request builder for <#=TypeName(prop)#>.
+     *
+     * @return The <#=ITypeRequestBuilder(prop)#> instance
      */
     public <#=ITypeRequestBuilder(prop)#> <#=sanitizedProperty#>() {
         return new <#=TypeRequestBuilder(prop)#>(getRequestUrlWithAdditionalSegment("<#=prop.Name#>"), getClient(), null);

--- a/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);
@@ -22,7 +22,7 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -31,8 +31,8 @@
     /**
      * Creates the request with specific requestOptions instead of the existing requestOptions
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeRequest(c)#>(getRequestUrl(), getClient(), requestOptions);
@@ -60,9 +60,9 @@ if (c.AsOdcmClass() != null)
 #>
 
     /**
-     * Gets the request builder for <#=TypeName(prop)#>.
+     * Gets the request builder for <#=TypeName(prop)#>
      *
-     * @return The <#=ITypeRequestBuilder(prop)#> instance
+     * @return the <#=ITypeRequestBuilder(prop)#> instance
      */
     public <#=ITypeRequestBuilder(prop)#> <#=sanitizedProperty#>() {
         return new <#=TypeRequestBuilder(prop)#>(getRequestUrlWithAdditionalSegment("<#=prop.Name#>"), getClient(), null);

--- a/Templates/Java/requests_generated/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityStreamRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeStreamRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);
@@ -22,7 +22,7 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeStreamRequest(c)#> instance
+     * @return the <#=ITypeStreamRequest(c)#> instance
      */
     public <#=ITypeStreamRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -31,8 +31,8 @@
     /**
      * Creates the request with specific options instead of the existing options
 	 *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeStreamRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeStreamRequest(c)#> instance
      */
     public <#=ITypeStreamRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeStreamRequest(c)#>(getRequestUrl(), getClient(), requestOptions);
@@ -57,9 +57,9 @@ if (c.AsOdcmClass() != null)
 #>
 
     /**
-     * Gets the request builder for <#=TypeName(prop)#>.
+     * Gets the request builder for <#=TypeName(prop)#>
      *
-     * @return The <#=ITypeRequestBuilder(prop)#>
+     * @return the <#=ITypeRequestBuilder(prop)#>
      */
     public <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>() {
         return new <#=TypeRequestBuilder(prop)#>(getRequestUrlWithAdditionalSegment("<#=prop.Name#>"), getClient(), null);

--- a/Templates/Java/requests_generated/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityStreamRequestBuilder.java.tt
@@ -21,6 +21,8 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeStreamRequest(c)#> instance
      */
     public <#=ITypeStreamRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -28,6 +30,9 @@
 
     /**
      * Creates the request with specific options instead of the existing options
+	 *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeStreamRequest(c)#> instance
      */
     public <#=ITypeStreamRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeStreamRequest(c)#>(getRequestUrl(), getClient(), requestOptions);
@@ -53,6 +58,8 @@ if (c.AsOdcmClass() != null)
 
     /**
      * Gets the request builder for <#=TypeName(prop)#>.
+     *
+     * @return The <#=ITypeRequestBuilder(prop)#>
      */
     public <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>() {
         return new <#=TypeRequestBuilder(prop)#>(getRequestUrlWithAdditionalSegment("<#=prop.Name#>"), getClient(), null);

--- a/Templates/Java/requests_generated/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityWithReferenceRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeWithReferencesRequest(c)#>(String requestUrl, <#=IBaseClientType()#> client, java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=ClassTypeName(c)#>.class);
@@ -43,8 +43,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeWithReferencesRequest(c)#> select(final String value) {
         getQueryOptions().add(new QueryOption("$select", value));
@@ -56,8 +56,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeWithReferencesRequest(c)#> expand(final String value) {
         getQueryOptions().add(new QueryOption("$expand", value));

--- a/Templates/Java/requests_generated/BaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityWithReferenceRequestBuilder.java.tt
@@ -21,6 +21,8 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeWithReferencesRequest(c)#> instance
      */
     public <#=ITypeWithReferencesRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -28,6 +30,9 @@
 
     /**
      * Creates the request with specific options instead of the existing options
+	 *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeWithReferencesRequest(c)#> instance
      */
     public <#=ITypeWithReferencesRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeWithReferencesRequest(c)#>(getRequestUrl(), getClient(), requestOptions);

--- a/Templates/Java/requests_generated/BaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityWithReferenceRequestBuilder.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request builder for the <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeWithReferencesRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions);
@@ -22,7 +22,7 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeWithReferencesRequest(c)#> instance
+     * @return the <#=ITypeWithReferencesRequest(c)#> instance
      */
     public <#=ITypeWithReferencesRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -31,8 +31,8 @@
     /**
      * Creates the request with specific options instead of the existing options
 	 *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeWithReferencesRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeWithReferencesRequest(c)#> instance
      */
     public <#=ITypeWithReferencesRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         return new <#=TypeWithReferencesRequest(c)#>(getRequestUrl(), getClient(), requestOptions);

--- a/Templates/Java/requests_generated/BaseMethodBodyRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodBodyRequest.java.tt
@@ -29,9 +29,9 @@
     /**
      * The request for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=baseTypeRequest#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=returnType#>.class);
@@ -50,8 +50,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=iTypeRequest#> select(final String value) {
         getQueryOptions().add(new QueryOption("$select", value));
@@ -63,8 +63,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=iTypeRequest#> top(final int value) {
         getQueryOptions().add(new QueryOption("$top", value+""));
@@ -76,8 +76,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=iTypeRequest#> expand(final String value) {
         getQueryOptions().add(new QueryOption("$expand", value));

--- a/Templates/Java/requests_generated/BaseMethodCollectionRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodCollectionRequest.java.tt
@@ -17,9 +17,9 @@
     /**
      * The request for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeCollectionRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
 <# if (c.AsOdcmMethod().ReturnType != null) { #>
@@ -96,8 +96,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> select(final String value) {
         addQueryOption(new QueryOption("$select", value));
@@ -109,8 +109,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> top(final int value) {
         addQueryOption(new QueryOption("$top", value+""));
@@ -122,8 +122,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeCollectionRequest(c)#> expand(final String value) {
         addQueryOption(new QueryOption("$expand", value));

--- a/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this collection of <#=ClassTypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=BaseTypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
@@ -14,7 +14,7 @@
      *
      * @param requestUrl The request url
      * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=BaseTypeCollectionRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseMethodRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodRequest.java.tt
@@ -11,9 +11,9 @@
     /**
      * The request for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      */
     public <#=BaseTypeRequest(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=ReturnType(c)#>.class);
@@ -26,7 +26,7 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     public void post(final ICallback<<#=ReturnType(c)#>> callback) {
         send(HttpMethod.POST, callback, null);
@@ -35,8 +35,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public <#=ReturnType(c)#> post() throws ClientException {
        return send(HttpMethod.POST, null);
@@ -48,8 +48,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> select(final String value) {
         getQueryOptions().add(new QueryOption("$select", value));
@@ -64,8 +64,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> expand(final String value) {
         getQueryOptions().add(new QueryOption("$expand", value));
@@ -81,8 +81,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> top(final int value) {
         getQueryOptions().add(new QueryOption("$top", value+""));
@@ -95,7 +95,7 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     public void post(final ICallback<Void> callback) {
         final IExecutors executors = getClient().getExecutors();
@@ -115,7 +115,7 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public void post() throws ClientException {
         this.send(HttpMethod.POST, null);
@@ -128,8 +128,8 @@ if (c.AsOdcmMethod().IsAction()) {
 #>
     /**
      * Patches the <#=TypeName(c)#>
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> with which to PATCH
-     * @param callback The callback to be called after success or failure
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> with which to PATCH
+     * @param callback the callback to be called after success or failure
      */
     public void patch(<#=ReturnType(c)#> src<#=ReturnType(c)#>, final ICallback<<#=ReturnType(c)#>> callback) {
         send(HttpMethod.PATCH, callback, src<#=ReturnType(c)#>);
@@ -138,9 +138,9 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Patches the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> with which to PATCH
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> with which to PATCH
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
      public <#=ReturnType(c)#> patch(<#=ReturnType(c)#> src<#=ReturnType(c)#>) throws ClientException {
         return this.send(HttpMethod.PATCH, src<#=ReturnType(c)#>);
@@ -149,8 +149,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> to PUT
-     * @param callback The callback to be called after success or failure
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> to PUT
+     * @param callback the callback to be called after success or failure
      */
     public void put(<#=ReturnType(c)#> src<#=ReturnType(c)#>, final ICallback<<#=ReturnType(c)#>> callback) {
         send(HttpMethod.PUT, callback, src<#=ReturnType(c)#>);
@@ -159,9 +159,9 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> to PUT
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> to PUT
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
      public <#=ReturnType(c)#> put(<#=ReturnType(c)#> src<#=ReturnType(c)#>) throws ClientException {
         return this.send(HttpMethod.PUT, src<#=ReturnType(c)#>);
@@ -172,7 +172,7 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Gets the <#=ReturnType(c)#>
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     public void get(final ICallback<<#=ReturnType(c)#>> callback) {
         send(HttpMethod.GET, callback, null);
@@ -181,8 +181,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Gets the <#=ReturnType(c)#>
      *
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public <#=ReturnType(c)#> get() throws ClientException {
        return send(HttpMethod.GET, null);
@@ -194,8 +194,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> select(final String value) {
         getQueryOptions().add(new QueryOption("$select", value));
@@ -210,8 +210,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> expand(final String value) {
         getQueryOptions().add(new QueryOption("$expand", value));
@@ -227,8 +227,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     public <#=ITypeRequest(c)#> top(final int value) {
         getQueryOptions().add(new QueryOption("$top", value+""));

--- a/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
@@ -12,9 +12,9 @@
     /**
      * The request builder for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request url
-     * @param client The service client
-     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=BaseTypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions);
@@ -31,7 +31,7 @@
     /**
      * Creates the <#=ITypeRequest(c)#>
      *
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest() {
         return buildRequest(getOptions());
@@ -41,7 +41,7 @@
      * Creates the <#=ITypeRequest(c)#> with specific requestOptions instead of the existing requestOptions
      *
      * @param requestOptions the options for the request
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     public <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions) {
         <#=TypeRequest(c)#> request = new <#=TypeRequest(c)#>(

--- a/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
@@ -14,7 +14,7 @@
      *
      * @param requestUrl The request url
      * @param client The service client
-     * @param requestOptions The options for this request
+     * @param requestOptions The options for this request<#=MethodParametersJavadocSignature(method)#>
      */
     public <#=BaseTypeRequestBuilder(c)#>(final String requestUrl, final <#=IBaseClientType()#> client, final java.util.List<? extends Option> requestOptions<#=MethodParametersSignature(method)#>) {
         super(requestUrl, client, requestOptions);

--- a/Templates/Java/requests_generated/BaseStreamRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseStreamRequest.java.tt
@@ -13,10 +13,10 @@ import java.io.*;
     /**
      * The request for this <#=TypeName(c)#>
      *
-     * @param requestUrl The request URL
-     * @param client The service client
-     * @param requestOptions The options for this request
-     * @param responseClass The class of the response
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     * @param responseClass  the class of the response
      */
     public <#=BaseTypeStreamRequest(c)#>(
                          final String requestUrl,
@@ -29,7 +29,7 @@ import java.io.*;
     /**
      * Gets the contents of this stream
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     public void get(final ICallback<InputStream> callback) {
         send(callback);
@@ -38,8 +38,8 @@ import java.io.*;
     /**
      * Gets the contents of this stream
      *
-     * @return The stream that the caller needs to close.
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the stream that the caller needs to close
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public InputStream get() throws ClientException {
        return send();
@@ -48,8 +48,8 @@ import java.io.*;
     /**
      * Uploads to the stream
      *
-     * @param fileContents The contents of the stream to upload.
-     * @param callback The callback to be called after success or failure.
+     * @param fileContents the contents of the stream to upload
+     * @param callback the callback to be called after success or failure
      */
     public void put(final byte[] fileContents, final ICallback<<#=ClassTypeName(c)#>> callback) {
         send(fileContents, callback);
@@ -58,9 +58,9 @@ import java.io.*;
     /**
      * Uploads to the stream
      *
-     * @param fileContents The contents of the stream to upload.
-     * @return The result of the upload.
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @param fileContents the contents of the stream to upload
+     * @return the result of the upload
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     public <#=ClassTypeName(c)#> put(final byte[] fileContents) throws ClientException {
         return send(fileContents);

--- a/Templates/Java/requests_generated/IBaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityCollectionRequest.java.tt
@@ -20,8 +20,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> expand(final String value);
 
@@ -30,8 +30,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> select(final String value);
 
@@ -40,8 +40,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> top(final int value);
 

--- a/Templates/Java/requests_generated/IBaseEntityReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityReferenceRequest.java.tt
@@ -16,8 +16,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=IBaseTypeReferenceRequest(c)#> select(final String value);
 
@@ -26,8 +26,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=IBaseTypeReferenceRequest(c)#> expand(final String value);
 
@@ -36,17 +36,17 @@
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=TypeName(c)#> The <#=TypeName(c)#> to PUT
-     * @param callback The callback to be called after success or failure
+     * @param src<#=TypeName(c)#> the <#=TypeName(c)#> to PUT
+     * @param callback the callback to be called after success or failure
      */
     void put(<#=TypeName(c)#> src<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback);
 
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=TypeName(c)#> The <#=TypeName(c)#> to PUT
-     * @return The <#=TypeName(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=TypeName(c)#> the <#=TypeName(c)#> to PUT
+     * @return the <#=TypeName(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     <#=TypeName(c)#> put(<#=TypeName(c)#> src<#=TypeName(c)#>) throws ClientException;
 <# } #>

--- a/Templates/Java/requests_generated/IBaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityReferenceRequestBuilder.java.tt
@@ -10,11 +10,16 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeReferenceRequest(c)#> instance
      */
     <#=ITypeReferenceRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeReferenceRequest(c)#> instance
      */
     <#=ITypeReferenceRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 }

--- a/Templates/Java/requests_generated/IBaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityReferenceRequestBuilder.java.tt
@@ -11,15 +11,15 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeReferenceRequest(c)#> instance
+     * @return the <#=ITypeReferenceRequest(c)#> instance
      */
     <#=ITypeReferenceRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeReferenceRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeReferenceRequest(c)#> instance
      */
     <#=ITypeReferenceRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 }

--- a/Templates/Java/requests_generated/IBaseEntityRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityRequest.java.tt
@@ -42,8 +42,8 @@
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=IBaseTypeRequest(c)#> select(final String value);
 
@@ -52,8 +52,8 @@
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=IBaseTypeRequest(c)#> expand(final String value);
 
@@ -63,8 +63,8 @@
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=IBaseTypeRequest(c)#> top(final int value);
 <# } #>
@@ -76,13 +76,15 @@
         var odcmObject = c.AsOdcmClass();
         var formatString =
 @"    /**
-     * Delete this item from the service.
-     * @param callback The callback when the deletion action has completed
+     * Delete this item from the service
+     *
+     * @param callback the callback when the deletion action has completed
      */
     void delete(final ICallback<Void> callback);
 
     /**
-     * Delete this item from the service.
+     * Delete this item from the service
+     *
      * @throws ClientException if there was an exception during the delete operation
      */
     void delete() throws ClientException;
@@ -96,14 +98,16 @@
         var formatString =
 @"    /**
      * Gets the {0} from the service
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param callback the callback to be called after success or failure
      */
     void get(final ICallback<{0}> callback);
 
     /**
      * Gets the {0} from the service
-     * @return The {0} from the request.
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @return the {0} from the request
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     {0} get() throws ClientException;
 ";
@@ -116,16 +120,18 @@
         var formatString =
 @"    /**
      * Patches this {0} with a source
-     * @param source{0} The source object with updates
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param source{0} the source object with updates
+     * @param callback the callback to be called after success or failure
      */
     void patch(final {0} source{0}, final ICallback<{0}> callback);
 
     /**
      * Patches this {0} with a source
-     * @param source{0} The source object with updates
-     * @return The updated {0}
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @param source{0} the source object with updates
+     * @return the updated {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     {0} patch(final {0} source{0}) throws ClientException;
 ";
@@ -138,16 +144,18 @@
         var formatString =
 @"    /**
      * Posts a {0} with a new object
-     * @param new{0} The new object to create
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param new{0} the new object to create
+     * @param callback the callback to be called after success or failure
      */
     void post(final {0} new{0}, final ICallback<{0}> callback);
 
     /**
      * Posts a {0} with a new object
-     * @param new{0} The new object to create
-     * @return The created {0}
-     * @throws ClientException This exception occurs if the request was unable to complete for any reason.
+     *
+     * @param new{0} the new object to create
+     * @return the created {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     {0} post(final {0} new{0}) throws ClientException;
 ";

--- a/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
@@ -9,11 +9,16 @@
 <#=CreateInterfaceDef(IBaseTypeRequestBuilder(c), "IRequestBuilder")#>
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 <#
@@ -36,6 +41,8 @@ if (c.AsOdcmClass() != null)
 
     /**
      * Gets the request builder for <#=TypeName(prop)#>.
+     *
+     * @return The <#=ITypeRequestBuilder(prop)#> instance
      */
     <#=ITypeRequestBuilder(prop)#> <#=sanitizedName.ToLowerFirstChar()#>();
 <#

--- a/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
@@ -10,15 +10,15 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 <#
@@ -40,9 +40,9 @@ if (c.AsOdcmClass() != null)
 #>
 
     /**
-     * Gets the request builder for <#=TypeName(prop)#>.
+     * Gets the request builder for <#=TypeName(prop)#>
      *
-     * @return The <#=ITypeRequestBuilder(prop)#> instance
+     * @return the <#=ITypeRequestBuilder(prop)#> instance
      */
     <#=ITypeRequestBuilder(prop)#> <#=sanitizedName.ToLowerFirstChar()#>();
 <#

--- a/Templates/Java/requests_generated/IBaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityStreamRequestBuilder.java.tt
@@ -10,11 +10,16 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeStreamRequest(c)#> instance
      */
     <#=ITypeStreamRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeStreamRequest(c)#> instance
      */
     <#=ITypeStreamRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 <#
@@ -35,6 +40,8 @@ if (c.AsOdcmClass() != null)
 
     /**
      * Gets the request builder for <#=TypeName(prop)#>.
+     *
+     * @return The <#=ITypeRequestBuilder(prop)#> instance
      */
     <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>();
 <#

--- a/Templates/Java/requests_generated/IBaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityStreamRequestBuilder.java.tt
@@ -11,15 +11,15 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeStreamRequest(c)#> instance
+     * @return the <#=ITypeStreamRequest(c)#> instance
      */
     <#=ITypeStreamRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeStreamRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeStreamRequest(c)#> instance
      */
     <#=ITypeStreamRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 <#
@@ -39,9 +39,9 @@ if (c.AsOdcmClass() != null)
 #>
 
     /**
-     * Gets the request builder for <#=TypeName(prop)#>.
+     * Gets the request builder for <#=TypeName(prop)#>
      *
-     * @return The <#=ITypeRequestBuilder(prop)#> instance
+     * @return the <#=ITypeRequestBuilder(prop)#> instance
      */
     <#=ITypeRequestBuilder(prop)#> <#=prop.Name#>();
 <#

--- a/Templates/Java/requests_generated/IBaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityWithReferenceRequestBuilder.java.tt
@@ -10,11 +10,16 @@
 
     /**
      * Creates the request
+     *
+     * @return The <#=ITypeWithReferencesRequest(c)#> instance
      */
     <#=ITypeWithReferencesRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
+     *
+     * @param requestOptions The options for this request
+     * @return The <#=ITypeWithReferencesRequest(c)#> instance
      */
     <#=ITypeWithReferencesRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 

--- a/Templates/Java/requests_generated/IBaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityWithReferenceRequestBuilder.java.tt
@@ -11,15 +11,15 @@
     /**
      * Creates the request
      *
-     * @return The <#=ITypeWithReferencesRequest(c)#> instance
+     * @return the <#=ITypeWithReferencesRequest(c)#> instance
      */
     <#=ITypeWithReferencesRequest(c)#> buildRequest();
 
     /**
      * Creates the request with specific options instead of the existing options
      *
-     * @param requestOptions The options for this request
-     * @return The <#=ITypeWithReferencesRequest(c)#> instance
+     * @param requestOptions the options for this request
+     * @return the <#=ITypeWithReferencesRequest(c)#> instance
      */
     <#=ITypeWithReferencesRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 

--- a/Templates/Java/requests_generated/IBaseMethodBodyRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodBodyRequest.java.tt
@@ -36,8 +36,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=iTypeRequest#> select(final String value) ;
 
@@ -46,8 +46,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=iTypeRequest#> top(final int value);
 
@@ -56,8 +56,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=iTypeRequest#> expand(final String value);
 

--- a/Templates/Java/requests_generated/IBaseMethodCollectionRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodCollectionRequest.java.tt
@@ -25,8 +25,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> select(final String value);
 
@@ -35,8 +35,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> expand(final String value);
 
@@ -45,8 +45,8 @@ import com.google.gson.annotations.*;
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=ITypeCollectionRequest(c)#> top(final int value);
 

--- a/Templates/Java/requests_generated/IBaseMethodRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodRequest.java.tt
@@ -18,15 +18,15 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     void post(final ICallback<<#=ReturnType(c)#>> callback);
 
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     <#=ReturnType(c)#> post() throws ClientException;
 
@@ -36,8 +36,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> select(final String value);
 
@@ -49,8 +49,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> expand(final String value);
 
@@ -64,8 +64,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> top(final int value);
 <#
@@ -75,14 +75,14 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     void post(final ICallback<Void> callback);
 
     /**
      * Creates the <#=TypeName(c)#>
      *
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     void post() throws ClientException;
 
@@ -95,34 +95,34 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Patches the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> with which to PATCH
-     * @param callback The callback to be called after success or failure
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> with which to PATCH
+     * @param callback the callback to be called after success or failure
      */
     void patch(<#=ReturnType(c)#> src<#=ReturnType(c)#>, final ICallback<<#=ReturnType(c)#>> callback);
 
     /**
      * Patches the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> with which to PATCH
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> with which to PATCH
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     <#=ReturnType(c)#> patch(<#=ReturnType(c)#> src<#=ReturnType(c)#>) throws ClientException;
 
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> to PUT
-     * @param callback The callback to be called after success or failure
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> to PUT
+     * @param callback the callback to be called after success or failure
      */
     void put(<#=ReturnType(c)#> src<#=ReturnType(c)#>, final ICallback<<#=ReturnType(c)#>> callback);
 
     /**
      * Puts the <#=TypeName(c)#>
      *
-     * @param src<#=ReturnType(c)#> The <#=ReturnType(c)#> to PUT
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent
+     * @param src<#=ReturnType(c)#> the <#=ReturnType(c)#> to PUT
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
      <#=ReturnType(c)#> put(<#=ReturnType(c)#> src<#=ReturnType(c)#>) throws ClientException;
 <#
@@ -130,15 +130,16 @@ if (c.AsOdcmMethod().IsAction()) {
 #>
     /**
      * Gets the <#=ReturnType(c)#>
-     * @param callback The callback to be called after success or failure.
+     *
+     * @param callback the callback to be called after success or failure
      */
     void get(final ICallback<<#=ReturnType(c)#>> callback);
 
     /**
      * Gets the <#=ReturnType(c)#>
      *
-     * @return The <#=ReturnType(c)#>
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the <#=ReturnType(c)#>
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     <#=ReturnType(c)#> get() throws ClientException;
 
@@ -148,8 +149,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the select clause for the request
      *
-     * @param value The select clause
-     * @return The updated request
+     * @param value the select clause
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> select(final String value);
 
@@ -160,8 +161,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the expand clause for the request
      *
-     * @param value The expand clause
-     * @return The updated request
+     * @param value the expand clause
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> expand(final String value);
 
@@ -175,8 +176,8 @@ if (c.AsOdcmMethod().IsAction()) {
     /**
      * Sets the top value for the request
      *
-     * @param value The max number of items to return
-     * @return The updated request
+     * @param value the max number of items to return
+     * @return the updated request
      */
     <#=ITypeRequest(c)#> top(final int value);
 <#

--- a/Templates/Java/requests_generated/IBaseMethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodRequestBuilder.java.tt
@@ -11,7 +11,7 @@
     /**
      * Creates the <#=ITypeRequest(c)#>
      *
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest();
 
@@ -19,7 +19,7 @@
      * Creates the <#=ITypeRequest(c)#> with specific options instead of the existing options
      *
      * @param requestOptions the options for the request
-     * @return The <#=ITypeRequest(c)#> instance
+     * @return the <#=ITypeRequest(c)#> instance
      */
     <#=ITypeRequest(c)#> buildRequest(final java.util.List<? extends Option> requestOptions);
 }

--- a/Templates/Java/requests_generated/IBaseStreamRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseStreamRequest.java.tt
@@ -13,32 +13,32 @@ import java.io.*;
     /**
      * Gets the contents of this stream
      *
-     * @param callback The callback to be called after success or failure.
+     * @param callback the callback to be called after success or failure
      */
     void get(final ICallback<InputStream> callback);
 
     /**
      * Gets the contents of this stream
      *
-     * @return The stream that the caller needs to close.
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @return the stream that the caller needs to close
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     InputStream get() throws ClientException;
 
     /**
      * Uploads to the stream
      *
-     * @param fileContents The contents of the stream to upload.
-     * @param callback The callback to be called after success or failure.
+     * @param fileContents the contents of the stream to upload
+     * @param callback the callback to be called after success or failure
      */
     void put(final byte[] fileContents, final ICallback<<#=ClassTypeName(c)#>> callback);
 
     /**
      * Uploads to the stream
      *
-     * @param fileContents The contents of the stream to upload.
-     * @return The result of the upload.
-     * @throws ClientException An exception occurs if there was an error while the request was sent.
+     * @param fileContents the contents of the stream to upload
+     * @return the result of the upload
+     * @throws ClientException an exception occurs if there was an error while the request was sent
      */
     <#=ClassTypeName(c)#> put(final byte[] fileContents) throws ClientException;
 }


### PR DESCRIPTION
- [7bc879f](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/7bc879f70b4d2877fdc5b9945b5a3c8ad62f3596): Add Javadoc where it was missing, mostly for @param and @return on buildRequest()
- [7c7b079](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/7c7b079d88b0f5ee7848512113cff0aac6cd1666): Add @param programmatically for action parameters
- [3cc433e](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/3cc433e844d0e3164c6246bc3e6880644e58e44a): Replace invalid characters with HTML equivalent. We will need to do this later for .NET as well. The HTML is escaped in the XML metadata, but gets translated back to encoded characters during the template writing process.
