### PR TITLE
Use description and long description annotations for TS

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -30,8 +30,8 @@ export type <#= enumType.Name.UpperCaseFirstChar() #> = <#= enumType.GetEnumValu
 export interface <#= entityType.Name.UpperCaseFirstChar() #><# if (entityType.Base != null) { #> extends <#=  entityType.Base.Name.UpperCaseFirstChar() #><# }#> {
 
 <# foreach(var prop in entityType.Properties.ToList()) { #>
-	<# if (prop.LongDescription != null) { #>
-    /** <#=prop.LongDescription#> */
+	<# if (prop.LongDescription != null || prop.Description != null) { #>
+    /** <#=prop.GetSanitizedLongDescription()#> */
 	<# } #>
 	<#=  prop.Name #>?: <#= prop.GetTypeString() #>
 
@@ -47,8 +47,8 @@ export interface <#= entityType.Name.UpperCaseFirstChar() #><# if (entityType.Ba
 export interface <#= complexType.Name.UpperCaseFirstChar()#><# if (complexType.Base != null) { #> extends <#=  complexType.Base.Name.UpperCaseFirstChar() #><# }#> {
 
 <# foreach(var prop in complexType.Properties) { #>
-	<# if (prop.LongDescription != null) { #>
-    /** <#=prop.LongDescription#> */
+	<# if (prop.LongDescription != null || prop.Description != null) { #>
+    /** <#=prop.GetSanitizedLongDescription()#> */
 	<# } #>
 	<#= prop.Name #>?: <#= prop.GetTypeString() #>
 

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
@@ -62,12 +62,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
 
         public static string GetSanitizedLongDescription(this OdcmProperty property)
         {
-            var description = property.LongDescription ?? property.Description;
-            if (description != null)
-            {
-                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
-            }
-            return null;
+            return property.LongDescription ?? property.Description;
         }
     }
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
@@ -59,7 +59,15 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         {
             return char.ToUpper(s[0]) + s.Substring(1);
         }
-        
-        
+
+        public static string GetSanitizedLongDescription(this OdcmProperty property)
+        {
+            var description = property.LongDescription ?? property.Description;
+            if (description != null)
+            {
+                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+            }
+            return null;
+        }
     }
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
@@ -62,7 +62,12 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
 
         public static string GetSanitizedLongDescription(this OdcmProperty property)
         {
-            return property.LongDescription ?? property.Description;
+            var description = property.LongDescription ?? property.Description;
+            if (description != null)
+            {
+                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
Added support for both description and long description as well sanitizing description strings.

MarkdownScanner to ApiDoctor appeared to change the way doc comments are parsed into the object model. This change addresses that change in the templates.

This will add many more jsdoc comments.