### PR TITLE
Java template fix to reduce memory footprint - continued

### DIFF
--- a/Templates/Java/requests_generated/BaseEntityRequest.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityRequest.java.tt
@@ -4,7 +4,14 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeRequest(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForBaseEntityRequest(host)#>
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.http.BaseRequest;
+import com.microsoft.graph.http.HttpMethod;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.QueryOption;
 <#
 String classDeclaration = "";
 if (c.AsOdcmClass().Derived.Any() && c.AsOdcmClass().Base != null)
@@ -209,4 +216,29 @@ classDeclaration += TypeName(c);
 ";
         return string.Format(formatString, TypeName(odcmObject));
     }
+
+	public string CreatePackageDefForBaseEntityRequest(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequest(host.CurrentType));
+		sb.Append("\n");
+
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"models.extensions",
+						TypeName(host.CurrentType.AsOdcmClass()));
+		sb.Append("\n");
+		return sb.ToString();
+	}
  #>

--- a/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseEntityRequestBuilder.java.tt
@@ -4,7 +4,10 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = BaseTypeRequestBuilder(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForBaseEntityRequestBuilder(host)#>
+import com.microsoft.graph.core.IBaseClient;
+import com.microsoft.graph.http.BaseRequestBuilder;
+import com.microsoft.graph.options.Option;
 
 <#=CreateClassDef(BaseTypeRequestBuilder(c), "BaseRequestBuilder", IBaseTypeRequestBuilder(c))#>
 
@@ -133,3 +136,130 @@ if (c.AsOdcmClass() != null)
 }
 #>
 }
+
+<#+
+	public string CreatePackageDefForBaseEntityRequestBuilder(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequest(host.CurrentType));
+		sb.Append("\n");
+		var c = host.CurrentType;
+		if (c.AsOdcmClass() != null)
+		{
+			foreach(var prop in c.AsOdcmClass().NavigationProperties())
+			{
+				if (prop.IsCollection()) {
+					
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequestBuilder(prop));
+					sb.Append("\n");
+
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeCollectionRequestBuilder(prop));
+					sb.Append("\n");
+				}
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequestBuilder(prop));
+				sb.Append("\n");
+
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequestBuilder(prop));
+				sb.Append("\n");
+			}
+
+			foreach (var prop in c.AsOdcmClass().GetProperties(typeName:"Stream"))
+			{
+				var propRequestBuilder = TypeRequestBuilder(prop);
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						"I" + propRequestBuilder);
+				sb.Append("\n");
+
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						propRequestBuilder);
+				sb.Append("\n");
+			}
+
+			if (c is OdcmMediaClass)
+			{
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeStreamRequestBuilder(host.CurrentType));
+				sb.Append("\n");
+
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeStreamRequestBuilder(host.CurrentType));
+				sb.Append("\n");
+			}
+
+			foreach (var method in c.AsOdcmClass().MethodsAndOverloads()) {
+				if (method.IsBoundToCollection) {
+					continue;
+				}
+
+				foreach (var p in method.Parameters)
+				{
+					if(!(p.Type is OdcmPrimitiveType) && p.Type.GetTypeString() != "com.google.gson.JsonElement") {
+						sb.AppendFormat(importFormat,
+							host.CurrentModel.NamespaceName(),
+							getPackagePrefix(p),
+							p.Type.GetTypeString());
+						sb.Append("\n");
+					}
+				}
+
+				if (method.IsCollection) {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequestBuilder(method));
+					sb.Append("\n");
+
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeCollectionRequestBuilder(method));
+					sb.Append("\n");
+				} else {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequestBuilder(method));
+					sb.Append("\n");
+
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						TypeRequestBuilder(method));
+					sb.Append("\n");
+				}
+			}
+		}
+		return sb.ToString();
+	}
+#>

--- a/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/IBaseEntityRequestBuilder.java.tt
@@ -4,7 +4,9 @@
 <#@ output extension="\\" #>
 <#host.TemplateName = IBaseTypeRequestBuilder(c);#>
 <#=writer.WriteHeader()#>
-<#=CreatePackageDef(host)#>
+<#=CreatePackageDefForIBaseEntityRequestBuilder(host)#>
+import com.microsoft.graph.http.IRequestBuilder;
+import com.microsoft.graph.options.Option;
 
 <#=CreateInterfaceDef(IBaseTypeRequestBuilder(c), "IRequestBuilder")#>
     /**
@@ -104,3 +106,95 @@ if (c.AsOdcmClass() != null)
 #>
 
 }
+<#+
+	public string CreatePackageDefForIBaseEntityRequestBuilder(CustomT4Host host)
+	{
+		var sb = new StringBuilder();
+		sb.Append(CreatePackageDefinition(host));
+		var importFormat = @"import {0}.{1}.{2};";
+		sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequest(host.CurrentType));
+		sb.Append("\n");
+		var c = host.CurrentType;
+		if (c.AsOdcmClass() != null)
+		{
+			foreach(var prop in c.AsOdcmClass().NavigationProperties())
+			{
+				if (prop.IsCollection()) {
+					
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequestBuilder(prop));
+					sb.Append("\n");
+
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequestBuilder(prop));
+					sb.Append("\n");
+				} else {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequestBuilder(prop));
+					sb.Append("\n");
+				}
+			}
+
+			foreach (var prop in c.AsOdcmClass().GetProperties(typeName:"Stream"))
+			{
+				var propRequestBuilder = TypeRequestBuilder(prop);
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						"I" + propRequestBuilder);
+				sb.Append("\n");
+			}
+
+			if (c is OdcmMediaClass)
+			{
+				sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeStreamRequestBuilder(host.CurrentType));
+				sb.Append("\n");
+			}
+
+			foreach (var method in c.AsOdcmClass().MethodsAndOverloads()) {
+				if (method.IsBoundToCollection) {
+					continue;
+				}
+
+				foreach (var p in method.Parameters)
+				{
+					if(!(p.Type is OdcmPrimitiveType) && p.Type.GetTypeString() != "com.google.gson.JsonElement") {
+						sb.AppendFormat(importFormat,
+							host.CurrentModel.NamespaceName(),
+							getPackagePrefix(p),
+							p.Type.GetTypeString());
+						sb.Append("\n");
+					}
+				}
+
+				if (method.IsCollection) {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeCollectionRequestBuilder(method));
+					sb.Append("\n");
+				} else {
+					sb.AppendFormat(importFormat,
+						host.CurrentModel.NamespaceName(),
+						"requests.extensions",
+						ITypeRequestBuilder(method));
+					sb.Append("\n");
+				}
+			}
+		}
+		return sb.ToString();
+	}
+				 
+#>


### PR DESCRIPTION
Fixing import statements for BaseEntityRequestBuilder template
Fixing import statements for IBaseEntityRequestBuilder template
Fixing import statements for BaseEntityRequest template
Together these templates impact ~750 files and these files will start getting optimized import statements with this fix.
Testing:
After generating files using these templates, java sdk has started building with 1.5GB RAM.