### PR TITLE
Changing I<*>RequestBuilder : IBaseRequestBuilder

### DIFF
--- a/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
@@ -40,7 +40,7 @@ public string GetInterfaceDefinition(string interfaceName)
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("    /// </summary>");
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("    public partial interface I{0}", interfaceName);
+    stringBuilder.AppendFormat("    public partial interface I{0} : IBaseRequestBuilder", interfaceName);
 
     return stringBuilder.ToString();
 }


### PR DESCRIPTION
today:
```cs
interface ICallParticipantsCollectionRequestBuilder
{
}
```

proposed change:
```cs
interface ICallParticipantsCollectionRequestBuilder : IBaseRequestBuilder
{
}
```

As far as I can tell, the method altered (`GetInterfaceDefinition`) is only reference by the following templates:
```cs
ICollectionRequestBuilder.Base.template.tt:
public string GetCollectionInterfaceDefinition(OdcmProperty odcmProperty);
public string GetCollectionReferencesInterfaceDefinition(OdcmProperty odcmProperty);
public string GetCollectionWithReferencesInterfaceDefinition(OdcmProperty odcmProperty);

IEntityRequestBuilder.Base.template.tt:
public string GetEntityReferenceRequestBuilderInterfaceDefinition(OdcmClass odcmClass);
public string GetEntityWithReferenceRequestBuilderInterfaceDefinition(OdcmClass odcmClass);
```

so it will change all these types to inherit from `IRequestBuilder`:
```cs
ICollectionRequestBuilder.Base.template.tt:
interface IOnenoteNotebooksCollectionRequestBuilder : IBaseRequestBuilder { }
interface IUserRegisteredDevicesCollectionReferencesRequestBuilder : IBaseRequestBuilder {}
interface IUserRegisteredDevicesCollectionWithReferencesRequestBuilder : IBaseRequestBuilder {}

IEntityRequestBuilder.Base.template.tt:
interface IUserReferenceRequestBuilder : IBaseRequestBuilder { }
interface IUserWithReferenceRequestBuilder : IBaseRequestBuilder { }
```

in all these cases the concrete implementation **already inherits** from `BaseRequestBuilder`:
```cs
CollectionRequestBuilder.Base.template.tt:
class OnenoteNotebooksCollectionRequestBuilder : BaseRequestBuilder, IOnenoteNotebooksCollectionRequestBuilder {}
class UserRegisteredDevicesCollectionReferencesRequestBuilder : BaseRequestBuilder, IUserRegisteredDevicesCollectionReferencesRequestBuilder {}
class UserRegisteredDevicesCollectionWithReferencesRequestBuilder : BaseRequestBuilder, IUserRegisteredDevicesCollectionWithReferencesRequestBuilder {}

EntityRequestBuilder.Base.template.tt:
class UserReferenceRequestBuilder : BaseRequestBuilder, IUserReferenceRequestBuilder {}
class UserWithReferenceRequestBuilder : BaseRequestBuilder, IUserWithReferenceRequestBuilder {}
```

With this change the `IRequestBuilder.Base.template.tt` will match the `RequestBuilder.Base.template.tt`:
```cs
public string GetClassDefinition(string className)
{
    var stringBuilder = new StringBuilder();

    stringBuilder.Append("/// <summary>");
    stringBuilder.Append(Environment.NewLine);
    stringBuilder.AppendFormat("    /// The type {0}.", className);
    stringBuilder.Append(Environment.NewLine);
    stringBuilder.Append("    /// </summary>");
    stringBuilder.Append(Environment.NewLine);
    stringBuilder.AppendFormat("    public partial class {0} : BaseRequestBuilder, I{0}", className);

    return stringBuilder.ToString();
}
```