### PR TITLE
Sanitize Parameter variables to fix errors

### DIFF
--- a/Templates/CSharp/Requests/IMethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/IMethodRequest.cs.tt
@@ -173,7 +173,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// </summary>
         /// <param name="<#=returnEntityParameter#>">The <#=returnEntityType#> object set with the properties to update.</param>
         /// <returns>The task to await for async call.</returns>
-        <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter#>);
+        <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>);
 
         /// <summary>
         /// Issues the PATCH request.
@@ -189,7 +189,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter#>, 
+        <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
 <#
     if (returnsStream)
     {
@@ -218,7 +218,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// </summary>
         /// <param name="<#=returnEntityParameter#>">The <#=returnEntityType#> object to update.</param>
         /// <returns>The task to await for async call.</returns>
-        <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter#>);
+        <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>);
 
         /// <summary>
         /// Issues the PUT request.
@@ -234,7 +234,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter#>, 
+        <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
 <#
     if (returnsStream)
     {

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -298,9 +298,9 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// </summary>
         /// <param name="<#=returnEntityParameter#>">The <#=returnEntityType#> object set with the properties to update.</param>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodOverloadReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter#>)
+        public <#=methodOverloadReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>)
         {
-            return this.PatchAsync(<#=returnEntityParameter#>, CancellationToken.None);
+            return this.PatchAsync(<#=returnEntityParameter.GetSanitizedParameterName()#>, CancellationToken.None);
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter#>, 
+        public <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
 <#
     if (returnsStream)
     {
@@ -341,7 +341,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     if (isCollection)
     {
 #>
-            var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter#>, cancellationToken).ConfigureAwait(false);
+            var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
                 if (response.AdditionalData != null)
@@ -376,13 +376,13 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     else if (!string.IsNullOrEmpty(sendAsyncReturnType))
     {
 #>
-            return this.SendAsync<<#=sendAsyncReturnType#>>(<#=returnEntityParameter#>, cancellationToken);
+            return this.SendAsync<<#=sendAsyncReturnType#>>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken);
 <#
     }
     else
     {
 #>
-            return this.SendAsync(<#=returnEntityParameter#>, cancellationToken);
+            return this.SendAsync(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken);
 <#
     }
 #>
@@ -399,9 +399,9 @@ namespace <#=method.Namespace.GetNamespaceName()#>
         /// </summary>
         /// <param name="<#=returnEntityParameter#>">The <#=returnEntityType#> object to update.</param>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodOverloadReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter#>)
+        public <#=methodOverloadReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>)
         {
-            return this.PutAsync(<#=returnEntityParameter#>, CancellationToken.None);
+            return this.PutAsync(<#=returnEntityParameter.GetSanitizedParameterName()#>, CancellationToken.None);
         }
 
         /// <summary>
@@ -418,7 +418,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter#>, 
+        public <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
 <#
     if (returnsStream)
     {
@@ -442,7 +442,7 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     if (isCollection)
     {
 #>
-            var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter#>, cancellationToken).ConfigureAwait(false);
+            var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
                 if (response.AdditionalData != null)
@@ -477,13 +477,13 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     else if (!string.IsNullOrEmpty(sendAsyncReturnType))
     {
 #>
-            return this.SendAsync<<#=sendAsyncReturnType#>>(<#=returnEntityParameter#>, cancellationToken);
+            return this.SendAsync<<#=sendAsyncReturnType#>>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken);
 <#
     }
     else
     {
 #>
-            return this.SendAsync(<#=returnEntityParameter#>, cancellationToken);
+            return this.SendAsync(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken);
 <#
     }
 #>


### PR DESCRIPTION
When generating the SDK, certain parameter names were not being sanitized, which resulted in errors such as myfunc(string string), as opposed to myfunc(string @string). To fix this, I sanitized the parameter .