### PR TITLE
Capture more descriptions.

### DIFF
--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -69,7 +69,7 @@ if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
 
         /// <summary>
         /// Gets or sets <#=property.Name#>.
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
         /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
@@ -84,7 +84,7 @@ if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
 
         /// <summary>
         /// Gets or sets <#=property.Name#>.
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
         /// <#=property.GetSanitizedLongDescription()#>
 <# } #>

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -101,7 +101,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
 
         /// <summary>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
         /// <#=property.GetSanitizedLongDescription()#>
 <# } #>
@@ -117,7 +117,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
 
         /// <summary>
         /// Gets or sets <#=property.Name.SplitCamelCase().ToLower()#>.
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
         /// <#=property.GetSanitizedLongDescription()#>
 <# } #>


### PR DESCRIPTION
GetSanitizedLongDescription captures both Description and LongDescription. We were missing many descriptions when we weren't checking the Description property.

This issue also exists for:
- TypeScript
- PHP
- Probably Java