### PR TITLE
Add DELETE/POST/PATCH to (I)EntityWithReferenceRequest

### DIFF
--- a/Templates/Android/generated/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Android/generated/BaseEntityWithReferenceRequest.java.tt
@@ -39,6 +39,22 @@
        return send(HttpMethod.GET, null);
     }
 
+	public void delete(final ICallback<<#=TypeName(c)#>> callback) {
+		send(HttpMethod.DELETE, callback, null);
+	}
+
+	public void delete() throws ClientException {
+		send(HttpMethod.DELETE, null);
+	}
+
+	public void patch(final <#=TypeName(c)#> source<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback) {
+		send(HttpMethod.PATCH, callback, source<#=TypeName(c)#>);
+	}
+
+	public <#=TypeName(c)#> patch(final <#=TypeName(c)#> source<#=TypeName(c)#>) throws ClientException {
+		return send(HttpMethod.PATCH, source<#=TypeName(c)#>);
+	}
+
 <# if (c.GetFeatures().CanSelect) { #>
     /**
      * Sets the select clause for the request

--- a/Templates/Android/generated/IBaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Android/generated/IBaseEntityWithReferenceRequest.java.tt
@@ -16,6 +16,14 @@
 
     <#=TypeName(c)#> get() throws ClientException;
 
+	void delete(final ICallback<<#=TypeName(c)#>> callback);
+
+	void delete() throws ClientException;
+
+	void patch(final <#=TypeName(c)#> source<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback);
+
+	<#=TypeName(c)#> patch(final <#=TypeName(c)#> source<#=TypeName(c)#>) throws ClientException;
+
 <# if (c.GetFeatures().CanSelect) { #>
     <#=IBaseTypeWithReferencesRequest(c)#> select(final String value);
 

--- a/Templates/CSharp/Base/EntityRequest.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequest.Base.template.tt
@@ -196,7 +196,7 @@ public void AppendCreateAsyncHeader(string entityName, string lowerCaseEntityNam
     stringBuilder.AppendFormat("        /// <returns>The created {0}.</returns>", entityName);
 }
 
-public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
+public string GetEntityCreateAsyncMethod(OdcmClass odcmClass, bool initializeCollectionProperties = true)
 {
     var stringBuilder = new StringBuilder();
 
@@ -238,10 +238,14 @@ public string GetEntityCreateAsyncMethod(OdcmClass odcmClass)
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("            var newEntity = await this.SendAsync<{0}>({1}ToCreate, cancellationToken).ConfigureAwait(false);", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append(
-@"            this.InitializeCollectionProperties(newEntity);
-            return newEntity;
+	if (initializeCollectionProperties) {
+		stringBuilder.Append(
+	@"            this.InitializeCollectionProperties(newEntity);");
+		stringBuilder.Append(Environment.NewLine);
+	}
+	stringBuilder.Append(@"            return newEntity;
         }");
+	
 
     return stringBuilder.ToString();
 }
@@ -352,7 +356,7 @@ public void AppendUpdateAsyncHeader(string entityName, string lowerCaseEntityNam
     stringBuilder.AppendFormat("        /// <returns>The updated {0}.</returns>", entityName);
 }
 
-public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
+public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass, bool initializeCollectionProperties = true)
 {
     var stringBuilder = new StringBuilder();
 
@@ -393,9 +397,12 @@ public string GetEntityUpdateAsyncMethod(OdcmClass odcmClass)
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.AppendFormat("            var updatedEntity = await this.SendAsync<{0}>({1}ToUpdate, cancellationToken).ConfigureAwait(false);", entityName, lowerCaseEntityName);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append(
-@"            this.InitializeCollectionProperties(updatedEntity);
-            return updatedEntity;
+	if (initializeCollectionProperties) {
+		stringBuilder.Append(
+	@"            this.InitializeCollectionProperties(updatedEntity);");
+	stringBuilder.Append(Environment.NewLine);
+	}
+	stringBuilder.Append(@"            return updatedEntity;
         }");
 
     return stringBuilder.ToString();

--- a/Templates/CSharp/Requests/EntityWithReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/EntityWithReferenceRequest.cs.tt
@@ -25,6 +25,12 @@ namespace <#=this.GetNamespaceName(entity)#>
 
         <#=this.GetEntityGetAsyncMethod(entity, false)#>
 
+		<#=this.GetEntityCreateAsyncMethod(entity, false)#>
+
+		<#=this.GetEntityUpdateAsyncMethod(entity, false)#>
+
+		<#=this.GetEntityDeleteAsyncMethod(entity)#>
+
 <#
     if (features.CanExpand)
     {

--- a/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
@@ -19,7 +19,13 @@ namespace <#=this.GetNamespaceName(entity)#>
 
     <#=this.GetEntityWithReferenceRequestInterfaceDefinition(entity)#>
     {
-        <#=this.GetEntityGetAsyncMethod(entity)#>
+        <#=this.GetEntityGetAsyncMethod(entity, false)#>
+
+		<#=this.GetEntityCreateAsyncMethod(entity, false)#>
+
+		<#=this.GetEntityUpdateAsyncMethod(entity, false)#>
+
+		<#=this.GetEntityDeleteAsyncMethod(entity)#>
 
 <#
     if (features.CanExpand)

--- a/Templates/Java/requests_generated/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityWithReferenceRequest.java.tt
@@ -39,6 +39,23 @@
        return send(HttpMethod.GET, null);
     }
 
+	public void delete(final ICallback<<#=TypeName(c)#>> callback) {
+		send(HttpMethod.DELETE, callback, null);
+	}
+
+	public void delete() throws ClientException {
+		send(HttpMethod.DELETE, null);
+	}
+
+	public void patch(final <#=TypeName(c)#> source<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback) {
+		send(HttpMethod.PATCH, callback, source<#=TypeName(c)#>);
+	}
+
+	public <#=TypeName(c)#> patch(final <#=TypeName(c)#> source<#=TypeName(c)#>) throws ClientException {
+		return send(HttpMethod.PATCH, source<#=TypeName(c)#>);
+	}
+
+
 <# if (c.GetFeatures().CanSelect) { #>
     /**
      * Sets the select clause for the request

--- a/Templates/Java/requests_generated/IBaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityWithReferenceRequest.java.tt
@@ -16,6 +16,14 @@
 
     <#=TypeName(c)#> get() throws ClientException;
 
+	void delete(final ICallback<<#=TypeName(c)#>> callback);
+
+	void delete() throws ClientException;
+
+	void patch(final <#=TypeName(c)#> source<#=TypeName(c)#>, final ICallback<<#=TypeName(c)#>> callback);
+
+	<#=TypeName(c)#> patch(final <#=TypeName(c)#> source<#=TypeName(c)#>) throws ClientException;
+
 <# if (c.GetFeatures().CanSelect) { #>
     <#=IBaseTypeWithReferencesRequest(c)#> select(final String value);
 


### PR DESCRIPTION
For C#/Java/Android, the libraries are missing delete, post, and/or patch.

Some scenarios allow users to delete/update references to items (these all seem to be on the directoryObject item). Two examples are DELETE on group member and DELETE on directory role member.