### PR TITLE
Use description and long description annotations for Java

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -1082,7 +1082,7 @@ public {1} {2}{3}{4} {{";
                 property.Name,
                 propertyType,
                 property.Name.SanitizePropertyName(property).ToLowerFirstChar(),
-				ReplaceInvalidCharacters(property.LongDescription));
+				GetSanitizedDescription(property));
         }
         return sb.ToString();
     }
@@ -1260,4 +1260,14 @@ public {1} {2}{3}{4} {{";
 		}
 		return null;
 	}
+
+    /**
+    * Get the description from the LongDescription or Description annotation and then return the sanitized string.
+    */
+    public string GetSanitizedDescription(OdcmProperty property)
+    {
+        var description = property.LongDescription ?? property.Description;
+
+        return ReplaceInvalidCharacters(description);
+    }
 #>


### PR DESCRIPTION
Added support for both description and long description as well sanitizing description strings.

MarkdownScanner to ApiDoctor appeared to change the way doc comments are parsed into the object model. This change addresses that change in the templates. Want to make sure that we don't miss descriptions. 

I branched this from dev. One thing I didn't understand is why did I generate with the import * everything declarations instead of what I see checked into the repo. Is there a branch that needs to be pulled into dev that you've been using for generation?

![image](https://user-images.githubusercontent.com/8527305/49479499-19a46180-f7d8-11e8-91ff-1605935b2a64.png)
