### PR TITLE
Java template fix to reduce memory footprint - continued

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -567,6 +567,58 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForBaseMethodBodyRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						TypeBody(host.CurrentType));
+		sb.Append("\n");
+		var returnType = ReturnType(host.CurrentType);
+		if(returnType != "Void" && !(host.CurrentType.AsOdcmMethod().ReturnType is OdcmPrimitiveType))
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						ReturnType(host.CurrentType));
+			sb.Append("\n");
+		}
+
+		if(host.CurrentType.AsOdcmMethod().IsCollection)
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequest(host.CurrentType));
+			sb.Append("\n");
+
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeCollectionRequest(host.CurrentType));
+			sb.Append("\n");
+		}
+		else
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+			sb.Append("\n");
+
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequest(host.CurrentType));
+			sb.Append("\n");
+		}
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefIBaseMethodRequestBuilder(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -567,6 +567,40 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForIBaseMethodBodyRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		var returnType = ReturnType(host.CurrentType);
+		if(returnType != "Void" && !(host.CurrentType.AsOdcmMethod().ReturnType is OdcmPrimitiveType))
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						ReturnType(host.CurrentType));
+			sb.Append("\n");
+		}
+		if(host.CurrentType.AsOdcmMethod().IsCollection)
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequest(host.CurrentType));
+			sb.Append("\n");
+		}
+		else
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+			sb.Append("\n");
+		}
+
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefForBaseMethodBodyRequest(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/requests_generated/BaseMethodBodyRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodBodyRequest.java.tt
@@ -21,7 +21,26 @@
 #>
 <#host.TemplateName = baseTypeRequest;#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForBaseMethodBodyRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.QueryOption;
+<#
+	if (c.AsOdcmMethod().IsCollection) {
+#>
+import com.microsoft.graph.concurrency.IExecutors;
+import com.microsoft.graph.http.BaseCollectionRequest;
+<#
+	}
+	else {
+#>
+import com.microsoft.graph.http.BaseRequest;
+import com.microsoft.graph.http.HttpMethod;
+<#
+	}
+#>
 
 <#=CreateClassDef(baseTypeRequest, baseClass, iBaseTypeRequest)#>
     protected final <#=TypeBody(c)#> body;

--- a/Templates/Java/requests_generated/IBaseMethodBodyRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodBodyRequest.java.tt
@@ -21,10 +21,9 @@
 #>
 <#host.TemplateName = iBaseTypeRequest;#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
-
-import com.google.gson.JsonObject;
-import com.google.gson.annotations.*;
+<#=CreatePackageDefForIBaseMethodBodyRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
 
 <#=CreateInterfaceDef(iBaseTypeRequest)#>
 


### PR DESCRIPTION
Fixing import statements for BaseMethodBodyRequest template
Fixing import statements for IBaseMethodBodyRequest template
Together these templates impact ~800 files and these files will start getting optimized import statements with this fix.
Testing:
After generating files using these templates, java sdk has started building with 3GB RAM.