### PR TITLE
Add generation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ Once setup is complete, you can work with the GraphODataTemplateWriter solution 
 
 For more information on submodules read [this chapter](http://git-scm.com/book/en/v2/Git-Tools-Submodules) from the Git book and search the Web.
 
+## Using Typewriter
+
+Typewriter is a new solution for generating code files using the GraphODataTemplateWriter and VIPR. It is an executable that is intended to simplify the generation of code files. Build the solution to find the typewriter executable in `\MSGraph-SDK-Code-Generator\src\Typewriter\bin\Release`. The typewriter run options are:
+
+* **-l**, **-language**:  The target language for the generated code files. The values can be: `Android`, `Java`, `ObjC`, `CSharp`, `PHP`, `Python`, `TypeScript`, or `GraphEndpointList`. The default value is `CSharp`. This is not applicable when only generating clean and annotated metadata as specified by the `-generationmode Metadata` option.
+* **-m**, **-metadata**: The local file path or URL to the target input metadata. The default value is `https://graph.microsoft.com/v1.0/$metadata`. This value is required.
+* **-v**, **-verbosity**: The log verbosity level. The values can be: `Minimal`, `Info`, `Debug`, or `Trace`. The default value is `Minimal`.
+* **-o**, **-output**: Specifies the path to the output folder. The default value is the directory that contains typewriter.exe. The structure and contents of the output directory will be different based on the `-generationmode` and `-language` options.
+* **-d**, **-docs**: Specifies the path to the local root of the [microsoft-graph-docs](https://github.com/microsoftgraph/microsoft-graph-docs) repo. The default value is the directory that contains typewriter.exe. The documentation is parsed to provide documentation annotations to the metadata which is then used to add doc comments in the generated code files. This option is required when using `-generationmode` values of `Metadata` or `Full`.
+* **-g**, **-generationmode**: Specifies the generation mode. The values can be: `Full`, `Metadata`, or `Files`. `Full` (default) generation mode produces the output code files by cleaning the input metadata, parsing the documentation, and adding annotations before generating the output files. `Metadata` generation mode produces an output metadata file by cleaning metadata, documentation parsing, and adding documentation annotations. `Files` generation mode produces code files from an input metadata and bypasses the cleaning, documentation parsing, and adding documentation annotations.
+* **-f**, **-outputMetadataFileName**: The base output metadata filename. Only applicable for `-generationmode Metadata`. The default value is `cleanMetadataWithDescriptions` which is used with the value of the `-endpointVersion` to generate a metadata file named `cleanMetadataWithDescriptionsv1.0.xml`.
+* **-e**, **-endpointVersion**: The endpoint version used when naming a metadata file. Expected values are `v1.0` and `beta`. Only applicable for `-generationmode Metadata`.
+
+### Example typewriter usage
+
+#### Generate TypeScript typings from a CSDL (metadata) file without cleaning or annotating the CSDL. 
+
+The output will go in to the `outputTypeScript` directory.
+
+`.\typewriter.exe -v Info -m D:\cleanMetadataWithDescriptions_v10.xml -o outputTypeScript -l TypeScript -g Files`
+
+#### Clean and annotate a metadata file with documentation annotations sourced from the documentation repo 
+
+The output metadata file will go in to the `output2` directory. The output metadata file will be named `cleanMetadataWithDescriptionsv1.0.xml` based on the default values.
+
+`.\typewriter.exe -v Info -m D:\v1.0_2018_10_23_source.xml -o output2 -d D:\repos\microsoft-graph-docs -g Metadata`
+
+#### Generate C# code files from the metadata that will be cleaned and annotated with documentation annotations sourced from the documentation repo
+
+The output C# code files will go in to the `output` directory.
+
+`.\typewriter.exe -v Info -m D:\v1.0_2018_10_23_source.xml -o output -l CSharp -d D:\repos\microsoft-graph-docs -g Full`
+
+
+
 ## Using Vipr with this Writer
 
 1. Build the solution in Visual Studio.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Source code writers for [VIPR][vipr-source-repo] utilizing T4 templates. The Gra
 Currently the following target languages are supported by this writer:
 - Android
 - CSharp
+- Java
 - Objective-C
 - Python
 - TypeScript

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -20,7 +20,7 @@ namespace Typewriter
         
         private readonly CsdlWriterOptions options;
 
-        internal DocAnnotationWriter(DocSet docSet, CsdlWriterOptions options, string csdl) : base(docSet, options)
+        internal DocAnnotationWriter(DocSet docSet, CsdlWriterOptions options) : base(docSet, options)
         {
             this.options = options; // Can change the base access modifier so we could use it. 
         }
@@ -77,21 +77,31 @@ namespace Typewriter
     {
         private static Logger Logger => LogManager.GetLogger("AnnotationHelper");
 
-        internal async static Task<string> ApplyAnnotationsToCsdl(string csdl, Options options)
+        /// <summary>
+        /// Applies annotations to CSDL file.
+        /// </summary>
+        /// <param name="options">The typewriter input options.</param>
+        /// <param name="pathToCleanMetadata">Optional. Contains the path to a clean metadata to use when applying annotations. Overrides Option.Metadata.</param>
+        /// <returns>An annotated metadata file.</returns>
+        internal async static Task<string> ApplyAnnotationsToCsdl(Options options, string pathToCleanMetadata = null)
         {
-            // Get DocSet
             DocSet docs = GetDocSet(options, new IssueLogger());
 
             var csdlWriterOptions = new CsdlWriterOptions()
             {
                 DocumentationSetPath = options.DocsRoot + "\\api-reference\\v1.0\\",
                 Annotations = AnnotationOptions.Properties,
-                SourceMetadataPath = options.Metadata,
                 SkipMetadataGeneration = true,
                 Formats = MetadataFormat.EdmxInput
             };
 
-            DocAnnotationWriter docWriter = new DocAnnotationWriter(docs, csdlWriterOptions, csdl);
+            // We only intend to ues the source metadata when we don't pass in a CSDL.
+            if (string.IsNullOrEmpty(pathToCleanMetadata))
+                csdlWriterOptions.SourceMetadataPath = options.Metadata;
+            else
+                csdlWriterOptions.SourceMetadataPath = pathToCleanMetadata;
+
+            DocAnnotationWriter docWriter = new DocAnnotationWriter(docs, csdlWriterOptions);
 
             return await docWriter.PublishToStringAsync(new IssueLogger()); 
         }

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -95,7 +95,7 @@ namespace Typewriter
                 Formats = MetadataFormat.EdmxInput
             };
 
-            // We only intend to ues the source metadata when we don't pass in a CSDL.
+            // We only intend to use the source metadata when we don't pass in a CSDL.
             if (string.IsNullOrEmpty(pathToCleanMetadata))
                 csdlWriterOptions.SourceMetadataPath = options.Metadata;
             else

--- a/src/Typewriter/FileWriter.cs
+++ b/src/Typewriter/FileWriter.cs
@@ -21,6 +21,7 @@ namespace Typewriter
         /// Writes a metadata file to disk.
         /// </summary>
         /// <param name="metadata">The metadata to write.</param>
+        /// <param name="fileName">The output metadata filename.</param>
         /// <param name="outputDirectoryPath">Metadata write location.</param>
         public static string WriteMetadata(string metadata, string fileName, string outputDirectoryPath = null)
         {

--- a/src/Typewriter/FileWriter.cs
+++ b/src/Typewriter/FileWriter.cs
@@ -18,6 +18,26 @@ namespace Typewriter
         internal static Logger Logger => LogManager.GetLogger("FileWriter");
 
         /// <summary>
+        /// Writes a metadata file to disk.
+        /// </summary>
+        /// <param name="metadata">The metadata to write.</param>
+        /// <param name="outputDirectoryPath">Metadata write location.</param>
+        public static string WriteMetadata(string metadata, string fileName, string outputDirectoryPath = null)
+        {
+            if (!string.IsNullOrWhiteSpace(outputDirectoryPath) && !Directory.Exists(outputDirectoryPath))
+                Directory.CreateDirectory(outputDirectoryPath);
+            if (string.IsNullOrWhiteSpace(outputDirectoryPath))
+                outputDirectoryPath = Environment.CurrentDirectory;
+
+            var fullFileName = string.Concat(outputDirectoryPath, "\\", fileName);
+
+            File.WriteAllText(fullFileName, metadata);
+            Logger.Info($"Metadata written to {fullFileName}");
+
+            return fullFileName;
+        }
+
+        /// <summary>
         /// Write all generated files to disk
         /// </summary>
         /// <param name="textFilesToWrite">A list of files to write</param>

--- a/src/Typewriter/Generator.cs
+++ b/src/Typewriter/Generator.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Graph.ODataTemplateWriter.TemplateProcessor;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Vipr.Core;
+using Vipr.Reader.OData.v4;
+
+[assembly: InternalsVisibleTo("GraphODataTemplateWriter.Test")]
+
+namespace Typewriter
+{
+    internal static class Generator
+    {
+        /// <summary>
+        /// Generate code files from the input metadata and do not preprocess.
+        /// </summary>
+        /// <param name="csdlContents">Metadata to process</param>
+        /// <param name="options">The options bag</param>
+        static internal void GenerateFiles(string csdlContents, Options options)
+        {
+            var filesToWrite = MetadataToClientSource(csdlContents, options.Language);
+            FileWriter.WriteAsync(filesToWrite, options.Output);
+        }
+
+        /// <summary>
+        /// Generate a metadata file that has been cleaned and doc annotations added to it.
+        /// </summary>
+        /// <param name="csdlContents">Metadata to process</param>
+        /// <param name="options">The options bag</param>
+        static internal void WriteCleanAnnotatedMetadata(string csdlContents, Options options)
+        {
+            string csdlWithDocAnnotations = CleanMetadata(csdlContents, options);
+            string metadataFileName = string.Concat(options.OutputMetadataFileName, options.EndpointVersion, ".xml");
+            FileWriter.WriteMetadata(csdlWithDocAnnotations, metadataFileName, options.Output);
+        }
+
+        /// <summary>
+        /// Clean and annotate the input metadata and then generate code files.
+        /// </summary>
+        /// <param name="csdlContents">Metadata to process</param>
+        /// <param name="options">The options bag</param>
+        static internal void GenerateFilesFromCleanMetadata(string csdlContents, Options options)
+        {
+            string csdlWithDocAnnotations = CleanMetadata(csdlContents, options);
+
+            // Create code files from the CSDL with annotations for the target platform and write those files to disk.
+            GenerateFiles(csdlWithDocAnnotations, options);
+        }
+
+        static private string CleanMetadata(string csdlContents, Options options)
+        {
+            // Clean up EDMX to work with the generators assumptions.
+            string processedCsdlContents = MetadataPreprocessor.CleanMetadata(csdlContents);
+
+            // Create clean metadata and provide a path to it.
+            string pathToCleanMetadata = FileWriter.WriteMetadata(processedCsdlContents, "cleanMetadata.xml");
+
+            // Inject documentation annotations into the CSDL using ApiDoctor and get back the file as a string.
+            return AnnotationHelper.ApplyAnnotationsToCsdl(options, pathToCleanMetadata).Result;
+        }
+
+        /// <summary>
+        /// Generates code files from an edmx file.
+        /// </summary>
+        /// <param name="edmxString">The EDMX file as a string.</param>
+        /// <param name="targetLanguage">Specifies the target language. Possible values are csharp, php, etc.</param>
+        /// <returns></returns>
+        static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage)
+        {
+            if (String.IsNullOrEmpty(edmxString))
+                throw new ArgumentNullException("edmxString", "The EDMX file string contains no content.");
+
+            var reader = new OdcmReader();
+            var writer = new TemplateWriter(targetLanguage);
+            writer.SetConfigurationProvider(new ConfigurationProvider());
+
+            var model = reader.GenerateOdcmModel(new List<TextFile> { new TextFile("$metadata", edmxString) });
+
+            return writer.GenerateProxy(model);
+        }
+    }
+}

--- a/src/Typewriter/Options.cs
+++ b/src/Typewriter/Options.cs
@@ -10,6 +10,25 @@ namespace Typewriter
         Trace
     }
 
+    /// <summary>
+    /// Specifies how Typewriter will processes the input metadata and what type of outputs it produces.
+    /// </summary>
+    public enum GenerationMode
+    {
+        /// <summary>
+        /// (default) Produces the output code files by cleaning the input metadata, parsing the docs, and adding annotations before generating the output files.
+        /// </summary>
+        Full,
+        /// <summary>
+        /// Produces an output metadata file by cleaning metadata, documentation parsing, and adding doc annotations.
+        /// </summary>
+        Metadata,
+        /// <summary>
+        /// Uses the input metadata and only generates code files for the target platform. It bypasses the cleaning, doc parsing, and adding doc annotations.
+        /// </summary>
+        Files
+    }
+
     class Options
     {
         [Option('l', "language", Default = "CSharp", HelpText = "The target language for the generated code files. The values can be: Android, Java, ObjC, CSharp, PHP, Python, TypeScript, or GraphEndpointList")]
@@ -26,5 +45,11 @@ namespace Typewriter
 
         [Option('d', "docs", Default = ".", HelpText = "Path to the root of the documentation repo folder")]
         public string DocsRoot { get; set; }
+
+        [Option('g', "generationmode", Default = GenerationMode.Full, HelpText = "Specifies the generation mode. The values can be: Full, Metadata, or Files. Full generation mode produces " +
+            "the output code files by cleaning the input metadata, parsing the documentation, and adding annotations before generating the output files. Metadata generation mode" +
+            "produces an output metadata file by cleaning metadata, documentation parsing, and adding documentation annotations. Files generation mode produces code files from" +
+            "an input metadata and bypasses the cleaning, documentation parsing, and adding documentation annotations.")]
+        public GenerationMode GenerateMode { get; set; }
     }
 }

--- a/src/Typewriter/Options.cs
+++ b/src/Typewriter/Options.cs
@@ -1,4 +1,7 @@
 ﻿using CommandLine;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("GraphODataTemplateWriter.Test")]
 
 namespace Typewriter
 {
@@ -29,7 +32,7 @@ namespace Typewriter
         Files
     }
 
-    class Options
+    public class Options
     {
         [Option('l', "language", Default = "CSharp", HelpText = "The target language for the generated code files. The values can be: Android, Java, ObjC, CSharp, PHP, Python, TypeScript, or GraphEndpointList")]
         public string Language { get; set; }
@@ -50,6 +53,12 @@ namespace Typewriter
             "the output code files by cleaning the input metadata, parsing the documentation, and adding annotations before generating the output files. Metadata generation mode" +
             "produces an output metadata file by cleaning metadata, documentation parsing, and adding documentation annotations. Files generation mode produces code files from" +
             "an input metadata and bypasses the cleaning, documentation parsing, and adding documentation annotations.")]
-        public GenerationMode GenerateMode { get; set; }
+        public GenerationMode GenerationMode { get; set; }
+
+        [Option('f', "outputMetadataFileName", Default = "cleanMetadataWithDescriptions", HelpText = "The output metadata filename. Only applicable for GenerationMode.Metadata.")]
+        public string OutputMetadataFileName { get; set; }
+
+        [Option('e', "endpointVersion", Default = "v1.0", HelpText = "The endpoint version. Expected values are 'v1.0' and 'beta'. Only applicable for GenerationMode.Metadata.")]
+        public string EndpointVersion { get; set; }
     }
 }

--- a/src/Typewriter/Program.cs
+++ b/src/Typewriter/Program.cs
@@ -45,7 +45,7 @@ namespace Typewriter
                     break;
             }
 
-            stopwatch.Stop();   
+            stopwatch.Stop();
             Logger.Info($"Generation time: {stopwatch.Elapsed } seconds.");
         }
 
@@ -88,25 +88,5 @@ namespace Typewriter
                 Console.Write(item.ToString());
             }
         }
-
-        /// <summary>
-        /// Generates code files from an edmx file.
-        /// </summary>
-        /// <param name="edmxString">The EDMX file as a string.</param>
-        /// <param name="targetLanguage">Specifies the target language. Possible values are csharp, php, etc.</param>
-        /// <returns></returns>
-        //static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage)
-        //{
-        //    if (String.IsNullOrEmpty(edmxString))
-        //        throw new ArgumentNullException("edmxString", "The EDMX file string contains no content.");
-
-        //    var reader = new OdcmReader();
-        //    var writer = new TemplateWriter(targetLanguage);
-        //    writer.SetConfigurationProvider(new ConfigurationProvider());
-
-        //    var model = reader.GenerateOdcmModel(new List<TextFile> { new TextFile("$metadata", edmxString) });
-
-        //    return writer.GenerateProxy(model);
-        //}
     }
 }

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ConfigurationProvider.cs" />
     <Compile Include="DocAnnotationWriter.cs" />
     <Compile Include="FileWriter.cs" />
+    <Compile Include="Generator.cs" />
     <Compile Include="MetadataPreprocessor.cs" />
     <Compile Include="MetadataResolver.cs" />
     <Compile Include="Options.cs" />

--- a/test/Typewriter.Test/GeneratorTests.cs
+++ b/test/Typewriter.Test/GeneratorTests.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace Typewriter.Test
+{
+    [TestClass]
+    [Ignore] // Work is needed to generate from the test project.
+    public class GeneratorTests
+    {
+        public string testMetadata;
+
+        /// <summary>
+        /// Load metadata from file into a string so we can validate MetadataPreprocessor.
+        /// </summary>
+        [TestInitialize]
+        public void Initialize()
+        {
+            testMetadata = Typewriter.Test.Properties.Resources.dirtyMetadata;
+        }
+
+        [TestMethod]
+        public void GenerateFilesTest()
+        {
+            const string outputDirectory = "output"; 
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "TypeScript"
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + @"\com\microsoft\graph\src\Microsoft-graph.d.ts");
+            Assert.IsTrue(fileInfo.Exists);
+        }
+    }
+}

--- a/test/Typewriter.Test/MetadataPreprocessorTests.cs
+++ b/test/Typewriter.Test/MetadataPreprocessorTests.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Xml.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text;
-using Typewriter;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
-using System.Collections.Generic;
+using System.Xml.Linq;
 
 namespace Typewriter.Test
 {

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -29,7 +29,7 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
       </ComplexType>
-      <EntityType Name="onenotePage" BaseType="microsoft.graph.onenoteEntitySchemaObjectModel" HasStream="true">
+      <EntityType Name="onenotePage" HasStream="true">
         <Property Name="content" Type="Edm.Stream" />
         <NavigationProperty Name="parentNotebook" Type="microsoft.graph.notebook" ContainsTarget="true" />
       </EntityType>

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -56,6 +56,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="GeneratorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This allows us to use typewriter in different ways in our build pipeline. There are now three generation options:
* Clean, annotate, and generate output metadata from an input metadata file.
* Generate code files from arbitrary input metadata without cleaning or annotating the metadata.
* Clean and annotate an input metadata before generating code files.