### PR TITLE
Add support for specifying properties from the typewriter cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ Typewriter is a new solution for generating code files using the GraphODataTempl
 * **-g**, **-generationmode**: Specifies the generation mode. The values can be: `Full`, `Metadata`, or `Files`. `Full` (default) generation mode produces the output code files by cleaning the input metadata, parsing the documentation, and adding annotations before generating the output files. `Metadata` generation mode produces an output metadata file by cleaning metadata, documentation parsing, and adding documentation annotations. `Files` generation mode produces code files from an input metadata and bypasses the cleaning, documentation parsing, and adding documentation annotations.
 * **-f**, **-outputMetadataFileName**: The base output metadata filename. Only applicable for `-generationmode Metadata`. The default value is `cleanMetadataWithDescriptions` which is used with the value of the `-endpointVersion` to generate a metadata file named `cleanMetadataWithDescriptionsv1.0.xml`.
 * **-e**, **-endpointVersion**: The endpoint version used when naming a metadata file. Expected values are `v1.0` and `beta`. Only applicable for `-generationmode Metadata`.
+* **-p**, **-properties**: Specify properties to support generation logic in the T4 templates. Properties must take the form of *key-string:value-string*. Multiple properties can be specified by setting a space in between property. The only property currently supported is the *php.namespace* property to specify the generated model file namespace. This property is optional.
 
 ### Example typewriter usage
 
-#### Generate TypeScript typings from a CSDL (metadata) file without cleaning or annotating the CSDL. 
+#### Generate TypeScript typings from a CSDL (metadata) file without cleaning or annotating the CSDL.
 
 The output will go in to the `outputTypeScript` directory.
 
 `.\typewriter.exe -v Info -m D:\cleanMetadataWithDescriptions_v10.xml -o outputTypeScript -l TypeScript -g Files`
 
-#### Clean and annotate a metadata file with documentation annotations sourced from the documentation repo 
+#### Clean and annotate a metadata file with documentation annotations sourced from the documentation repo
 
 The output metadata file will go in to the `output2` directory. The output metadata file will be named `cleanMetadataWithDescriptionsv1.0.xml` based on the default values.
 
@@ -144,7 +145,7 @@ The type of template.
 
 #### Template Name
 
-To set the name of the template using the `Name` format string. You can insert `<Class>`, `<Property>`, `<Method>`, and `<Container>` the values will be replaced by the names of the corresponding object.  If you insert an item that doesn't exist it will be replaced with an empty string.  
+To set the name of the template using the `Name` format string. You can insert `<Class>`, `<Property>`, `<Method>`, and `<Container>` the values will be replaced by the names of the corresponding object.  If you insert an item that doesn't exist it will be replaced with an empty string.
 Note: You can also set the template name from inside the template by : `host.SetTemplateName("foo");`
 
 #### Template Editing
@@ -174,9 +175,9 @@ There are currently several steps we take to form the metadata into one that wil
   - Remove HasStream properties from ```onenotePage``` and ```onenoteEntityBaseModel```
   - Add ```ContainsTarget="true"``` to navigation properties that do not have a corresponding EntitySet. This currently applies to navigation properties that contain plannerBucket, plannerTask, plannerPlan, and plannerDelta.
   - Add long descriptions to types and properties from [docs](https://developer.microsoft.com/en-us/graph/docs/concepts/overview)
-  
+
 In order to build against metadata other than that stored in the [metadata](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/tree/master/metadata) directory, you will need to perform the first four on this list.
-  
+
 ## Contributing
 
 Before we can accept your pull request, you'll need to electronically complete Microsoft's [Contributor License Agreement](https://cla.microsoft.com/). If you've done this for other Microsoft projects, then you're already covered.

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -5,14 +5,24 @@
 CustomT4Host host      = (CustomT4Host) Host;
 OdcmModel model        = host.CurrentModel;
 CodeWriterPHP writer   = (CodeWriterPHP) host.CodeWriter;
+TemplateWriterSettings settings = ConfigurationService.Settings;
 OdcmClass complex      = (OdcmClass)host.CurrentType;
 String complexName     = complex.Name.SanitizeEntityName();
+string targetNamespace = @"Microsoft\Graph\Model";
 String complexBaseName = "";
 if (complex.Base != null)
 	complexBaseName = complex.Base.Name.SanitizeEntityName();
+
+// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
+// documentation for more information on how the TemplateWriterSettings.Properties is used.
+if (settings.Properties.ContainsKey("php.namespace"))
+{
+    targetNamespace = settings.Properties["php.namespace"];
+}      
+
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(complexName.ToCheckedCase()))#>
-namespace Microsoft\Graph\Model;
+namespace <#=targetNamespace#>;
 <#=writer.GetClassBlock(complexName.ToCheckedCase().ToString(), "Model")#>
 <#
 if (complex.Base != null) {
@@ -118,7 +128,7 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
     public function get<#=propertyName.ToCheckedCase()#>()
     {
         if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "Microsoft\Graph\Model\<#=property.Type.GetTypeString()#>")) {
+            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=targetNamespace#>\<#=property.Type.GetTypeString()#>")) {
                 return $this->_propDict["<#=property.Name.ToCamelize()#>"];
             } else {
 <# if (property.Type.GetTypeString() == "\\GuzzleHttp\\Psr7\\Stream") { #>

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -8,12 +8,22 @@ CodeWriterPHP writer	        = (CodeWriterPHP) host.CodeWriter;
 OdcmClass entity                = host.CurrentType.AsOdcmClass();
 TemplateWriterSettings settings = ConfigurationService.Settings;
 String entityName               = entity.Name.SanitizeEntityName();
+string targetNamespace          = @"Microsoft\Graph\Model";
 String entityBaseName           = "";
+
 if (entity.Base != null)
 	entityBaseName = entity.Base.Name.SanitizeEntityName();
+
+// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
+// documentation for more information on how the TemplateWriterSettings.Properties is used.
+if (settings.Properties.ContainsKey("php.namespace"))
+{
+    targetNamespace = settings.Properties["php.namespace"];
+}      
+
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(entityName.ToCheckedCase()))#>
-namespace Microsoft\Graph\Model;
+namespace <#=targetNamespace#>;
 
 <#=writer.GetClassBlock(entityName.ToCheckedCase().ToString(), "Model")#>
 <#
@@ -122,7 +132,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 if (property.Type.GetTypeString()[0] == '\\') { #>
             if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=property.Type.GetTypeString()#>")) {
 <# } else { #>
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "Microsoft\Graph\Model\<#=property.Type.GetTypeString()#>")) {
+            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=targetNamespace#>\<#=property.Type.GetTypeString()#>")) {
 <# } #>
                 return $this->_propDict["<#=property.Name.ToCamelize()#>"];
             } else {

--- a/Templates/PHP/Model/EnumType.php.tt
+++ b/Templates/PHP/Model/EnumType.php.tt
@@ -2,14 +2,23 @@
 <#@ template debug="true" hostspecific="true" language="C#" #>
 <#@ output extension="\\" #>
 <#
-CustomT4Host host       = (CustomT4Host) Host;
-OdcmModel model         = host.CurrentModel;
-CodeWriterPHP writer   = (CodeWriterPHP) host.CodeWriter;
+CustomT4Host host               = (CustomT4Host) Host;
+OdcmModel model                 = host.CurrentModel;
+CodeWriterPHP writer            = (CodeWriterPHP) host.CodeWriter;
+TemplateWriterSettings settings = ConfigurationService.Settings;
+string targetNamespace          = @"Microsoft\Graph\Model";
+var enumT                       = host.CurrentType.AsOdcmEnum();
 
-var enumT = host.CurrentType.AsOdcmEnum();
+// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
+// documentation for more information on how the TemplateWriterSettings.Properties is used.
+if (settings.Properties.ContainsKey("php.namespace"))
+{
+    targetNamespace = settings.Properties["php.namespace"];
+}      
+
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(enumT.Name.ToCheckedCase()))#>
-namespace Microsoft\Graph\Model;
+namespace <#=targetNamespace#>;
 
 use Microsoft\Graph\Core\Enum;
 

--- a/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
+++ b/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
         {
             get
             {
-                if (templateWriterSettings == null)
+                if (templateWriterSettings == null || templateWriterSettings.TargetLanguage != ConfigurationService.targetLanguage)
                 {
                     templateWriterSettings = _configurationProvider != null
                         ? LoadSettingsForLanguage()

--- a/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
+++ b/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
@@ -3,21 +3,45 @@
 namespace Microsoft.Graph.ODataTemplateWriter.Settings
 {
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
     using System.Reflection.Emit;
     using Vipr.Core;
 
+    /// <summary>
+    /// The ConfigurationService configures the template writer with the target language and 
+    /// other properties used to direct how the code files are generated.
+    /// </summary>
     public static class ConfigurationService
     {
         private static IConfigurationProvider _configurationProvider;
         private static TemplateWriterSettings templateWriterSettings = null;
         private static string targetLanguage = null;
-        public static void Initialize(IConfigurationProvider configurationProvider, string targetLanguage = null)
+        private static Dictionary<string, string> properties = null;
+
+        public static void Initialize(IConfigurationProvider configurationProvider, string targetLanguage = null, IEnumerable<string> properties = null)
         {
             _configurationProvider = configurationProvider;
             if (!String.IsNullOrEmpty(targetLanguage))
             {
                 ConfigurationService.targetLanguage = targetLanguage;
+            }
+            if (properties != null)
+            {
+                Dictionary<string, string> propertyDictionary = new Dictionary<string, string>();
+                foreach (string property in properties)
+                {
+                    string[] props = property.Split(':');
+
+                    if (props.Length != 2)
+                    {
+                        throw new ArgumentException("A property was set in a unexpected form from the typewriter commandline.", "-p -properties");
+                    }
+
+                    propertyDictionary.Add(props[0],props[1]);
+                }
+
+                ConfigurationService.properties = propertyDictionary;
             }
         }
 
@@ -29,6 +53,11 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
             {
                 mainTWS.TargetLanguage = targetLanguage;
             }
+            if (properties != null)
+            {
+                mainTWS.Properties = properties;
+            }
+
 
             TemplateWriterSettings.mainSettingsObject = mainTWS;
             

--- a/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
+++ b/src/GraphODataTemplateWriter/Settings/TemplateWriterSettings.cs
@@ -102,6 +102,12 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
         private readonly List<Dictionary<string, string>> templateConfiguration;
 
         /// <summary>
+        /// A dictionary of strings that represent a property. These properties can be provided from the command line
+        /// and used in the templates.
+        /// </summary>
+        public Dictionary<string, string> Properties { get; set; }
+
+        /// <summary>
         /// The dictionary created by combining the "Shared" and current language mapping.
         /// </summary>
         public IList<Dictionary<string, string>> TemplateConfiguration

--- a/src/GraphODataTemplateWriter/TemplateProcessor/TemplateProcessor.cs
+++ b/src/GraphODataTemplateWriter/TemplateProcessor/TemplateProcessor.cs
@@ -25,14 +25,11 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
 
         protected static CustomT4Host Host(ITemplateInfo templateInfo, string templatesDirectory, OdcmObject odcmObject, OdcmModel odcmModel)
         {
-            if (_host == null)
-            {
-                _host = new CustomT4Host(templateInfo, templatesDirectory, odcmObject, odcmModel);
-            }
-            else
-            {
-                _host.Reset(templateInfo, templatesDirectory, odcmObject, odcmModel);
-            }
+            // Need to always set the host. Typically, this is run against a single platform when generating codefiels.
+            // In test cases, we need to target multiple platforms. Since much of this code is static, we need to make sure 
+            // reset the information provided to the template processor. This change fixes a bug when targeting 
+            // multiple platforms in a test.
+            _host = new CustomT4Host(templateInfo, templatesDirectory, odcmObject, odcmModel);
 
             return _host;
         }

--- a/src/GraphODataTemplateWriter/TemplateProcessor/TemplateWriter.cs
+++ b/src/GraphODataTemplateWriter/TemplateProcessor/TemplateWriter.cs
@@ -24,6 +24,25 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
         private static Logger logger = LogManager.GetCurrentClassLogger();
 
         private string pathWriterClassNameFormatString;
+        
+        private string targetLanguage;
+        private IEnumerable<string> properties;
+
+        public TemplateWriter()
+        {
+        }
+
+        public TemplateWriter(string targetLanguage)  
+        {
+            this.targetLanguage = targetLanguage;
+        }
+
+        public TemplateWriter(string targetLanguage, IEnumerable<string> properties)
+        {
+            this.targetLanguage = targetLanguage;
+            this.properties = properties;
+        }
+
         private string PathWriterClassNameFormatString
         {
             get {
@@ -76,22 +95,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
             }
         }
 
-        private string targetLanguage;
-
-        public TemplateWriter()
-        {
-
-        }
-
-        public TemplateWriter(string targetLanguage)
-        {
-            this.targetLanguage = targetLanguage;
-        }
-
         // IConfigurationProvider
         public void SetConfigurationProvider(IConfigurationProvider configurationProvider)
         {
-            ConfigurationService.Initialize(configurationProvider, this.targetLanguage);
+            ConfigurationService.Initialize(configurationProvider, this.targetLanguage, this.properties);
             FileNameCasing nameCasing;
             if(!Enum.TryParse(ConfigurationService.Settings.DefaultFileCasing, out nameCasing))
             {

--- a/src/Typewriter/Generator.cs
+++ b/src/Typewriter/Generator.cs
@@ -18,7 +18,7 @@ namespace Typewriter
         /// <param name="options">The options bag</param>
         static internal void GenerateFiles(string csdlContents, Options options)
         {
-            var filesToWrite = MetadataToClientSource(csdlContents, options.Language);
+            var filesToWrite = MetadataToClientSource(csdlContents, options.Language, options.Properties);
             FileWriter.WriteAsync(filesToWrite, options.Output);
         }
 
@@ -65,13 +65,13 @@ namespace Typewriter
         /// <param name="edmxString">The EDMX file as a string.</param>
         /// <param name="targetLanguage">Specifies the target language. Possible values are csharp, php, etc.</param>
         /// <returns></returns>
-        static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage)
+        static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage, IEnumerable<string> properties)
         {
             if (String.IsNullOrEmpty(edmxString))
                 throw new ArgumentNullException("edmxString", "The EDMX file string contains no content.");
 
             var reader = new OdcmReader();
-            var writer = new TemplateWriter(targetLanguage);
+            var writer = new TemplateWriter(targetLanguage, properties);
             writer.SetConfigurationProvider(new ConfigurationProvider());
 
             var model = reader.GenerateOdcmModel(new List<TextFile> { new TextFile("$metadata", edmxString) });

--- a/src/Typewriter/Options.cs
+++ b/src/Typewriter/Options.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("GraphODataTemplateWriter.Test")]
@@ -60,5 +61,10 @@ namespace Typewriter
 
         [Option('e', "endpointVersion", Default = "v1.0", HelpText = "The endpoint version. Expected values are 'v1.0' and 'beta'. Only applicable for GenerationMode.Metadata.")]
         public string EndpointVersion { get; set; }
+
+        [Option('p', "properties",  HelpText = "A space separated list of properties in the form of 'key:value'. These properties can be accessed in the " +
+            "templates from the TemplateWriterSettings object returned by ConfigurationService.Settings. The suggested convention for specifying a key should be " +
+            "the targeted template language name and the property name. For example, php.namespace:Microsoft\\Graph\\Beta\\Model would be a property to be consumed in the PHP templates.")]
+        public IEnumerable<string> Properties { get; set; }
     }
 }

--- a/test/Typewriter.Test/GeneratorTests.cs
+++ b/test/Typewriter.Test/GeneratorTests.cs
@@ -12,7 +12,7 @@ namespace Typewriter.Test
     {
         public string testMetadata;
         // The second segment is generated from the namespace in the target metadata file.
-        public string generatedOutputUrl = @"\com\Graph";
+        public string generatedOutputUrl = @"\com\microsoft\Graph";
 
         /// <summary>
         /// Load metadata from file into a string so we can validate MetadataPreprocessor.
@@ -37,7 +37,7 @@ namespace Typewriter.Test
             Generator.GenerateFiles(testMetadata, options);
 
             FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\src\Microsoft-graph.d.ts");
-            Assert.IsTrue(fileInfo.Exists);
+            Assert.IsTrue(fileInfo.Exists, $"Expected {fileInfo.FullName}. File was not found.");
         }
 
         [TestMethod]

--- a/test/Typewriter.Test/GeneratorTests.cs
+++ b/test/Typewriter.Test/GeneratorTests.cs
@@ -57,7 +57,7 @@ namespace Typewriter.Test
             Generator.GenerateFiles(testMetadata, options);
 
             FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\Entity.php");
-            Assert.IsTrue(fileInfo.Exists, "The expected file was not found.");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
 
             // Check that the namespace applied at the CLI was added to the document.
             IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);

--- a/test/Typewriter.Test/GeneratorTests.cs
+++ b/test/Typewriter.Test/GeneratorTests.cs
@@ -1,13 +1,18 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Typewriter.Test
 {
+    /// <summary>
+    /// End to end tests that check the results of running Typewriter from the CLI.
+    /// </summary>
     [TestClass]
-    [Ignore] // Work is needed to generate from the test project.
     public class GeneratorTests
     {
         public string testMetadata;
+        // The second segment is generated from the namespace in the target metadata file.
+        public string generatedOutputUrl = @"\com\Graph";
 
         /// <summary>
         /// Load metadata from file into a string so we can validate MetadataPreprocessor.
@@ -31,8 +36,41 @@ namespace Typewriter.Test
 
             Generator.GenerateFiles(testMetadata, options);
 
-            FileInfo fileInfo = new FileInfo(outputDirectory + @"\com\microsoft\graph\src\Microsoft-graph.d.ts");
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\src\Microsoft-graph.d.ts");
             Assert.IsTrue(fileInfo.Exists);
+        }
+
+        [TestMethod]
+        public void Validate_PHP_Generated_Beta_Namespace_Tests()
+        {
+            const string testNamespace = "TEST.NAMESPACE";
+            const string outputDirectory = "output";
+            
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "PHP",
+                Properties = new List<string>() { $"php.namespace:{testNamespace}" },
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\Entity.php");
+            Assert.IsTrue(fileInfo.Exists, "The expected file was not found.");
+
+            // Check that the namespace applied at the CLI was added to the document.
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool isExpectedNamespaceSet = false;
+            foreach (var line in lines)
+            {
+                if (line.Contains($"namespace {testNamespace}"))
+                {
+                    isExpectedNamespaceSet = true;
+                    break;
+                }
+            } 
+            Assert.IsTrue(isExpectedNamespaceSet, $"The expected namespace, {testNamespace}, was not set in the generated test file.");
         }
     }
 }

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -8,7 +8,7 @@ namespace Typewriter.Test
     /// End to end tests that check the results of running Typewriter from the CLI.
     /// </summary>
     [TestClass]
-    public class GeneratorTests
+    public class Given_a_valid_metadata_file_to_Typewriter
     {
         public string testMetadata;
         // The second segment is generated from the namespace in the target metadata file.
@@ -24,7 +24,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void GenerateFilesTest()
+        public void It_generates_a_typings_file()
         {
             const string outputDirectory = "output"; 
 
@@ -41,7 +41,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void Validate_PHP_Generated_Beta_Namespace_Tests()
+        public void It_generates_PHP_models_with_a_property()
         {
             const string testNamespace = "TEST.NAMESPACE";
             const string outputDirectory = "output";

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
@@ -5,7 +5,7 @@ using System.Xml.Linq;
 namespace Typewriter.Test
 {
     [TestClass]
-    public class MetadataPreprocessorTests
+    public class Given_a_valid_metadata_file_to_metadata_preprocessor
     {
         public string testMetadata;
         public XDocument testXMetadata;
@@ -22,7 +22,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void RemoveHasStreamTest()
+        public void It_removes_the_HasStream_attribute()
         {
             var entityToProcess = "onenotePage";
 
@@ -44,7 +44,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void AddContainsTargetTest()
+        public void It_adds_the_ContainsTarget_attribute()
         {
             var navPropTypeToProcess = "plannerPlan";
 
@@ -69,7 +69,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void RemoveCapabilityAnnotationsTest()
+        public void It_removes_capability_annotations()
         {
             bool hasCapabilityAnnotationsBefore = MetadataPreprocessor.GetXMetadata().Descendants()
                     .Where(x => (string)x.Name.LocalName == "Annotation")
@@ -86,7 +86,7 @@ namespace Typewriter.Test
         }
 
         [TestMethod]
-        public void AddLongDescriptionToThumbnailTest()
+        public void It_adds_long_description_to_thumbnail()
         {
             XElement thumbnailComplexTypeBefore = MetadataPreprocessor.GetXMetadata().Descendants()
                 .Where(x => (string)x.Name.LocalName == "ComplexType")

--- a/test/Typewriter.Test/MetadataPreprocessorTests.cs
+++ b/test/Typewriter.Test/MetadataPreprocessorTests.cs
@@ -51,7 +51,7 @@ namespace Typewriter.Test
             bool doesntContainTargetBefore = MetadataPreprocessor.GetXMetadata().Descendants()
                     .Where(x => x.Name.LocalName == "NavigationProperty")
                     .Where(x => x.Attribute("ContainsTarget") == null || x.Attribute("ContainsTarget").Value.Equals("false"))
-                    .Where(x => x.Attribute("Type").Value == "Collection(microsoft.graph." + navPropTypeToProcess + ")")
+                    .Where(x => x.Attribute("Type").Value == "Collection(graph." + navPropTypeToProcess + ")")
                     .Any();
 
             Assert.IsTrue(doesntContainTargetBefore, "Expected: ContainsTarget is false. Actual: ContainsTarget is true");
@@ -62,7 +62,7 @@ namespace Typewriter.Test
                     .Where(x => x.Name.LocalName == "NavigationProperty")
                     .Where(x => x.Attribute("ContainsTarget") != null)
                     .Where(x => x.Attribute("ContainsTarget").Value == "true")
-                    .Where(x => x.Attribute("Type").Value == "Collection(microsoft.graph." + navPropTypeToProcess + ")")
+                    .Where(x => x.Attribute("Type").Value == "Collection(graph." + navPropTypeToProcess + ")")
                     .Any();
 
             Assert.IsTrue(doesContainTargetAfter, "Expected: ContainsTarget is true. Actual: ContainsTarget is false");

--- a/test/Typewriter.Test/MetadataPreprocessorTests.cs
+++ b/test/Typewriter.Test/MetadataPreprocessorTests.cs
@@ -51,7 +51,7 @@ namespace Typewriter.Test
             bool doesntContainTargetBefore = MetadataPreprocessor.GetXMetadata().Descendants()
                     .Where(x => x.Name.LocalName == "NavigationProperty")
                     .Where(x => x.Attribute("ContainsTarget") == null || x.Attribute("ContainsTarget").Value.Equals("false"))
-                    .Where(x => x.Attribute("Type").Value == "Collection(graph." + navPropTypeToProcess + ")")
+                    .Where(x => x.Attribute("Type").Value == $"Collection(microsoft.graph.{navPropTypeToProcess})")
                     .Any();
 
             Assert.IsTrue(doesntContainTargetBefore, "Expected: ContainsTarget is false. Actual: ContainsTarget is true");
@@ -62,7 +62,7 @@ namespace Typewriter.Test
                     .Where(x => x.Name.LocalName == "NavigationProperty")
                     .Where(x => x.Attribute("ContainsTarget") != null)
                     .Where(x => x.Attribute("ContainsTarget").Value == "true")
-                    .Where(x => x.Attribute("Type").Value == "Collection(graph." + navPropTypeToProcess + ")")
+                    .Where(x => x.Attribute("Type").Value == $"Collection(microsoft.graph.{navPropTypeToProcess})")
                     .Any();
 
             Assert.IsTrue(doesContainTargetAfter, "Expected: ContainsTarget is true. Actual: ContainsTarget is false");

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -8,18 +8,18 @@
         </Key>
         <Property Name="id" Unicode="false" Nullable="false" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="testType"></EntityType>
-      <EntityType Name="testType2"></EntityType>
-      <EntityType Name="testType3"></EntityType>
-      <EntityType Name="testEntity">
+      <EntityType Name="testType" BaseType="graph.entity"></EntityType>
+      <EntityType Name="testType2" BaseType="graph.entity"></EntityType>
+      <EntityType Name="testType3" BaseType="graph.entity"></EntityType>
+      <EntityType Name="testEntity" BaseType="graph.entity">
         <NavigationProperty Name="testNav" Type="graph.testType"/>
         <NavigationProperty Name="testInvalidNav" Type="graph.testType2"/>
         <NavigationProperty Name="testExplicitNav" Type="graph.testType3"/>
       </EntityType>
-      <EntityType Name="testSingleton">
+      <EntityType Name="testSingleton" BaseType="graph.entity">
         <NavigationProperty Name="testSingleNav" Type="graph.testType" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="testSingleton2">
+      <EntityType Name="testSingleton2" BaseType="graph.entity">
         <NavigationProperty Name="testSingleNav2" Type="graph.testType3" ContainsTarget="true" />
       </EntityType>
       <ComplexType Name="thumbnail">
@@ -29,19 +29,19 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
       </ComplexType>
-      <EntityType Name="onenotePage" HasStream="true">
+      <EntityType Name="onenotePage" HasStream="true" BaseType="graph.entity">
         <Property Name="content" Type="Edm.Stream" />
-        <NavigationProperty Name="parentNotebook" Type="microsoft.graph.notebook" ContainsTarget="true" />
+        <NavigationProperty Name="parentNotebook" Type="graph.notebook" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="plannerGroup" BaseType="microsoft.graph.entity">
-        <NavigationProperty Name="plans" Type="Collection(microsoft.graph.plannerPlan)" />
+      <EntityType Name="plannerGroup" BaseType="graph.entity">
+        <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)" />
       </EntityType>
       <EntityContainer Name="GraphService">
         <Singleton Name="testSingleton" Type="graph.testSingleton"/>
         <Singleton Name="testSingleton2" Type="graph.testSingleton2"/>
         <EntitySet Name="testTypes" EntityType="graph.testType3"/>
       </EntityContainer>
-      <Annotations Target="microsoft.graph.directoryObject">
+      <Annotations Target="graph.directoryObject">
         <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
           <Record>
             <PropertyValue Property="Expandable" Bool="false" />

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:DataServices>
-    <Schema Namespace="graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+    <Schema Namespace="microsoft.graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="entity">
         <Key>
           <PropertyRef Name="id"/>
         </Key>
         <Property Name="id" Unicode="false" Nullable="false" Type="Edm.String"/>
       </EntityType>
-      <EntityType Name="testType" BaseType="graph.entity"></EntityType>
-      <EntityType Name="testType2" BaseType="graph.entity"></EntityType>
-      <EntityType Name="testType3" BaseType="graph.entity"></EntityType>
-      <EntityType Name="testEntity" BaseType="graph.entity">
-        <NavigationProperty Name="testNav" Type="graph.testType"/>
-        <NavigationProperty Name="testInvalidNav" Type="graph.testType2"/>
-        <NavigationProperty Name="testExplicitNav" Type="graph.testType3"/>
+      <EntityType Name="testType" BaseType="microsoft.graph.entity"></EntityType>
+      <EntityType Name="testType2" BaseType="microsoft.graph.entity"></EntityType>
+      <EntityType Name="testType3" BaseType="microsoft.graph.entity"></EntityType>
+      <EntityType Name="testEntity" BaseType="microsoft.graph.entity">
+        <NavigationProperty Name="testNav" Type="microsoft.graph.testType"/>
+        <NavigationProperty Name="testInvalidNav" Type="microsoft.graph.testType2"/>
+        <NavigationProperty Name="testExplicitNav" Type="microsoft.graph.testType3"/>
       </EntityType>
-      <EntityType Name="testSingleton" BaseType="graph.entity">
-        <NavigationProperty Name="testSingleNav" Type="graph.testType" ContainsTarget="true" />
+      <EntityType Name="testSingleton" BaseType="microsoft.graph.entity">
+        <NavigationProperty Name="testSingleNav" Type="microsoft.graph.testType" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="testSingleton2" BaseType="graph.entity">
-        <NavigationProperty Name="testSingleNav2" Type="graph.testType3" ContainsTarget="true" />
+      <EntityType Name="testSingleton2" BaseType="microsoft.graph.entity">
+        <NavigationProperty Name="testSingleNav2" Type="microsoft.graph.testType3" ContainsTarget="true" />
       </EntityType>
       <ComplexType Name="thumbnail">
         <Property Name="content" Type="Edm.Stream" />
@@ -29,19 +29,19 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
       </ComplexType>
-      <EntityType Name="onenotePage" HasStream="true" BaseType="graph.entity">
+      <EntityType Name="onenotePage" HasStream="true" BaseType="microsoft.graph.entity">
         <Property Name="content" Type="Edm.Stream" />
-        <NavigationProperty Name="parentNotebook" Type="graph.notebook" ContainsTarget="true" />
+        <NavigationProperty Name="parentNotebook" Type="microsoft.graph.notebook" ContainsTarget="true" />
       </EntityType>
-      <EntityType Name="plannerGroup" BaseType="graph.entity">
-        <NavigationProperty Name="plans" Type="Collection(graph.plannerPlan)" />
+      <EntityType Name="plannerGroup" BaseType="microsoft.graph.entity">
+        <NavigationProperty Name="plans" Type="Collection(microsoft.graph.plannerPlan)" />
       </EntityType>
       <EntityContainer Name="GraphService">
-        <Singleton Name="testSingleton" Type="graph.testSingleton"/>
-        <Singleton Name="testSingleton2" Type="graph.testSingleton2"/>
-        <EntitySet Name="testTypes" EntityType="graph.testType3"/>
+        <Singleton Name="testSingleton" Type="microsoft.graph.testSingleton"/>
+        <Singleton Name="testSingleton2" Type="microsoft.graph.testSingleton2"/>
+        <EntitySet Name="testTypes" EntityType="microsoft.graph.testType3"/>
       </EntityContainer>
-      <Annotations Target="graph.directoryObject">
+      <Annotations Target="microsoft.graph.directoryObject">
         <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
           <Record>
             <PropertyValue Property="Expandable" Bool="false" />

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -49,14 +49,14 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MetadataPreprocessorTests.cs" />
+    <Compile Include="Given_a_valid_metadata_file_to_metadata_preprocessor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="GeneratorTests.cs" />
+    <Compile Include="Given_a_valid_metadata_file_to_Typewriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Typewriter can now support properties to be specified from the CLI and used in the templates. This option should only be used when:
* We can't update target metadata either by having workload teams fix their metadata, or by alteration with the metadata preprocessor.
* We can't make a fix in the templates or template logic by themselves.
* We need to inject control data at runtime.

The specified properties can be accessed from the templates. We needed this for beta PHP file generation since it uses a different namespace.

The attached file demonstrates the file generated from the test case where it injects a custom namespace.
[Entity.txt](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/files/2819516/Entity.txt)

## Change summary

* Updated the readme with information on the new command line option.
* Updated the PHP model templates to access the property bag and inject a beta namespace if applicable.
* Updated the ConfigurationService to accept the optional property bag and to update the templateWriterSettings in case we are running tests that target multiple languages in the same test suite. This last part is necessary since we are dealing with a lot of static members. 
* Updated the TemplateProcessor  to always provide a new T4 host. This is required as we need to update the host so that the appropriate language specific *CodeWriter.cs is used in the template processor and accessed from the templates.
* Updated tests and test metadata.