### PR TITLE
Handle CRLF in doc annotations as code comments.

### DIFF
--- a/GraphODataTemplateWriter.Test/TypeHelperTests.cs
+++ b/GraphODataTemplateWriter.Test/TypeHelperTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp;
+using Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript;
+using Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vipr.Core.CodeModel;
+
+
+namespace GraphODataTemplateWriter.Test
+{
+    [TestClass]
+    public class TypeHelperTests
+    {
+        OdcmProperty testProperty;
+        string actualInputString = "\r\n Test string";
+        string expectedOutputString = "\r\n/// Test string";
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            testProperty = new OdcmProperty("testPropertyName");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides long descriptions without uncommented lines of text.
+        /// </summary>
+        [TestMethod]
+        public void Long_Description_Doesnt_Contain_Uncommented_NewLine_For_CSharp()
+        {
+            testProperty.LongDescription = actualInputString;
+            string sanitizedString = TypeHelperCSharp.GetSanitizedLongDescription(testProperty); // Explicitly bind to extension method.
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides descriptions without uncommented lines of text.
+        /// </summary>
+        [TestMethod]
+        public void Description_Doesnt_Contain_Uncommented_NewLine_For_CSharp()
+        {
+            testProperty.Description = actualInputString;
+            string sanitizedString = TypeHelperCSharp.GetSanitizedLongDescription(testProperty);
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides long descriptions without uncommented lines of text for Typescript.
+        /// </summary>
+        [TestMethod]
+        public void Long_Description_Doesnt_Contain_Uncommented_NewLine_For_Typescript()
+        {
+            testProperty.LongDescription = actualInputString;
+            string sanitizedString = TypeHelperTypeScript.GetSanitizedLongDescription(testProperty); // Explicitly bind to extension method.
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides descriptions without uncommented lines of text for Typescript.
+        /// </summary>
+        [TestMethod]
+        public void Description_Doesnt_Contain_Uncommented_NewLine_For_Typescript()
+        {
+            testProperty.Description = actualInputString;
+            string sanitizedString = TypeHelperTypeScript.GetSanitizedLongDescription(testProperty);
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides long descriptions without uncommented lines of text for PHP.
+        /// </summary>
+        [TestMethod]
+        public void Long_Description_Doesnt_Contain_Uncommented_NewLine_For_PHP()
+        {
+            testProperty.LongDescription = actualInputString;
+            string sanitizedString = TypeHelperPHP.GetSanitizedLongDescription(testProperty); // Explicitly bind to extension method.
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+
+        /// <summary>
+        /// Test that GetSanitizedLongDescription provides descriptions without uncommented lines of text for PHP.
+        /// </summary>
+        [TestMethod]
+        public void Description_Doesnt_Contain_Uncommented_NewLine_For_PHP()
+        {
+            testProperty.Description = actualInputString;
+            string sanitizedString = TypeHelperPHP.GetSanitizedLongDescription(testProperty);
+
+            Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
+        }
+    }
+}

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -217,7 +217,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 
             if (description != null)
             {
-                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+                return description.Replace("<", "&lt;")
+                                  .Replace(">", "&gt;")
+                                  .Replace("&", "&amp;")
+                                  .Replace("\r\n", "\r\n///"); // &#xD;&#xA; The HTML encoded has already been converted to escaped chars.
             }
             return null;
         }

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
 
             if (description != null)
             {
-                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+                return description.Replace("<", "&lt;")
+                                  .Replace(">", "&gt;")
+                                  .Replace("&", "&amp;")
+                                  .Replace("\r\n", "\r\n///"); // &#xD;&#xA; The HTML encoded has already been converted to escaped chars.
             }
             return null;
         }

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeHelperTypeScript.cs
@@ -66,7 +66,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
             var description = property.LongDescription ?? property.Description;
             if (description != null)
             {
-                return description.Replace("<", "&lt;").Replace(">", "&gt;").Replace("&", "&amp;");
+                return description.Replace("<", "&lt;")
+                                  .Replace(">", "&gt;")
+                                  .Replace("&", "&amp;")
+                                  .Replace("\r\n", "\r\n///"); // &#xD;&#xA; The HTML encoded has already been converted to escaped chars.
             }
             return null;
         }

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -106,5 +106,39 @@ namespace Typewriter.Test
             }
             Assert.IsTrue(hasFoundBetaUrl, $"The expected default base URL, {betaUrl}, was not set in the generated test file.");
         }
+
+
+        [TestMethod]
+        public void It_generates_dotNet_client_with_commented_out_code_comments()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\OnenotePage.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            // Check that the test string is found in the output file. Converting "&#xD;&#xA; Test token string" to "/// Test token string" is what we are testing.
+            // We are making sure that the documentation annotation is handled correctly for this scenario.
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            string testString = @"/// Test token string";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We are not correctly handling the \r\n coming from the annotations.");
+        }
     }
 }

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -41,6 +41,9 @@
         <Singleton Name="testSingleton2" Type="microsoft.graph.testSingleton2"/>
         <EntitySet Name="testTypes" EntityType="microsoft.graph.testType3"/>
       </EntityContainer>
+      <Annotations Target="microsoft.graph.onenotePage/content">
+        <Annotation Term="Org.OData.Core.V1.Description" String="The OneNotePage content.&#xD;&#xA;&#xD;&#xA; Test token string" />
+      </Annotations>
       <Annotations Target="microsoft.graph.directoryObject">
         <Annotation Term="Org.OData.Capabilities.V1.ExpandRestrictions">
           <Record>


### PR DESCRIPTION
Fixes #187 

HTML encoded CRLF in doc annotations gets converted to escaped chars \r\n. We need to make sure we emit the new line doc comments with ///. Updated C#, PHP, and Typescript to support this.