### PR TITLE
A check for null values of function/action parameters

### DIFF
--- a/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_generated/BaseMethodCollectionRequestBuilder.java.tt
@@ -20,9 +20,13 @@
         super(requestUrl, client, requestOptions);
 <# foreach (var p in method.Parameters) { #>
   <# if (isAction) { #>
-      bodyParams.put("<#=ParamName(p)#>", <#=ParamName(p)#>);
+	 if(<#=ParamName(p)#>!=null){
+			bodyParams.put("<#=ParamName(p)#>", <#=ParamName(p)#>);
+		}
   <# } else { #>
-      functionOptions.add(new FunctionOption("<#=ParamName(p)#>", <#=ParamName(p)#>));
+   	 if(<#=ParamName(p)#>!=null){
+			functionOptions.add(new FunctionOption("<#=ParamName(p)#>", <#=ParamName(p)#>));
+		}
   <# } #>
 <# } #>
     }


### PR DESCRIPTION
I have put a check for null values of function/action parameters in BaseMethodCollectionRequestBuilder template for Java.

It will stop passing null valued parameters to requests which are generated through this template.