### PR TITLE
Fixing import statement for java sdk

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -662,10 +662,16 @@
 			foreach (var p in method.Parameters)
 			{
 				if(!(p.Type is OdcmPrimitiveType) && p.Type.GetTypeString() != "com.google.gson.JsonElement") {
+					var propertyType = p.Type.GetTypeString();
+					if(propertyType.StartsWith("EnumSet")){
+						propertyType = propertyType.Substring("EnumSet<".Length, propertyType.Length-("EnumSet<".Length+1));
+						sb.Append("import java.util.EnumSet;\n");
+					}
+						
 					sb.AppendFormat(importFormat,
 						host.CurrentModel.NamespaceName(),
 						getPackagePrefix(p),
-						p.Type.GetTypeString());
+						propertyType);
 					sb.Append("\n");
 				}
 			}


### PR DESCRIPTION
Fixing import statements for request builder classes when an enumset property gets used in the class.
[BaseTeamCloneRequestBuilder.zip](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/files/2679316/BaseTeamCloneRequestBuilder.zip)
