### PR TITLE
Use both description and long description annotations

### DIFF
--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -49,9 +49,9 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
 #>
     /**
     * Gets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @return <#=property.Type.GetTypeString()#> The <#=propertyName#>
@@ -77,9 +77,9 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
 
     /**
     * Sets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @param <#=property.Type.GetTypeString()#> $val The value of the <#=propertyName#>
@@ -108,9 +108,9 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
 
     /**
     * Gets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @return <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> The <#=propertyName#>
@@ -135,9 +135,9 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
 
     /**
     * Sets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @param <#=property.Type.GetTypeString()#> $val The value to assign to the <#=property.Name#>

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -69,9 +69,9 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 
      /** 
      * Gets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
      *
      * @return array The <#=propertyName#>
@@ -87,9 +87,9 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     
     /** 
     * Sets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @param <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> $val The <#=propertyName#>
@@ -107,9 +107,9 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 #>
     /**
     * Gets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @return <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> The <#=propertyName#>
@@ -140,9 +140,9 @@ if (property.Type.GetTypeString()[0] == '\\') { #>
     
     /**
     * Sets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @param <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> $val The <#=propertyName#>
@@ -167,9 +167,9 @@ if (property.Type.GetTypeString()[0] == '\\') { #>
 #>
     /**
     * Gets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @return <#=property.Type.GetTypeString()#> The <#=propertyName#>
@@ -195,9 +195,9 @@ if (property.Type.GetTypeString()[0] == '\\') { #>
     
     /**
     * Sets the <#=propertyName#>
-<# if (property.LongDescription != null) {
+<# if (property.LongDescription != null || property.Description != null) {
 #>
-    * <#=property.LongDescription#>
+    * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
     * @param <#=property.Type.GetTypeString()#> $val The <#=propertyName#>

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -37,7 +37,16 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 "double",
                 "string"
             };
+        public static string GetSanitizedLongDescription(this OdcmProperty property)
+        {
+            var description = property.LongDescription ?? property.Description;
 
+            if (description != null)
+            {
+                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+            }
+            return null;
+        }
 
         public static string GetTypeString(this OdcmType @type)
         {


### PR DESCRIPTION
Added support for both description and long description as well sanitizing description strings.

MarkdownScanner to ApiDoctor appeared to change the way doc comments are parsed into the object model. This change addresses that change in the templates.

This will address the issue of the missing descriptions in https://github.com/microsoftgraph/msgraph-sdk-php/pull/116