### PR TITLE
Java template fix to reduce memory footprint - continued

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -591,6 +591,36 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForBaseMethodRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+
+		var returnType = ReturnType(host.CurrentType);
+		if(returnType != "Void" && !(host.CurrentType.AsOdcmMethod().ReturnType is OdcmPrimitiveType))
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						ReturnType(host.CurrentType));
+			sb.Append("\n");
+		}
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequest(host.CurrentType));
+		sb.Append("\n");
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefForBaseMethodRequestBuilder(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -615,6 +615,19 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForIBaseEntityRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						TypeName(host.CurrentType.AsOdcmClass()));
+		sb.Append("\n");
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefForBaseMethodRequest(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -591,6 +591,30 @@
 		return sb.ToString();
 	}
 
+	public string CreatePackageDefForIBaseMethodRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+
+		var returnType = ReturnType(host.CurrentType);
+		if(returnType != "Void" && !(host.CurrentType.AsOdcmMethod().ReturnType is OdcmPrimitiveType))
+		{
+			sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						ReturnType(host.CurrentType));
+			sb.Append("\n");
+		}
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+		return sb.ToString();
+	}
+
 	public string CreatePackageDefForBaseMethodRequest(CustomT4Host host)
 	{
 		var sb = new StringBuilder();

--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -618,25 +618,8 @@
 	public string CreatePackageDefForBaseMethodRequest(CustomT4Host host)
 	{
 		var sb = new StringBuilder();
-		sb.Append(CreatePackageDefinition(host));
+		sb.Append(CreatePackageDefForIBaseMethodRequest(host));
 		var importFormat = @"import {0}.{1}.{2};";
-
-		var returnType = ReturnType(host.CurrentType);
-		if(returnType != "Void" && !(host.CurrentType.AsOdcmMethod().ReturnType is OdcmPrimitiveType))
-		{
-			sb.AppendFormat(importFormat,
-						host.CurrentModel.NamespaceName(),
-						"models.extensions",
-						ReturnType(host.CurrentType));
-			sb.Append("\n");
-		}
-
-		sb.AppendFormat(importFormat,
-						host.CurrentModel.NamespaceName(),
-						"requests.extensions",
-						ITypeRequest(host.CurrentType));
-		sb.Append("\n");
-
 		sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						"requests.extensions",

--- a/Templates/Java/requests_generated/BaseMethodRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodRequest.java.tt
@@ -4,7 +4,15 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeRequest(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForBaseMethodRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.concurrency.IExecutors;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.http.BaseRequest;
+import com.microsoft.graph.http.HttpMethod;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.QueryOption;
 
 <#=CreateClassDef(BaseTypeRequest(c), "BaseRequest", IBaseTypeRequest(c))#>
 

--- a/Templates/Java/requests_generated/IBaseEntityRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityRequest.java.tt
@@ -4,7 +4,10 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = IBaseTypeRequest(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForIBaseEntityRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.http.IHttpRequest;
 
 <#=CreateInterfaceDef(IBaseTypeRequest(c), "IHttpRequest")#>
 

--- a/Templates/Java/requests_generated/IBaseMethodRequest.java.tt
+++ b/Templates/Java/requests_generated/IBaseMethodRequest.java.tt
@@ -4,10 +4,15 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = IBaseTypeRequest(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
-
-import com.google.gson.JsonObject;
-import com.google.gson.annotations.*;
+<#=CreatePackageDefForIBaseMethodRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.concurrency.IExecutors;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.http.BaseRequest;
+import com.microsoft.graph.http.HttpMethod;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.QueryOption;
 
 <#=CreateInterfaceDef(IBaseTypeRequest(c))#>
 


### PR DESCRIPTION
Fixing import statements for IBaseEntityRequest template
Fixing import statements for IBaseMethodRequest template
Fixing import statements for BaseMethodRequest template
Together these templates impact ~1400 files and these files will start getting optimized import statements with this fix.
Testing:
After generating files using these templates, java sdk has started building with 2GB RAM.