### PR TITLE
Fix build errors for same method and property name

### DIFF
--- a/GraphODataTemplateWriter.Test/GraphODataTemplateWriter.Test.csproj
+++ b/GraphODataTemplateWriter.Test/GraphODataTemplateWriter.Test.csproj
@@ -40,11 +40,9 @@
     <Reference Include="System.Core" />
     <Reference Include="Vipr.Core">
       <HintPath>..\submodules\vipr\src\Core\Vipr.Core\bin\Debug\Vipr.Core.dll</HintPath>
-      <HintPath>..\submodules\vipr\src\Core\Vipr.Core\bin\Release\Vipr.Core.dll</HintPath>
     </Reference>
     <Reference Include="Vipr.Reader.OData.v4">
       <HintPath>..\submodules\vipr\src\Readers\Vipr.Reader.OData.v4\bin\Debug\Vipr.Reader.OData.v4.dll</HintPath>
-      <HintPath>..\submodules\vipr\src\Readers\Vipr.Reader.OData.v4\bin\Release\Vipr.Reader.OData.v4.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Templates/CSharp/Base/EntityRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/EntityRequestBuilder.Base.template.tt
@@ -142,7 +142,8 @@ public string GetRequestBuilderProperty(string propertyName, string urlValue, st
 
 public string GetCollectionPropertyRequestBuilderProperty(string entityName, OdcmProperty odcmProperty)
 {
-    var propertyName = this.GetPropertyName(odcmProperty).GetSanitizedPropertyName();
+    var propertyName = this.GetPropertyName(odcmProperty);
+    propertyName = propertyName.GetSanitizedPropertyName(suffix: propertyName == "Request" ? "_" : null);
     var propertyPrefix = string.Concat(entityName, this.GetPropertyName(odcmProperty));
     var collectionRequestBuilder = odcmProperty.IsReference()
         ? this.GetCollectionWithReferencesRequestBuilderString(propertyPrefix)
@@ -153,7 +154,8 @@ public string GetCollectionPropertyRequestBuilderProperty(string entityName, Odc
 
 public string GetNonCollectionRequestBuilderProperty(OdcmProperty odcmProperty)
 {
-    var propertyName = this.GetPropertyName(odcmProperty).GetSanitizedPropertyName();
+    var propertyName = this.GetPropertyName(odcmProperty);
+    propertyName = propertyName.GetSanitizedPropertyName(suffix: propertyName == "Request" ? "_" : null);
     var propertyPrefix = this.GetPropertyTypeName(odcmProperty);
     var propertyRequestBuilder = odcmProperty.IsReference()
         ? this.GetWithReferenceRequestBuilderString(propertyPrefix)

--- a/Templates/CSharp/Base/IEntityRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/IEntityRequestBuilder.Base.template.tt
@@ -98,8 +98,9 @@ public string GetRequestBuilderProperty(string propertyName, string requestBuild
 }
 
 public string GetCollectionPropertyRequestBuilderProperty(string entityName, OdcmProperty odcmProperty)
-{
-    var propertyName = this.GetPropertyName(odcmProperty).GetSanitizedPropertyName();
+{   
+    var propertyName = this.GetPropertyName(odcmProperty);
+    propertyName = propertyName.GetSanitizedPropertyName(suffix: propertyName == "Request" ? "_" : null);
     var propertyPrefix = string.Concat(entityName, this.GetPropertyName(odcmProperty));
     var collectionRequestBuilder = odcmProperty.IsReference()
         ? this.GetCollectionWithReferencesRequestBuilderString(propertyPrefix)
@@ -110,7 +111,8 @@ public string GetCollectionPropertyRequestBuilderProperty(string entityName, Odc
 
 public string GetNonCollectionRequestBuilderProperty(OdcmProperty odcmProperty)
 {
-    var propertyName = this.GetPropertyName(odcmProperty).GetSanitizedPropertyName();
+    var propertyName = this.GetPropertyName(odcmProperty);
+    propertyName = propertyName.GetSanitizedPropertyName(suffix: propertyName == "Request" ? "_" : null);
     var propertyPrefix = this.GetPropertyTypeName(odcmProperty);
     var propertyRequestBuilder = odcmProperty.IsReference()
         ? this.GetWithReferenceRequestBuilderString(propertyPrefix)

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -222,9 +222,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             return null;
         }
 
-        public static string GetSanitizedPropertyName(this OdcmProperty property)
+        public static string GetSanitizedPropertyName(this OdcmProperty property, string prefix = null, string suffix = null)
         {
-            return GetSanitizedPropertyName(property.Name);
+            return GetSanitizedPropertyName(property.Name, prefix, suffix);
         }
 
         public static string GetSanitizedClassName(this OdcmClass odcmClass)
@@ -232,9 +232,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             return GetSanitizedClassName(odcmClass.Name, odcmClass);
         }
 
-        public static string GetSanitizedPropertyName(this string property, string prefix = null)
+        public static string GetSanitizedPropertyName(this string property, string prefix = null, string suffix = null)
         {
-            return GetSanitizedPropertyName(property, null, prefix);
+            return GetSanitizedPropertyName(property, null, prefix, suffix);
         }
 
         /// <summary>
@@ -248,34 +248,37 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
         /// <param name="odcmProperty">An OdcmProperty. Use the property that you want to sanitize.</param>
         /// <param name="prefix">The prefix to use on this property.</param>
         /// <returns></returns>
-        public static string GetSanitizedPropertyName(this string property, OdcmProperty odcmProperty, string prefix = null)
+        public static string GetSanitizedPropertyName(this string property, OdcmProperty odcmProperty, string prefix = null, string suffix = null)
         {
+            string result = property;
             if (GetReservedNames().Contains(property))
             {
                 var reservedPrefix = string.IsNullOrEmpty(prefix) ? DefaultReservedPrefix : prefix;
 
                 logger.Info("Property \"{0}\" is a reserved word in .NET. Converting to \"{1}{0}\"", property.ToUpperFirstChar(), reservedPrefix);
-                return string.Concat(reservedPrefix, property.ToUpperFirstChar());
+                result = string.Concat(reservedPrefix, property.ToUpperFirstChar());
             }
-
-            // Check whether the propertyObject is null (means they called the extension from a string).
-            // Check whether the property name is the same as the class name.
-            // Only constructor members may be named the same as the class name.
-            if (odcmProperty != null && property == odcmProperty.Class.Name.ToUpperFirstChar())
+            else if (odcmProperty != null && property == odcmProperty.Class.Name.ToUpperFirstChar())
             {
+                // Check whether the propertyObject is null (means they called the extension from a string).
+                // Check whether the property name is the same as the class name.
+                // Only constructor members may be named the same as the class name.
+
                 // Check whether the property type is the same as the class name.
                 if (odcmProperty.Projection.Type.Name.ToUpperFirstChar() == odcmProperty.Class.Name.ToUpperFirstChar())
                 {
                     // Name the property: {metadataName} + "Property"
                     logger.Info("Property type \"{0}\" has the same name as the class. Converting to \"{0}Property\"", property);
-                    return string.Concat(property, "Property");
+                    result = string.Concat(property, "Property");
                 }
-
-                // Name the property by its type. Sanitize it in case the type is a reserved name.  
-                return odcmProperty.Projection.Type.Name.ToUpperFirstChar().GetSanitizedPropertyName();
+                else
+                {
+                    // Name the property by its type. Sanitize it in case the type is a reserved name.  
+                    result = odcmProperty.Projection.Type.Name.ToUpperFirstChar().GetSanitizedPropertyName();
+                }
             }
 
-            return property;
+            return result+suffix;
         }
 
         public static string GetSanitizedClassName(this string className, OdcmClass odcmClass)


### PR DESCRIPTION
Fixes build errors brought about due to template file instantiating property to have same name as methods within the same class. The commits within this PR perform a specific check to ensure this does not happen, allowing successful build.