### PR TITLE
Fixing templates for java model generated files import statement for …

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -506,6 +506,148 @@
         }
         return "<" + BaseTypeCollectionResponse(c) + ", " + ITypeCollectionPage(c) + ">";
     }
+	
+	public string CreatePackageDefForEnum(CustomT4Host host)
+    {
+		var sb = new StringBuilder();
+		var packageFormat = @"package {0}.{1};";
+		sb.AppendFormat(packageFormat,
+						host.CurrentModel.NamespaceName(),
+						host.TemplateInfo.OutputParentDirectory.Replace("_", "."));
+		sb.Append("\n");
+		return sb.ToString();
+    }
+	
+	public string getPrefixForModels(string propertyName)
+	{
+		if(propertyName.StartsWith("Base"))
+		{
+			if(propertyName == "BaseItem" || propertyName == "BaseItemVersion")
+				return "models.extensions";
+			else
+				return "models.generated";
+		}
+		
+		return "models.extensions";
+	}
+	
+	public string getPrefixForRequests(string propertyName)
+	{
+		if(propertyName == "BaseItemCollectionPage")
+			return "requests.extensions";
+			
+		if(propertyName.StartsWith("Base") || propertyName.StartsWith("IBase"))
+			return "requests.generated";
+	
+		return "requests.extensions";
+	}
+	
+	public string getPackagePrefix(OdcmProperty property)
+	{
+		var propertyType = property.GetTypeString();
+	
+		if(property.Type is OdcmEnum)
+			return "models.generated";
+		
+		return getPrefixForModels(propertyType);	
+	}
+	
+	public string CreatePackageDefForEntity(CustomT4Host host)
+    {
+		IEnumerable<OdcmProperty> properties = ((OdcmClass)host.CurrentType).Properties;
+        var sb = new StringBuilder();
+		var packageFormat = @"package {0}.{1};";
+		sb.AppendFormat(packageFormat,
+						host.CurrentModel.NamespaceName(),
+						host.TemplateInfo.OutputParentDirectory.Replace("_", "."));
+		sb.Append("\n");
+
+		 sb.AppendFormat(@"import {0}.concurrency.*;
+import {0}.core.*;
+import {0}.http.*;
+import {0}.options.*;
+import {0}.serializer.*;
+import java.util.Arrays;
+import java.util.EnumSet;", host.CurrentModel.NamespaceName());
+
+		sb.Append("\n");		
+        var format = @"import {0}.{1}.{2};";
+
+        foreach (var property in properties.Where(p => !p.Projection.Type.Name.Equals("Stream")))
+        { 
+            var propertyType = property.GetTypeString();
+			if(property.Type is OdcmPrimitiveType)
+				continue;
+				
+			if(propertyType == "com.google.gson.JsonElement" || propertyType == "com.google.gson.JsonElement" || propertyType.StartsWith("com.microsoft.graph.models"))
+				continue;
+				
+			if(propertyType.StartsWith("EnumSet"))
+				propertyType = propertyType.Substring("EnumSet<".Length, propertyType.Length-("EnumSet<".Length+1));
+				
+			string prefixValue = getPackagePrefix(property);
+			sb.AppendFormat(format,
+						host.CurrentModel.NamespaceName(),
+						prefixValue,
+						propertyType);
+			sb.Append("\n");
+			
+        }
+
+		string baseClassNameType = BaseClassName(host.CurrentType);
+		if(baseClassNameType != "")
+		{
+			string prefixValue = getPrefixForModels(baseClassNameType);
+			sb.AppendFormat(format,
+						host.CurrentModel.NamespaceName(),
+						prefixValue,
+						baseClassNameType);
+			sb.Append("\n");
+		}
+		
+		string baseTypeNameStr = BaseTypeName(host.CurrentType);
+		if(baseTypeNameStr == "BasePlannerAssignments")
+		{
+			sb.AppendFormat(format,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						 "PlannerAssignment");
+					sb.Append("\n");
+		}
+		if(baseTypeNameStr == "BasePlannerChecklistItems")
+		{
+			sb.AppendFormat(format,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						 "PlannerChecklistItem");
+					sb.Append("\n");
+		}
+		
+		if (properties != null)
+        {
+            foreach (var property in properties.Where(p => p.IsCollection() && p.IsNavigation())) 
+			{
+				var propertyType = BaseTypeCollectionResponse(property);
+				
+				if(property.Type is OdcmPrimitiveType)
+					continue;
+				
+				sb.AppendFormat(format,
+					host.CurrentModel.NamespaceName(),
+					getPrefixForRequests(propertyType),
+					propertyType);
+				sb.Append("\n");
+					
+				string propertyValue = TypeCollectionPage(property);	
+				sb.AppendFormat(format,
+					host.CurrentModel.NamespaceName(),
+					getPrefixForRequests(propertyValue),
+					propertyValue);
+				sb.Append("\n");
+			}
+        }
+        return sb.ToString();
+    }
 
     public string CreatePackageDef(CustomT4Host host)
     {

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -507,6 +507,7 @@
         return "<" + BaseTypeCollectionResponse(c) + ", " + ITypeCollectionPage(c) + ">";
     }
 	
+	//Creating package definition for Enum.java.tt template file
 	public string CreatePackageDefForEnum(CustomT4Host host)
     {
 		var sb = new StringBuilder();
@@ -518,6 +519,7 @@
 		return sb.ToString();
     }
 	
+	//Getting import prefix using property name for model classes
 	public string getPrefixForModels(string propertyName)
 	{
 		if(propertyName.StartsWith("Base"))
@@ -531,6 +533,7 @@
 		return "models.extensions";
 	}
 	
+	//Getting import prefix using property name for Request classes
 	public string getPrefixForRequests(string propertyName)
 	{
 		if(propertyName == "BaseItemCollectionPage")
@@ -542,6 +545,7 @@
 		return "requests.extensions";
 	}
 	
+	//Get package prefix using OdcmProperty for model classes
 	public string getPackagePrefix(OdcmProperty property)
 	{
 		var propertyType = property.GetTypeString();
@@ -552,6 +556,7 @@
 		return getPrefixForModels(propertyType);	
 	}
 	
+	//Fixing package and import statement for model classes
 	public string CreatePackageDefForEntity(CustomT4Host host)
     {
 		IEnumerable<OdcmProperty> properties = ((OdcmClass)host.CurrentType).Properties;
@@ -571,7 +576,7 @@ import java.util.Arrays;
 import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 
 		sb.Append("\n");		
-        var format = @"import {0}.{1}.{2};";
+        var importFormat = @"import {0}.{1}.{2};";
 
         foreach (var property in properties.Where(p => !p.Projection.Type.Name.Equals("Stream")))
         { 
@@ -586,7 +591,7 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 				propertyType = propertyType.Substring("EnumSet<".Length, propertyType.Length-("EnumSet<".Length+1));
 				
 			string prefixValue = getPackagePrefix(property);
-			sb.AppendFormat(format,
+			sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						prefixValue,
 						propertyType);
@@ -598,7 +603,7 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 		if(baseClassNameType != "")
 		{
 			string prefixValue = getPrefixForModels(baseClassNameType);
-			sb.AppendFormat(format,
+			sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						prefixValue,
 						baseClassNameType);
@@ -608,7 +613,7 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 		string baseTypeNameStr = BaseTypeName(host.CurrentType);
 		if(baseTypeNameStr == "BasePlannerAssignments")
 		{
-			sb.AppendFormat(format,
+			sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						"models.extensions",
 						 "PlannerAssignment");
@@ -616,7 +621,7 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 		}
 		if(baseTypeNameStr == "BasePlannerChecklistItems")
 		{
-			sb.AppendFormat(format,
+			sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						"models.extensions",
 						 "PlannerChecklistItem");
@@ -627,19 +632,19 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
         {
             foreach (var property in properties.Where(p => p.IsCollection() && p.IsNavigation())) 
 			{
-				var propertyType = BaseTypeCollectionResponse(property);
-				
 				if(property.Type is OdcmPrimitiveType)
 					continue;
+
+				var propertyType = BaseTypeCollectionResponse(property);
 				
-				sb.AppendFormat(format,
+				sb.AppendFormat(importFormat,
 					host.CurrentModel.NamespaceName(),
 					getPrefixForRequests(propertyType),
 					propertyType);
 				sb.Append("\n");
 					
 				string propertyValue = TypeCollectionPage(property);	
-				sb.AppendFormat(format,
+				sb.AppendFormat(importFormat,
 					host.CurrentModel.NamespaceName(),
 					getPrefixForRequests(propertyValue),
 					propertyValue);

--- a/Templates/Java/models_generated/BaseEntity.java.tt
+++ b/Templates/Java/models_generated/BaseEntity.java.tt
@@ -3,7 +3,7 @@
 <#@ include file="BaseJavaModel.template.tt"#>
 <#@ output extension="\\" #>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForEntity(host)#>
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;

--- a/Templates/Java/models_generated/Enum.java.tt
+++ b/Templates/Java/models_generated/Enum.java.tt
@@ -3,7 +3,7 @@
 <#@ include file="BaseJavaModel.template.tt"#>
 <#@ output extension="\\" #>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForEnum(host)#>
 
 /**
  * The Enum <#=c.Name.ToUpperFirstChar().SplitCamelCase()#>.


### PR DESCRIPTION
…models related files.

This is an initial change to fix imports for java files. (Formatting appearing in visual studio and in github change looks a bit different)
These changes in templates only fixes the import statements and doesn't change any other content of the java files.

Testing steps:
1. Generated models and requests files using generator code.
2. Copied over models-generated and requests-generated completely to java sdk corresponding directory
3. Copied over new models-extensions and requests-extensions file to java sdk corresponding locations
4. Built java sdk with success