### PR TITLE
Java template fix to reduce memory footprint - continued

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -556,6 +556,17 @@
 		return getPrefixForModels(propertyType);	
 	}
 
+	//Get package prefix using OdcmProperty for model classes
+	public string getPackagePrefix(OdcmParameter property)
+	{
+		var propertyType = property.GetTypeString();
+	
+		if(property.Type is OdcmEnum)
+			return "models.generated";
+		
+		return getPrefixForModels(propertyType);	
+	}
+
 	public string CreatePackageDefinition(CustomT4Host host)
 	{
 		var sb = new StringBuilder();
@@ -577,6 +588,38 @@
 						"models.extensions",
 						TypeName(host.CurrentType));
 		sb.Append("\n");
+		return sb.ToString();
+	}
+
+	public string CreatePackageDefForBaseMethodRequestBuilder(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequest(host.CurrentType));
+		sb.Append("\n");
+
+		foreach (var method in host.CurrentType.AsOdcmMethod().WithOverloads()) {
+			foreach (var p in method.Parameters)
+			{
+				if(!(p.Type is OdcmPrimitiveType) && p.Type.GetTypeString() != "com.google.gson.JsonElement") {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						getPackagePrefix(p),
+						p.Type.GetTypeString());
+					sb.Append("\n");
+				}
+			}
+		}
 		return sb.ToString();
 	}
 

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -567,6 +567,19 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForBaseEntityCollectionResponse(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						TypeName(host.CurrentType));
+		sb.Append("\n");
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefForIBaseMethodBodyRequest(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/requests_generated/BaseEntityCollectionResponse.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityCollectionResponse.java.tt
@@ -4,11 +4,14 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeCollectionResponse(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
-
+<#=CreatePackageDefForBaseEntityCollectionResponse(host)#>
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.annotations.*;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import com.microsoft.graph.serializer.AdditionalDataManager;
+import com.microsoft.graph.serializer.IJsonBackedObject;
+import com.microsoft.graph.serializer.ISerializer;
 
 <#=CreateClassDef(BaseTypeCollectionResponse(c), null, "IJsonBackedObject")#>
 

--- a/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodRequestBuilder.java.tt
@@ -4,7 +4,14 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeRequestBuilder(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForBaseMethodRequestBuilder(host)#>
+import com.microsoft.graph.core.BaseActionRequestBuilder;
+import com.microsoft.graph.core.BaseFunctionRequestBuilder;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.FunctionOption;
+import com.google.gson.JsonElement;
+
 <# bool isAction = !c.AsOdcmMethod().IsFunction; #>
 <#=CreateClassDef(BaseTypeRequestBuilder(c),  RequestBuilderSuperClass(c))#>
 


### PR DESCRIPTION
Fixing import statements for BaseMethodRequestBuilder template
Fixing import statements for BaseEntityCollectionResponse template
Together these templates impact ~600 files and these files will start getting optimized import statements with this fix.
Testing:
After generating files using these templates, java sdk has started building with 2.5GB RAM.