### PR TITLE
Revert strict model generation for typescript

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -33,11 +33,7 @@ export interface <#= entityType.Name.UpperCaseFirstChar() #><# if (entityType.Ba
 	<# if (prop.LongDescription != null) { #>
     /** <#=prop.LongDescription#> */
 	<# } #>
-	<# if (prop.IsNullable == false) { #>
-        <#=  prop.Name #>: <#= prop.GetTypeString() #>
-	<# } else { #>
-        <#=  prop.Name #>?: <#= prop.GetTypeString() #>
-	<# } #>
+	<#=  prop.Name #>?: <#= prop.GetTypeString() #>
 
 <# } #>
 }
@@ -54,11 +50,7 @@ export interface <#= complexType.Name.UpperCaseFirstChar()#><# if (complexType.B
 	<# if (prop.LongDescription != null) { #>
     /** <#=prop.LongDescription#> */
 	<# } #>
-	<# if (prop.IsNullable == false) { #>
-        <#= prop.Name #>: <#= prop.GetTypeString() #>
-	<# } else { #>
-        <#= prop.Name #>?: <#= prop.GetTypeString() #>
-	<# } #>
+	<#= prop.Name #>?: <#= prop.GetTypeString() #>
 
 <# } #>
 }


### PR DESCRIPTION
**Sharepoint issue:** In particular the Entity type’s id and the createdDateTime and lastModifiedDateTime fields are now not nullable.  This makes list creation in SharePoint problematic since those fields are server generated and shouldn’t be expected when you’re doing a POST to create a list or Column Definition (both of which derive from those base types).

Potentially a blocker for web part demo for Ignite. so reverting the strict model types generation.