### PR TITLE
Intellisense fixes for .NET

### DIFF
--- a/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -90,6 +90,8 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 
     var stringBuilder = new StringBuilder();
 
+	stringBuilder.Append(Environment.NewLine);
+	this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        System.Threading.Tasks.Task AddAsync({0} {1});", propertyType, sanitizedPropertyName);
 

--- a/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -91,9 +91,6 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
-    stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        System.Threading.Tasks.Task AddAsync({0} {1});", propertyType, sanitizedPropertyName);
 
     stringBuilder.Append(Environment.NewLine);
@@ -101,6 +98,8 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 
     this.AppendMethodHeaderToPostAsyncMethod(propertyType, sanitizedPropertyName, stringBuilder);
     stringBuilder.Append(Environment.NewLine);
+	stringBuilder.Append("        /// <param name=\"cancellationToken\">The <see cref=\"CancellationToken\"/> for the request.</param>");
+	stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("        System.Threading.Tasks.Task AddAsync({0} {1}, CancellationToken cancellationToken);", propertyType, sanitizedPropertyName);
 
     return stringBuilder.ToString();

--- a/Templates/CSharp/Base/IEntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequest.Base.template.tt
@@ -159,7 +159,8 @@ public void AppendPutAsyncMethodHeader(string putTargetString, StringBuilder str
     stringBuilder.AppendFormat("        /// Puts the specified {0}.", putTargetString);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        /// </summary>");
-
+	stringBuilder.Append(Environment.NewLine);
+	stringBuilder.AppendFormat("        /// <param name=\"id\">The {0} reference to update.</param>", putTargetString);
     if (includeSendParams)
     {
         stringBuilder.Append(Environment.NewLine);

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -61,7 +61,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name#>.
 <# if (property.LongDescription != null) {
 #>
-        /// <#=property.LongDescription#>
+        /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
         /// </summary>
         <#=attributeDefinition#>
@@ -76,7 +76,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name#>.
 <# if (property.LongDescription != null) {
 #>
-        /// <#=property.LongDescription#>
+        /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
         /// </summary>
         <#=attributeDefinition#>

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -57,6 +57,9 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         {
     #>
 
+		///<summary>
+		/// The internal <#=entityName#> constructor
+		///</summary>
         protected internal <#=entityName#>()
         {
             // Don't allow initialization of abstract entity types

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -88,7 +88,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
 <# if (property.LongDescription != null) {
 #>
-        /// <#=property.LongDescription#>
+        /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
         /// </summary>
         <#=attributeDefinition#>
@@ -103,7 +103,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
 <# if (property.LongDescription != null) {
 #>
-        /// <#=property.LongDescription#>
+        /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
         /// </summary>
         <#=attributeDefinition#>
@@ -119,7 +119,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
 <# if (property.LongDescription != null) {
 #>
-        /// <#=property.LongDescription#>
+        /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
         /// </summary>
         <#=attributeDefinition#>

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -211,6 +211,15 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             return property.Name.ToLowerFirstChar();
         }
 
+        public static string GetSanitizedLongDescription(this OdcmProperty property)
+        {
+            if (property.LongDescription != null)
+            {
+                return property.LongDescription.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+            }
+            return null;
+        }
+
         public static string GetSanitizedPropertyName(this OdcmProperty property)
         {
             return GetSanitizedPropertyName(property.Name);


### PR DESCRIPTION
Intellisense fixes to match https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/255

[0af305a](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/0af305a889790d3e48d647891bab904f41a826e8) - Added a long description sanitizer similar to Java that replaces invalid Intellisense characters with HTML equivalents

[d287f57](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/commit/d287f57cc89a9bb41b89589d1895931b37869f78) - Cancellation token comment was being generated randomly at the top of the document instead of in line with the rest of the method comment