### PR TITLE
Add odata type to complex types for .Net and PHP

### DIFF
--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -44,7 +44,10 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     {
 
 <#
-// We need to set the @odata.type property when this type has 
+// Set the @odata.type property when this type is not abstract. If problems are caused by this, 
+// then we should consider only setting @odata.type when this types base class is an abstract class
+// referenced as the type for a property. That is really the only time when the API will need the
+// disambiguation.
 if (!complex.IsAbstract)
 {
 #>        public <#=complexTypeName#>()

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -43,18 +43,16 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     public <#=classType#> <#=typeDeclaration#>
     {
 
-    <# 
-    // We need to set the @odata.type property when this type has 
-    if (!complex.Base.IsAbstract)
-    {
-    #>
-        public <#=complexTypeName#>()
+<#
+// We need to set the @odata.type property when this type has 
+if (!complex.IsAbstract)
+{
+#>        public <#=complexTypeName#>()
         {
-            this.ODataType = this.GetType().FullName;
+            this.ODataType = "<#=complex.FullName#>";
         }
-
     <#
-    }
+}
         foreach(var property in complex.Properties)
         {
 

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -42,7 +42,19 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     <#=attributeStringBuilder.ToString()#>
     public <#=classType#> <#=typeDeclaration#>
     {
+
+    <# 
+    // We need to set the @odata.type property when this type has 
+    if (!complex.Base.IsAbstract)
+    {
+    #>
+        public <#=complexTypeName#>()
+        {
+            this.ODataType = this.GetType().FullName;
+        }
+
     <#
+    }
         foreach(var property in complex.Properties)
         {
 
@@ -86,6 +98,7 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
         }
 
     // Only include AdditionalData in the base classes.
+    // Adding odata.type to all complex types with no base class. 
     if (complex.Base == null)
     {
     #>
@@ -95,6 +108,12 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     <#
     }
     #>

--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -42,19 +42,16 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     <#=attributeStringBuilder.ToString()#>
     public <#=classType#> <#=typeDeclaration#>
     {
-
 <#
-// Set the @odata.type property when this type is not abstract. If problems are caused by this, 
-// then we should consider only setting @odata.type when this types base class is an abstract class
-// referenced as the type for a property. That is really the only time when the API will need the
-// disambiguation.
-if (!complex.IsAbstract)
+// Generate a constructor to initialize the @odata.type property when this type is not abstract and if this 
+// type's base is abstract and the base is referenced as the type of a structural property. We need this
+// to disambiguate the type of the descendant class being sent. 
+if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
 {
 #>        public <#=complexTypeName#>()
         {
             this.ODataType = "<#=complex.FullName#>";
-        }
-    <#
+        }<#
 }
         foreach(var property in complex.Properties)
         {

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -27,6 +27,22 @@ class <#=complexName.ToCheckedCase()#> extends Entity
 #>
 {
 <# 
+// Generate a constructor to initialize the @odata.type property when this type is not abstract and if this 
+// type's base is abstract and the base is referenced as the type of a structural property. We need this
+// to disambiguate the type of the descendant class being sent. 
+if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
+{
+#>    /**
+    * Set the @odata.type since this type is immediately descended from an abstract
+    * type that is referenced as the type in an entity.
+    */
+    public function __construct()
+    {
+        $this->setODataType("#<#=complex.FullName#>");
+    }
+
+<# 
+}
 foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString() != "bytes")){
     var propertyName = property.Name.SanitizePropertyName(complexName);
     if (!property.Type.IsComplex()) {

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -223,6 +223,30 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             return implicitPropertyName;
         }
 
+        /// <summary>
+        /// Indicates whether the abstract base class of a descendant is referenced as the type of a structural property.
+        /// This has significance to scenarios where client needs to set the @odata.type property because the type cannot
+        /// be inferred since the reference is the to abstract base class and the actual class used by the client is
+        /// one of its descendants. 
+        /// </summary>
+        /// <param name="complex">The ComplexType that we want to query whether its base type is the referenced type for any property in any entity.</param>
+        /// <returns></returns>
+        public static bool IsBaseAbstractAndReferencedAsPropertyType(this OdcmClass complex)
+        {
+            if (complex.Base == null)
+            {
+                return false;
+            }
+            else
+            {
+                return complex.Namespace.Types.Select(someType => (someType as OdcmEntityClass))
+                               .Where(someType => someType is OdcmEntityClass)
+                               .Where(someType => (someType as OdcmEntityClass).Properties
+                                    .Any(x => x.Type.Name == complex.Base.Name && complex.Base.IsAbstract))
+                               .Any();
+            }
+        }
+
         public static IEnumerable<OdcmProperty> NavigationProperties(this OdcmClass odcmClass)
         {
             return odcmClass.Properties.Where(prop => prop.IsNavigation());


### PR DESCRIPTION
@odata.type property is now serialized for all complexTypes. We need to:
- [x] verify that this won't be a problem for the workloads. It shouldn't be an issue but I'd like to ask an OData expert.

This will fix https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/294.

This will be applicable for .Net, Java, PHP, and TypeScript.

I'll link to what this looks like in a .Net PR.