### PR TITLE
Acute fixes for RequestObject bugs

### DIFF
--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -73,6 +73,11 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
         var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
         var propertyType = this.GetPropertyTypeName(odcmProperty);
 
+		if (propertyType.EndsWith("Request"))
+		{
+			propertyType = String.Concat(propertyType, "Object");
+		}
+
         var templateWriterHost = (CustomT4Host)Host;
         var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 

--- a/Templates/CSharp/Base/EntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequest.Base.template.tt
@@ -70,6 +70,11 @@ public string GetDeleteAsyncMethod(string deleteTargetString, string deleteTarge
 {
     var stringBuilder = new StringBuilder();
 
+	if (deleteTargetType.EndsWith("Request"))
+	{
+		deleteTargetType = String.Concat(deleteTargetType, "Object");
+	}
+
     this.AppendDeleteAsyncHeader(deleteTargetString, stringBuilder, false);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        public System.Threading.Tasks.Task DeleteAsync()");

--- a/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -51,6 +51,11 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty)
         var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
         var propertyType = this.GetPropertyTypeName(odcmProperty);
 
+		if (propertyType.EndsWith("Request"))
+		{
+			propertyType = String.Concat(propertyType, "Object");
+		}
+
         var templateWriterHost = (CustomT4Host)Host;
         var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 

--- a/Templates/CSharp/Requests/EntityCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionPage.cs.tt
@@ -8,7 +8,10 @@ var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity is OdcmPrimitiveType ? innerEntity.GetTypeString() : innerEntity.Name.ToCheckedCase();
 var entityCollectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionRequest");
 var entityCollectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionPage");
-
+if (innerEntityType.EndsWith("Request"))
+	{
+		innerEntityType = String.Concat(innerEntityType, "Object");
+	}
 #>
 
 namespace <#=prop.Class.AsOdcmClass().Namespace.GetNamespaceName()#>

--- a/Templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -5,6 +5,10 @@
 var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity.Name.ToCheckedCase();
+if (innerEntityType.EndsWith("Request"))
+{
+	innerEntityType = String.Concat(innerEntityType, "Object");
+}
 var collectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionRequest");
 var collectionResponse = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionResponse");
 var collectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionPage");

--- a/Templates/CSharp/Requests/IEntityCollectionPage.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionPage.cs.tt
@@ -6,6 +6,11 @@
 var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity is OdcmPrimitiveType ? innerEntity.GetTypeString() : innerEntity.Name.ToCheckedCase();
+if (innerEntityType.EndsWith("Request"))
+	{
+		innerEntityType = String.Concat(innerEntityType, "Object");
+	}
+
 var entityCollectionRequest = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionRequest");
 var entityCollectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionPage");
 

--- a/Templates/CSharp/Requests/IEntityCollectionRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityCollectionRequest.cs.tt
@@ -5,6 +5,11 @@
 var prop = host.CurrentType.AsOdcmProperty();
 var innerEntity = prop.Projection.Type;
 var innerEntityType = innerEntity.Name.ToCheckedCase();
+if (innerEntityType.EndsWith("Request"))
+{
+	innerEntityType = String.Concat(innerEntityType, "Object");
+}
+
 var collectionRequest = this.GetPropertyCollectionRequestName(prop);
 var collectionResponse = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionResponse");
 var collectionPage = string.Concat(prop.Class.Name.ToCheckedCase(), prop.Name.ToCheckedCase(), "CollectionPage");

--- a/Templates/CSharp/Requests/IStreamRequest.cs.tt
+++ b/Templates/CSharp/Requests/IStreamRequest.cs.tt
@@ -26,6 +26,11 @@ else
     propRequest = propClass + prop.Name.ToCheckedCase() + "Request";
     namespaceValue = prop.Class.AsOdcmClass().Namespace.GetNamespaceName();
 }
+
+	if (propClass.EndsWith("Request"))
+	{
+		propClass = String.Concat(propClass, "Object");
+	}
 #>
 
 namespace <#=namespaceValue#>

--- a/Templates/CSharp/Requests/StreamRequest.cs.tt
+++ b/Templates/CSharp/Requests/StreamRequest.cs.tt
@@ -23,9 +23,14 @@ else
 {
     propName = prop.Name;
     propClass = prop.Class.Name.ToCheckedCase();
+
     propRequest = propClass + prop.Name.ToCheckedCase() + "Request";
     namespaceValue = prop.Class.AsOdcmClass().Namespace.GetNamespaceName();
 }
+	if (propClass.EndsWith("Request"))
+	{
+		propClass = String.Concat(propClass, "Object");
+	}
 #>
 
 namespace <#=namespaceValue#>

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -216,6 +216,11 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             return GetSanitizedPropertyName(property.Name);
         }
 
+        public static string GetSanitizedClassName(this OdcmClass odcmClass)
+        {
+            return GetSanitizedClassName(odcmClass.Name, odcmClass);
+        }
+
         public static string GetSanitizedPropertyName(this string property, string prefix = null)
         {
             return GetSanitizedPropertyName(property, null, prefix);
@@ -260,6 +265,16 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             }
 
             return property;
+        }
+
+        public static string GetSanitizedClassName(this string className, OdcmClass odcmClass)
+        {
+            var entityName = className.ToCheckedCase();
+            if (entityName.EndsWith("Request"))
+            {
+                entityName = String.Concat(entityName, "Object");
+            }
+            return entityName;
         }
 
         public static string GetSanitizedParameterName(this string parameter, string prefix = null)


### PR DESCRIPTION
In beta, there are two new "XYRequest" EntityType objects that require us to append "-Object" to the end (`fileClassificationRequest` and `textClassificationRequest`). These hit new scenarios in the templates that weren't previously checked, so this commit adds the appropriate checks in several more places.

There are probably other places in the templates where we are missing checks for `EndsWith("Request")` but it is a difficult piece to search for since the variable is not always consistently named. The best alternative would be to refactor this logic out of the individual templates.