### PR TITLE
Fixing BaseMethodBody java template files to use import statements co…

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -555,7 +555,18 @@
 		
 		return getPrefixForModels(propertyType);	
 	}
-	
+
+	public string CreatePackageDefinition(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		var packageFormat = @"package {0}.{1};";
+		sb.AppendFormat(packageFormat,
+						host.CurrentModel.NamespaceName(),
+						host.TemplateInfo.OutputParentDirectory.Replace("_", "."));
+		sb.Append("\n");
+		return sb.ToString();
+	}
+
 	//Fixing package and import statement for model classes
 	public string CreatePackageDefForEntity(CustomT4Host host)
     {

--- a/Templates/Java/models_generated/BaseMethodBody.java.tt
+++ b/Templates/Java/models_generated/BaseMethodBody.java.tt
@@ -4,10 +4,13 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeBody(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefinition(host)#>
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.JsonObject;
-import com.google.gson.annotations.*;
+import com.microsoft.graph.serializer.ISerializer;
+import com.microsoft.graph.models.extensions.*;
 
 <#=CreateClassDef(BaseTypeBody(c))#>
 


### PR DESCRIPTION
…rrectly

This is part of the effort to reduce memory footprint for java sdk. As per the findings, generic import statements are contributing to large memory usage. This template generates ~450 files. With this fix, these 450 files will start having optimized import statements, resulting in lesser memory footprint.