### PR TITLE
Support updating the default base Graph URL

### DIFF
--- a/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
+++ b/src/GraphODataTemplateWriter/Settings/ConfigurationService.cs
@@ -17,10 +17,13 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
         private static IConfigurationProvider _configurationProvider;
         private static TemplateWriterSettings templateWriterSettings = null;
         private static string targetLanguage = null;
+        private static string endpointVersion = null;
         private static Dictionary<string, string> properties = null;
 
-        public static void Initialize(IConfigurationProvider configurationProvider, string targetLanguage = null, IEnumerable<string> properties = null)
+        public static void Initialize(IConfigurationProvider configurationProvider, string targetLanguage = null, IEnumerable<string> properties = null, string endpointVersion = "v1.0")
         {
+            ConfigurationService.endpointVersion = endpointVersion;
+
             _configurationProvider = configurationProvider;
             if (!String.IsNullOrEmpty(targetLanguage))
             {
@@ -58,6 +61,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Settings
                 mainTWS.Properties = properties;
             }
 
+            mainTWS.DefaultBaseEndpointUrl = String.Format("https://graph.microsoft.com/{0}", endpointVersion);
 
             TemplateWriterSettings.mainSettingsObject = mainTWS;
             

--- a/src/GraphODataTemplateWriter/TemplateProcessor/TemplateWriter.cs
+++ b/src/GraphODataTemplateWriter/TemplateProcessor/TemplateWriter.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
         
         private string targetLanguage;
         private IEnumerable<string> properties;
+        private string endpointVersion;
 
         public TemplateWriter()
         {
@@ -41,6 +42,13 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
         {
             this.targetLanguage = targetLanguage;
             this.properties = properties;
+        }
+
+        public TemplateWriter(string targetLanguage, IEnumerable<string> properties, string endpointVersion)
+        {
+            this.targetLanguage = targetLanguage;
+            this.properties = properties;
+            this.endpointVersion = endpointVersion;
         }
 
         private string PathWriterClassNameFormatString
@@ -98,7 +106,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
         // IConfigurationProvider
         public void SetConfigurationProvider(IConfigurationProvider configurationProvider)
         {
-            ConfigurationService.Initialize(configurationProvider, this.targetLanguage, this.properties);
+            ConfigurationService.Initialize(configurationProvider, this.targetLanguage, this.properties, this.endpointVersion);
             FileNameCasing nameCasing;
             if(!Enum.TryParse(ConfigurationService.Settings.DefaultFileCasing, out nameCasing))
             {

--- a/src/Typewriter/Generator.cs
+++ b/src/Typewriter/Generator.cs
@@ -18,7 +18,7 @@ namespace Typewriter
         /// <param name="options">The options bag</param>
         static internal void GenerateFiles(string csdlContents, Options options)
         {
-            var filesToWrite = MetadataToClientSource(csdlContents, options.Language, options.Properties);
+            var filesToWrite = MetadataToClientSource(csdlContents, options.Language, options.Properties, options.EndpointVersion);
             FileWriter.WriteAsync(filesToWrite, options.Output);
         }
 
@@ -65,13 +65,13 @@ namespace Typewriter
         /// <param name="edmxString">The EDMX file as a string.</param>
         /// <param name="targetLanguage">Specifies the target language. Possible values are csharp, php, etc.</param>
         /// <returns></returns>
-        static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage, IEnumerable<string> properties)
+        static private IEnumerable<TextFile> MetadataToClientSource(string edmxString, string targetLanguage, IEnumerable<string> properties, string endpointVersion = "v1.0")
         {
             if (String.IsNullOrEmpty(edmxString))
                 throw new ArgumentNullException("edmxString", "The EDMX file string contains no content.");
 
             var reader = new OdcmReader();
-            var writer = new TemplateWriter(targetLanguage, properties);
+            var writer = new TemplateWriter(targetLanguage, properties, endpointVersion);
             writer.SetConfigurationProvider(new ConfigurationProvider());
 
             var model = reader.GenerateOdcmModel(new List<TextFile> { new TextFile("$metadata", edmxString) });

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -72,5 +72,39 @@ namespace Typewriter.Test
             } 
             Assert.IsTrue(isExpectedNamespaceSet, $"The expected namespace, {testNamespace}, was not set in the generated test file.");
         }
+
+        [TestMethod]
+        public void It_generates_dotNet_client_with_default_beta_baseUrl()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files,
+                EndpointVersion = "beta"
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\GraphServiceClient.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            // Check that the beta endpoint was set as the default endpoint. Otherwise it uses v1.0.
+            // https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/src/Microsoft.Graph/Requests/Generated/GraphServiceClient.cs#L25
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasFoundBetaUrl = false;
+            string betaUrl = "https://graph.microsoft.com/beta";
+            foreach (var line in lines)
+            {
+                if (line.Contains(betaUrl))
+                {
+                    hasFoundBetaUrl = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(hasFoundBetaUrl, $"The expected default base URL, {betaUrl}, was not set in the generated test file.");
+        }
     }
 }


### PR DESCRIPTION
Via the endpointVersion argument.

![image](https://user-images.githubusercontent.com/8527305/53764878-648b4f00-3e83-11e9-8aab-3829ea075775.png)

This change will affect the following templates:
https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/blob/dev/Templates/CSharp/Requests/EntityClient.cs.tt#L25
