### PR TITLE
Support nav path bindings

### DIFF
--- a/GraphODataTemplateWriter.sln
+++ b/GraphODataTemplateWriter.sln
@@ -34,8 +34,8 @@ Global
 		{5F526973-F69E-4C26-B8AD-612590A17A9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{2256EC8D-FD7E-4A49-B616-70755AFC9F6C}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -137,6 +137,14 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
 
 public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, OdcmProperty odcmProperty)
 {
+		/****
+		To help the future dev in figuring this out, put a break point on the next executable line
+		with the condition odcmProperty.Name == "teachers". The CSDL in and entities mentioned in these 
+		comments are an example of the use of this scenario. 
+		
+		****/
+
+
         // (1) Check that there are NavigationPropertyBindings. If there aren't any, then we know this segment of 
 		// the canonical path to the reference.
         if (singleton.NavigationPropertyBindings.Count == 0)
@@ -145,13 +153,13 @@ public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, O
         }
 
         // (2) Get all of the keys that contain our target path name. The keys come from the Path attribute on a 
-		// NavigationPropertyBinding. So if our target property (OdcmProperty.Name) is named 'schools', then we need to only consider
-		// NavigationPropertyBinding paths that end with 'schools'. The NavigationPropertyBindings are found in the Singleton that 
+		// NavigationPropertyBinding. So if our target property (OdcmProperty.Name) is named 'teachers', then we need to only consider
+		// NavigationPropertyBinding paths that end with 'teachers'. The NavigationPropertyBindings are found in the Singleton that 
 		// defines the EntitySet that contains this property. The NavigationPropertyBindings provide generation hints for how to 
 		// reference non-contained entities that are defined within the same Singleton (this statement is conjecture). This generation
 		// hints is used to specify a reference URL for $ref call. 
 
-		// TODO DELETE: in this case, "teachers". This should be the end part of the BindingPath.
+		// Example: in this case, "teachers". This should be the end part of the BindingPath.
 
         IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
 		/*
@@ -164,18 +172,50 @@ public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, O
                     <NavigationPropertyBinding Path="users/schools" Target="schools" />
                     <NavigationPropertyBinding Path="users/classes" Target="classes" />
                 </Singleton>
+
+				<EntityType Name="educationRoot" BaseType="microsoft.graph.entity">
+					<NavigationProperty Name="synchronizationProfiles" Type="Collection(microsoft.graph.educationSynchronizationProfile)" ContainsTarget="true" />
+					 <NavigationProperty Name="classes" Type="Collection(microsoft.graph.educationClass)" ContainsTarget="true" />
+					<NavigationProperty Name="schools" Type="Collection(microsoft.graph.educationSchool)" ContainsTarget="true" />
+					<NavigationProperty Name="users" Type="Collection(microsoft.graph.educationUser)" ContainsTarget="true" />
+					<NavigationProperty Name="me" Type="microsoft.graph.educationUser" ContainsTarget="true" />
+				</EntityType>
+
+				<EntityType Name="educationClass" BaseType="microsoft.graph.entity">
+					<Property Name="displayName" Type="Edm.String" Nullable="false" />
+					<NavigationProperty Name="schools" Type="Collection(microsoft.graph.educationSchool)" />
+					<NavigationProperty Name="members" Type="Collection(microsoft.graph.educationUser)" />
+ 					 <NavigationProperty Name="teachers" Type="Collection(microsoft.graph.educationUser)" />
+					<NavigationProperty Name="group" Type="microsoft.graph.group" />
+					<NavigationProperty Name="assignments" Type="Collection(microsoft.graph.educationAssignment)" ContainsTarget="true" />
+				</EntityType>
 		*/
 
 		// We need to support long NavPropBindings. That is, we need to support multi-segment NavigationPropertyBinding paths
 		// (3) We need to query the paths in {keys} against the entity (odcmProperty.Class) that contains this navigation property (odcmProperty). 
 		//	   We need to determine the unique binding path from the singleton through the entity on to this navigation property, query the keys
-		//       for it, and then get the target. There could be 1 or more hops that we need to account for.
+		//       for it, and then get the target. There could be 1 or more pat segments that we need to account for.
+		// Example: odcmProperty.Class is the entity "educationClass" that has the non-contained navigation property represented by odcmProperty,
+		// which is named 'teachers'. At this point, we know the singleton and all of its NavigationPropertyBindings, we know the singleton's entity type,
+		// which is named 'educationRoot'.
+		// We need to determine whether a NavigationPropertyBinding pth and target is different than the CSDL described path to the reference non-contained entity. 
 
 		// odcmProperty.Name; // --> "teachers"
 
 		var navPropClassToFind = odcmProperty.Class.Name; // -- > "educationClass"; This is the EntityType that contains the navigation property
 		string firstBindingPathSegment = ""; // We are incorrectly assuming to segment.
 				
+		// Get the path segments.
+		//string[] navPropBindingSegments = keys.First().Split('/'); 
+
+		// Example: After hitting the conditional breakpoint, singleton.Type.Name is "educationRoot". 
+		// We are going to inspect each navigation property on singleton's type and compare to the segments
+		// in the keys IEnumerable. 
+		// The assumption here is that the first segment is a navigation property of the singleton's type
+		// The second assumption is that there are only two segments. We know this is a bad assumption.
+		// The third assumption is that the last segment is the most meaningful. 
+		// In short, this only works for a Path that has two segments.
+
 		foreach (OdcmProperty prop in (singleton.Type as OdcmEntityClass).Properties)
 		{
 			if (prop.Type.Name == navPropClassToFind)
@@ -184,6 +224,32 @@ public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, O
 				break;
 			}		 	
 		}
+
+		/*
+			What we know.
+
+			We know the navigation property name and type.
+			We know whih entity contains the navigation property.
+			We know that the navigation property does not contain the entity.
+			We know which singleton is the entity set for the navigation property.
+			We know the singleton's type.
+			We know the NavigationPropertyBindings and which candidates CAN be the one to define the reference path to the entity in the navigation.
+
+			We don't know the paths to the entity that contains our navigation property. So, the question is, can we know the context in which the 
+			navigation property is being accessed at generation time? I don't think we can.
+
+			The next question is can we code the templates to generate code that is context aware and can create the ref path based on that context. 
+			This is a maybe. 
+
+			Our current example works since the scenario only has two levels of entities. What happens when we have three level of entities like
+			/schools/classes/teachers. We know the teachers segments. We don't have context which entities are accessed across the request builders
+			at runtime. 
+
+			We may need to generate a dictionary from the NavPropBindings in to the code files and use those at runtime to discover the context in
+			which a navigtion is called in order to provide the correct reference path. 
+
+			TODO: investigate what it would take to generate code that is context aware of binding path.
+		*/
 
 		string secondBindingPathSegment = odcmProperty.Name;
 

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -3,6 +3,8 @@
 <#@ include file="Request.Base.template.tt"#>
 <#+
 
+using System.Linq.Enumerable;
+
 // -------------------------------------------------------------
 // Methods for standard entity collection classes
 // -------------------------------------------------------------
@@ -146,7 +148,58 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 	//Append the singleton's navigation type to the @odata.id if relevant
 	var implicitNavigationProperty = string.Empty;
 	if (serviceNavigationProperty.GetType() == typeof(OdcmSingleton)) 
-		implicitNavigationProperty = "/" + odcmProperty.Name;
+	{
+		var singleton = (OdcmSingleton)serviceNavigationProperty;
+
+        // (1) Get all of the keys (Binding Paths) that contain our target path name, in this case, "teachers". This should be the end part of the BindingPath.
+        IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
+		// TODO: if keys.Count == 0, we need to short circuit this. 
+
+/*
+        // Check that we actually matched a key. If we have NavigationPropertyBindings and we didn't find a potential match, then we have an error
+        if (singleton.NavigationPropertyBindings.Count != 0 && keys.Count() == 0) // I don't think this is good.
+        {
+            throw new Exception("Expected that a prospect key match is found. No key was found.");
+        }
+*/
+
+		// (2) We need to query the paths in {keys} against the entity (odcmProperty.Class) that contains this navigation property (odcmProperty). 
+		//	   We need to determine the unique binding path from the singleton through the entity on to this navigation property, query the keys
+		//       for it, and then get the target. There could be 1 or more hops that we need to account for.
+
+		// odcmProperty.Name; // --> "teachers"
+
+		var navPropClassToFind = odcmProperty.Class.Name; // -- > "educationClass";
+		string firstBindingPathSegment = ""; // We are incorrectly assuming to segment.
+
+		
+		foreach (OdcmProperty prop in (singleton.Type as OdcmEntityClass).Properties)
+		{
+			if (prop.Type.Name == navPropClassToFind)
+			{
+				firstBindingPathSegment = prop.Name;
+				break;
+			}		 	
+		}
+
+		string secondBindingPathSegment = odcmProperty.Name;
+
+		//string bindingPath = firstBindingPathSegment + "/" + keys.First(); // TODO: Need to fix this.
+		string bindingPath = firstBindingPathSegment + "/" + secondBindingPathSegment;
+
+		string bindingTarget;
+
+		if (singleton.NavigationPropertyBindings.TryGetValue(bindingPath, out bindingTarget))
+		{
+			// We found the target
+			implicitNavigationProperty = "/" + bindingTarget;
+		}
+		else
+			implicitNavigationProperty = "/" + odcmProperty.Name;
+		
+			
+	}
+	
 
     var stringBuilder = new StringBuilder();
 

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -1,9 +1,11 @@
 <# // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information. #>
 <#@ template debug="true" hostspecific="true" language="C#" #>
 <#@ include file="Request.Base.template.tt"#>
+
+
 <#+
 
-using System.Linq.Enumerable;
+// using System.Linq.Enumerable;
 
 // -------------------------------------------------------------
 // Methods for standard entity collection classes
@@ -133,46 +135,47 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
     return string.Empty;
 }
 
-public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
+public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, OdcmProperty odcmProperty)
 {
-    var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
-    var propertyType = this.GetPropertyTypeName(odcmProperty);
-
-    var templateWriterHost = (CustomT4Host)Host;
-    var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
-
-    var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType();
-	if (serviceNavigationProperty == null)
-		return string.Empty;
-	
-	//Append the singleton's navigation type to the @odata.id if relevant
-	var implicitNavigationProperty = string.Empty;
-	if (serviceNavigationProperty.GetType() == typeof(OdcmSingleton)) 
-	{
-		var singleton = (OdcmSingleton)serviceNavigationProperty;
-
-        // (1) Get all of the keys (Binding Paths) that contain our target path name, in this case, "teachers". This should be the end part of the BindingPath.
-        IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
-		// TODO: if keys.Count == 0, we need to short circuit this. 
-
-/*
-        // Check that we actually matched a key. If we have NavigationPropertyBindings and we didn't find a potential match, then we have an error
-        if (singleton.NavigationPropertyBindings.Count != 0 && keys.Count() == 0) // I don't think this is good.
+        // (1) Check that there are NavigationPropertyBindings. If there aren't any, then we know this segment of 
+		// the canonical path to the reference.
+        if (singleton.NavigationPropertyBindings.Count == 0)
         {
-            throw new Exception("Expected that a prospect key match is found. No key was found.");
+			return "/" + odcmProperty.Name;
         }
-*/
 
-		// (2) We need to query the paths in {keys} against the entity (odcmProperty.Class) that contains this navigation property (odcmProperty). 
+        // (2) Get all of the keys that contain our target path name. The keys come from the Path attribute on a 
+		// NavigationPropertyBinding. So if our target property (OdcmProperty.Name) is named 'schools', then we need to only consider
+		// NavigationPropertyBinding paths that end with 'schools'. The NavigationPropertyBindings are found in the Singleton that 
+		// defines the EntitySet that contains this property. The NavigationPropertyBindings provide generation hints for how to 
+		// reference non-contained entities that are defined within the same Singleton (this statement is conjecture). This generation
+		// hints is used to specify a reference URL for $ref call. 
+
+		// TODO DELETE: in this case, "teachers". This should be the end part of the BindingPath.
+
+        IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
+		/*
+                <Singleton Name="education" Type="microsoft.graph.educationRoot">
+                     <NavigationPropertyBinding Path="classes/teachers" Target="users" />
+                    <NavigationPropertyBinding Path="classes/members" Target="users" />
+                    <NavigationPropertyBinding Path="classes/schools" Target="schools" />
+                    <NavigationPropertyBinding Path="schools/classes" Target="classes" />
+                    <NavigationPropertyBinding Path="schools/users" Target="users" />
+                    <NavigationPropertyBinding Path="users/schools" Target="schools" />
+                    <NavigationPropertyBinding Path="users/classes" Target="classes" />
+                </Singleton>
+		*/
+
+		// We need to support long NavPropBindings. That is, we need to support multi-segment NavigationPropertyBinding paths
+		// (3) We need to query the paths in {keys} against the entity (odcmProperty.Class) that contains this navigation property (odcmProperty). 
 		//	   We need to determine the unique binding path from the singleton through the entity on to this navigation property, query the keys
 		//       for it, and then get the target. There could be 1 or more hops that we need to account for.
 
 		// odcmProperty.Name; // --> "teachers"
 
-		var navPropClassToFind = odcmProperty.Class.Name; // -- > "educationClass";
+		var navPropClassToFind = odcmProperty.Class.Name; // -- > "educationClass"; This is the EntityType that contains the navigation property
 		string firstBindingPathSegment = ""; // We are incorrectly assuming to segment.
-
-		
+				
 		foreach (OdcmProperty prop in (singleton.Type as OdcmEntityClass).Properties)
 		{
 			if (prop.Type.Name == navPropClassToFind)
@@ -192,14 +195,35 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 		if (singleton.NavigationPropertyBindings.TryGetValue(bindingPath, out bindingTarget))
 		{
 			// We found the target
-			implicitNavigationProperty = "/" + bindingTarget;
+			return "/" + bindingTarget;
 		}
 		else
-			implicitNavigationProperty = "/" + odcmProperty.Name;
-		
-			
-	}
+			 return "/" + odcmProperty.Name;
+}
+
+public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
+{
+    var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
+    var propertyType = this.GetPropertyTypeName(odcmProperty);
+
+    var templateWriterHost = (CustomT4Host)Host;
+    var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
+
+    var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType();
+	if (serviceNavigationProperty == null)
+		return string.Empty;
 	
+	var implicitNavigationProperty = string.Empty;
+	
+	// If the odcmProperty is a part of Singleton, then we need to determine whether there is a  
+	// NavigationPropertyBinding generation hint. If there is, then we need to use it for 
+	// creating the URL of a reference entity in a POST body. 
+	if (serviceNavigationProperty.GetType() == typeof(OdcmSingleton)) 
+	{
+		var singleton = (OdcmSingleton)serviceNavigationProperty;
+
+        implicitNavigationProperty = GetImplicitNavigationPropertyUrlSegment(singleton, odcmProperty);
+	}
 
     var stringBuilder = new StringBuilder();
 

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -135,48 +135,6 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string requestBody =
     return string.Empty;
 }
 
-public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, OdcmProperty odcmProperty)
-{
-		/****
-		To help the future dev in figuring this out, put a break point on the next executable line
-		with the condition odcmProperty.Name == "teachers". The CSDL in and entities mentioned in these 
-		comments are an example of the use of this scenario. 
-		****/
-
-        // (1) Check that there are NavigationPropertyBindings. If there aren't any, then we know this segment is 
-		// the canonical path to the reference.
-        if (singleton.NavigationPropertyBindings.Count == 0)
-        {
-			return "/" + odcmProperty.Name;
-        }
-
-        // (2) Get all of the keys that contain our target path name. The keys come from the Path attribute on a 
-		// NavigationPropertyBinding. So if our target property (OdcmProperty.Name) is named 'teachers', then we need to only consider
-		// NavigationPropertyBinding paths that end with 'teachers'. The NavigationPropertyBindings are found in the Singleton that 
-		// defines the EntitySet that contains this property. The NavigationPropertyBindings provide generation hints for how to 
-		// reference non-contained entities that are defined within the same Singleton (this statement is conjecture). This generation
-		// hints is used to specify a reference URL for $ref call. 
-		// Example: in this case, "teachers". This should be the end part of the BindingPath.
-
-        IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
-
-		string bindingTarget;
-
-        // The first assumption is that CSDL is added with a convention where the last path segment in NavigationPropertyBinding.Path
-        // is named consistently in a singleton so it doesn't matter what the preceding segments are. 
-        // The second assumption is that if the last path is named consistently, the target will be consistent as well.
-        // These may turn out to be a weak assumption. We use this assumption since we can't determine a unique path
-        // for three or more segments since *RequestBuilder and *Request objects are generated per entity+navigation,
-        // and not [entity+navigation]*n --> across multiple navigations.
-		if (keys.Count() > 0 && singleton.NavigationPropertyBindings.TryGetValue(keys.First(), out bindingTarget))
-		{
-			// We found the target
-			return "/" + bindingTarget;
-		}
-		else
-			 return "/" + odcmProperty.Name;
-}
-
 public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 {
     var sanitizedPropertyName = odcmProperty.Projection.Type.Name.GetSanitizedPropertyName(odcmProperty.Name);
@@ -195,11 +153,7 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty)
 	// NavigationPropertyBinding generation hint. If there is, then we need to use it for 
 	// creating the URL of a reference entity in a POST body. 
 	if (serviceNavigationProperty.GetType() == typeof(OdcmSingleton)) 
-	{
-		var singleton = (OdcmSingleton)serviceNavigationProperty;
-
-        implicitNavigationProperty = GetImplicitNavigationPropertyUrlSegment(singleton, odcmProperty);
-	}
+	    implicitNavigationProperty = "/" + odcmProperty.GetImplicitPropertyName((OdcmSingleton)serviceNavigationProperty);
 
     var stringBuilder = new StringBuilder();
 

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -1,11 +1,7 @@
 <# // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information. #>
 <#@ template debug="true" hostspecific="true" language="C#" #>
 <#@ include file="Request.Base.template.tt"#>
-
-
 <#+
-
-// using System.Linq.Enumerable;
 
 // -------------------------------------------------------------
 // Methods for standard entity collection classes

--- a/Templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -141,11 +141,9 @@ public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, O
 		To help the future dev in figuring this out, put a break point on the next executable line
 		with the condition odcmProperty.Name == "teachers". The CSDL in and entities mentioned in these 
 		comments are an example of the use of this scenario. 
-		
 		****/
 
-
-        // (1) Check that there are NavigationPropertyBindings. If there aren't any, then we know this segment of 
+        // (1) Check that there are NavigationPropertyBindings. If there aren't any, then we know this segment is 
 		// the canonical path to the reference.
         if (singleton.NavigationPropertyBindings.Count == 0)
         {
@@ -158,107 +156,19 @@ public string GetImplicitNavigationPropertyUrlSegment(OdcmSingleton singleton, O
 		// defines the EntitySet that contains this property. The NavigationPropertyBindings provide generation hints for how to 
 		// reference non-contained entities that are defined within the same Singleton (this statement is conjecture). This generation
 		// hints is used to specify a reference URL for $ref call. 
-
 		// Example: in this case, "teachers". This should be the end part of the BindingPath.
 
         IEnumerable<string> keys = singleton.NavigationPropertyBindings.Where(kvp => kvp.Key.EndsWith(odcmProperty.Name)).Select(kvp => kvp.Key);
-		/*
-                <Singleton Name="education" Type="microsoft.graph.educationRoot">
-                     <NavigationPropertyBinding Path="classes/teachers" Target="users" />
-                    <NavigationPropertyBinding Path="classes/members" Target="users" />
-                    <NavigationPropertyBinding Path="classes/schools" Target="schools" />
-                    <NavigationPropertyBinding Path="schools/classes" Target="classes" />
-                    <NavigationPropertyBinding Path="schools/users" Target="users" />
-                    <NavigationPropertyBinding Path="users/schools" Target="schools" />
-                    <NavigationPropertyBinding Path="users/classes" Target="classes" />
-                </Singleton>
-
-				<EntityType Name="educationRoot" BaseType="microsoft.graph.entity">
-					<NavigationProperty Name="synchronizationProfiles" Type="Collection(microsoft.graph.educationSynchronizationProfile)" ContainsTarget="true" />
-					 <NavigationProperty Name="classes" Type="Collection(microsoft.graph.educationClass)" ContainsTarget="true" />
-					<NavigationProperty Name="schools" Type="Collection(microsoft.graph.educationSchool)" ContainsTarget="true" />
-					<NavigationProperty Name="users" Type="Collection(microsoft.graph.educationUser)" ContainsTarget="true" />
-					<NavigationProperty Name="me" Type="microsoft.graph.educationUser" ContainsTarget="true" />
-				</EntityType>
-
-				<EntityType Name="educationClass" BaseType="microsoft.graph.entity">
-					<Property Name="displayName" Type="Edm.String" Nullable="false" />
-					<NavigationProperty Name="schools" Type="Collection(microsoft.graph.educationSchool)" />
-					<NavigationProperty Name="members" Type="Collection(microsoft.graph.educationUser)" />
- 					 <NavigationProperty Name="teachers" Type="Collection(microsoft.graph.educationUser)" />
-					<NavigationProperty Name="group" Type="microsoft.graph.group" />
-					<NavigationProperty Name="assignments" Type="Collection(microsoft.graph.educationAssignment)" ContainsTarget="true" />
-				</EntityType>
-		*/
-
-		// We need to support long NavPropBindings. That is, we need to support multi-segment NavigationPropertyBinding paths
-		// (3) We need to query the paths in {keys} against the entity (odcmProperty.Class) that contains this navigation property (odcmProperty). 
-		//	   We need to determine the unique binding path from the singleton through the entity on to this navigation property, query the keys
-		//       for it, and then get the target. There could be 1 or more pat segments that we need to account for.
-		// Example: odcmProperty.Class is the entity "educationClass" that has the non-contained navigation property represented by odcmProperty,
-		// which is named 'teachers'. At this point, we know the singleton and all of its NavigationPropertyBindings, we know the singleton's entity type,
-		// which is named 'educationRoot'.
-		// We need to determine whether a NavigationPropertyBinding pth and target is different than the CSDL described path to the reference non-contained entity. 
-
-		// odcmProperty.Name; // --> "teachers"
-
-		var navPropClassToFind = odcmProperty.Class.Name; // -- > "educationClass"; This is the EntityType that contains the navigation property
-		string firstBindingPathSegment = ""; // We are incorrectly assuming to segment.
-				
-		// Get the path segments.
-		//string[] navPropBindingSegments = keys.First().Split('/'); 
-
-		// Example: After hitting the conditional breakpoint, singleton.Type.Name is "educationRoot". 
-		// We are going to inspect each navigation property on singleton's type and compare to the segments
-		// in the keys IEnumerable. 
-		// The assumption here is that the first segment is a navigation property of the singleton's type
-		// The second assumption is that there are only two segments. We know this is a bad assumption.
-		// The third assumption is that the last segment is the most meaningful. 
-		// In short, this only works for a Path that has two segments.
-
-		foreach (OdcmProperty prop in (singleton.Type as OdcmEntityClass).Properties)
-		{
-			if (prop.Type.Name == navPropClassToFind)
-			{
-				firstBindingPathSegment = prop.Name;
-				break;
-			}		 	
-		}
-
-		/*
-			What we know.
-
-			We know the navigation property name and type.
-			We know whih entity contains the navigation property.
-			We know that the navigation property does not contain the entity.
-			We know which singleton is the entity set for the navigation property.
-			We know the singleton's type.
-			We know the NavigationPropertyBindings and which candidates CAN be the one to define the reference path to the entity in the navigation.
-
-			We don't know the paths to the entity that contains our navigation property. So, the question is, can we know the context in which the 
-			navigation property is being accessed at generation time? I don't think we can.
-
-			The next question is can we code the templates to generate code that is context aware and can create the ref path based on that context. 
-			This is a maybe. 
-
-			Our current example works since the scenario only has two levels of entities. What happens when we have three level of entities like
-			/schools/classes/teachers. We know the teachers segments. We don't have context which entities are accessed across the request builders
-			at runtime. 
-
-			We may need to generate a dictionary from the NavPropBindings in to the code files and use those at runtime to discover the context in
-			which a navigtion is called in order to provide the correct reference path. 
-
-			TODO: investigate what it would take to generate code that is context aware of binding path.
-		*/
-
-		string secondBindingPathSegment = odcmProperty.Name;
-
-		//string bindingPath = firstBindingPathSegment + "/" + keys.First(); // TODO: Need to fix this.
-		string bindingPath = firstBindingPathSegment + "/" + secondBindingPathSegment;
 
 		string bindingTarget;
 
-		if (singleton.NavigationPropertyBindings.TryGetValue(bindingPath, out bindingTarget))
+        // The first assumption is that CSDL is added with a convention where the last path segment in NavigationPropertyBinding.Path
+        // is named consistently in a singleton so it doesn't matter what the preceding segments are. 
+        // The second assumption is that if the last path is named consistently, the target will be consistent as well.
+        // These may turn out to be a weak assumption. We use this assumption since we can't determine a unique path
+        // for three or more segments since *RequestBuilder and *Request objects are generated per entity+navigation,
+        // and not [entity+navigation]*n --> across multiple navigations.
+		if (keys.Count() > 0 && singleton.NavigationPropertyBindings.TryGetValue(keys.First(), out bindingTarget))
 		{
 			// We found the target
 			return "/" + bindingTarget;

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -208,6 +208,21 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             }
         }
 
+        public static string GetImplicitPropertyName(this OdcmProperty property, OdcmSingleton singleton)
+        {
+            var implicitPropertyName = property.Name;
+            // Default behavior
+            if (singleton.NavigationPropertyBindings.Count() > 0)
+            {
+                var target = singleton.NavigationPropertyBindings.Where(kv => kv.Key.EndsWith(property.Name)).Select(kvp => kvp.Value).FirstOrDefault();
+                if (target != null)
+                {
+                    implicitPropertyName = target;
+                }
+            }
+            return implicitPropertyName;
+        }
+
         public static IEnumerable<OdcmProperty> NavigationProperties(this OdcmClass odcmClass)
         {
             return odcmClass.Properties.Where(prop => prop.IsNavigation());


### PR DESCRIPTION
This change adds support for NavigationPropertyBindings for singletons as a generation hint for generating the correct canonical URLs for adding references to non-contained navigation entities. 

The education based files represent the outcome of this change.

https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/afterNavPathUpdate
