### PR TITLE
Fix with ref request

### DIFF
--- a/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
+++ b/Templates/CSharp/Requests/IEntityWithReferenceRequest.cs.tt
@@ -19,11 +19,11 @@ namespace <#=this.GetNamespaceName(entity)#>
 
     <#=this.GetEntityWithReferenceRequestInterfaceDefinition(entity)#>
     {
-        <#=this.GetEntityGetAsyncMethod(entity, false)#>
+        <#=this.GetEntityGetAsyncMethod(entity)#>
 
-		<#=this.GetEntityCreateAsyncMethod(entity, false)#>
+		<#=this.GetEntityCreateAsyncMethod(entity)#>
 
-		<#=this.GetEntityUpdateAsyncMethod(entity, false)#>
+		<#=this.GetEntityUpdateAsyncMethod(entity)#>
 
 		<#=this.GetEntityDeleteAsyncMethod(entity)#>
 

--- a/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
+++ b/src/GraphODataTemplateWriter/.config/TemplateWriterSettings.json
@@ -1,30 +1,76 @@
 {
-    "AvailableLanguages": [ "Android", "Java", "ObjC", "CSharp", "PHP", "Python", "TypeScript", "GraphEndpointList" ],
-    "TargetLanguage": "CSharp",
-    "Plugins": [ ],
-    "PrimaryNamespaceName": "com",
-    "NamespacePrefix": "com",
-    "InitializeCollections": "false",
-    "AllowShortActions": "false",
-    "NamespaceOverride": "",
-    "TemplatesDirectory": "../../../../Templates",
-    "DefaultFileCasing": "UpperCamel",
-    "CustomFlags": [ "python2" ],
-    "DefaultBaseEndpointUrl":  "https://graph.microsoft.com/v1.0",
-    "LicenseHeader": [
-        "Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information."
-    ],
-    "TemplateMapping": {
-        "Shared": [
-            { "Template": "EntityType", "SubProcessor": "EntityType", "Type": "Model", "Name": "<Class>" },
-            { "Template": "ComplexType", "SubProcessor": "ComplexType", "Type": "Model", "Name": "<Class>", "Ignore": "methodResponse"},
-            { "Template": "EnumType", "SubProcessor": "EnumType", "Type": "Model", "Name": "<Class>" },
-            { "Template": "EntityClient", "SubProcessor": "EntityContainer", "Type": "Client", "Name": "<Container>Client" },
-            { "Template": "EntityRequest", "SubProcessor": "EntityType", "Type": "Request", "Name": "<Class>Request" },
-            { "Template": "EntityRequestBuilder", "SubProcessor": "EntityType", "Type": "Request", "Name": "<Class>RequestBuilder" },
-            { "Template": "StreamRequest", "SubProcessor": "StreamProperty", "Type": "Request", "Name": "<Class><Property>Request" },
-            { "Template": "MethodRequest", "SubProcessor": "Method", "Type": "Request", "Name": "<Class><Method>Request" },
-            { "Template": "MethodRequestBuilder", "SubProcessor": "Method", "Type": "Request", "Name": "<Class><Method>RequestBuilder" }
-        ]
-    }
+  "AvailableLanguages": [ "Android", "Java", "ObjC", "CSharp", "PHP", "Python", "TypeScript", "GraphEndpointList" ],
+  "TargetLanguage": "CSharp",
+  "Plugins": [],
+  "PrimaryNamespaceName": "com",
+  "NamespacePrefix": "com",
+  "InitializeCollections": "false",
+  "AllowShortActions": "false",
+  "NamespaceOverride": "",
+  "TemplatesDirectory": "../../../../Templates",
+  "DefaultFileCasing": "UpperCamel",
+  "CustomFlags": [ "python2" ],
+  "DefaultBaseEndpointUrl": "https://graph.microsoft.com/v1.0",
+  "LicenseHeader": [
+    "Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information."
+  ],
+  "TemplateMapping": {
+    "Shared": [
+      {
+        "Template": "EntityType",
+        "SubProcessor": "EntityType",
+        "Type": "Model",
+        "Name": "<Class>"
+      },
+      {
+        "Template": "ComplexType",
+        "SubProcessor": "ComplexType",
+        "Type": "Model",
+        "Name": "<Class>",
+        "Ignore": "methodResponse"
+      },
+      {
+        "Template": "EnumType",
+        "SubProcessor": "EnumType",
+        "Type": "Model",
+        "Name": "<Class>"
+      },
+      {
+        "Template": "EntityClient",
+        "SubProcessor": "EntityContainer",
+        "Type": "Client",
+        "Name": "<Container>Client"
+      },
+      {
+        "Template": "EntityRequest",
+        "SubProcessor": "EntityType",
+        "Type": "Request",
+        "Name": "<Class>Request"
+      },
+      {
+        "Template": "EntityRequestBuilder",
+        "SubProcessor": "EntityType",
+        "Type": "Request",
+        "Name": "<Class>RequestBuilder"
+      },
+      {
+        "Template": "StreamRequest",
+        "SubProcessor": "StreamProperty",
+        "Type": "Request",
+        "Name": "<Class><Property>Request"
+      },
+      {
+        "Template": "MethodRequest",
+        "SubProcessor": "Method",
+        "Type": "Request",
+        "Name": "<Class><Method>Request"
+      },
+      {
+        "Template": "MethodRequestBuilder",
+        "SubProcessor": "Method",
+        "Type": "Request",
+        "Name": "<Class><Method>RequestBuilder"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes issue introduced with #131 

Was causing the following issue at generation time.
```
11:25:29 Microsoft.Graph.ODataTemplateWriter.TemplateProcessor.TemplateProcessor Error(0): d:\repos\MSGraph-SDK-Code-Generator\Templates\CSharp\Requests\IEntityWithReferenceRequest.cs.tt(22,64) : error CS1501: No overload for method 'GetEntityGetAsyncMethod' takes 2 arguments
11:25:30 Microsoft.Graph.ODataTemplateWriter.TemplateProcessor.TemplateProcessor Error(1): d:\repos\MSGraph-SDK-Code-Generator\Templates\CSharp\Requests\IEntityWithReferenceRequest.cs.tt(24,64) : error CS1501: No overload for method 'GetEntityCreateAsyncMethod' takes 2 arguments
11:25:30 Microsoft.Graph.ODataTemplateWriter.TemplateProcessor.TemplateProcessor Error(2): d:\repos\MSGraph-SDK-Code-Generator\Templates\CSharp\Requests\IEntityWithReferenceRequest.cs.tt(26,64) : error CS1501: No overload for method 'GetEntityUpdateAsyncMethod' takes 2 arguments
11:25:30 VIPR System.InvalidOperationException: Template error.
   at ........
```