### PR TITLE
Update apidoctor reference

### DIFF
--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ApiDoctor.Publishing">
-      <Version>1.0.0-CI-20181030-211105</Version>
+      <Version>1.0.0-CI-20181115-192733</Version>
     </PackageReference>
     <PackageReference Include="CommandLineParser">
       <Version>2.2.1</Version>


### PR DESCRIPTION
Incorp https://github.com/OneDrive/apidoctor/pull/9

Fixes issue where ApiDoctor built with JSON.Net 6 but NuGet pulls in JSON.Net 7.