### PR TITLE
Fix for enum naming for camelcased+underscore scenario

### DIFF
--- a/Templates/PHP/Model/EnumType.php.tt
+++ b/Templates/PHP/Model/EnumType.php.tt
@@ -42,7 +42,7 @@ class <#=enumT.Name.ToUpperFirstChar()#> extends Enum
 <#
 		} else {
 #>
-    const <#= value.Name.ToUnderscore().ToUpper()#> = "<#= value.Name.ToCamelize()#>";
+    const <#= value.Name.ToUnderscorePHPEnum().ToUpper()#> = "<#= value.Name#>";
 <#		}
 	count++;
     }

--- a/Templates/PHP/Model/EnumType.php.tt
+++ b/Templates/PHP/Model/EnumType.php.tt
@@ -42,7 +42,7 @@ class <#=enumT.Name.ToUpperFirstChar()#> extends Enum
 <#
 		} else {
 #>
-    const <#= value.Name.ToUnderscorePHPEnum().ToUpper()#> = "<#= value.Name#>";
+    const <#= value.Name.ToUnderscorePHPEnum().ToUpper()#> = "<#= value.Name.ToCamelize()#>";
 <#		}
 	count++;
     }

--- a/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
@@ -72,6 +72,26 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             return Inflector.Inflector.Underscore(input);
         }
 
+        /// <summary>
+        /// Replaces underscores with double underscore, adds underscore between camel
+        /// case, converts hypehns to underscore.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string ToUnderscorePHPEnum(this string input)
+        {
+            return Regex.Replace(
+                        Regex.Replace(
+                            Regex.Replace(
+                                Regex.Replace(input, @"([_\s])([A-Z])", "$1_$2"), 
+                                    @"([a-z\d])([A-Z])",
+                                    "$1_$2"),
+                                @"([A-Z]+)([A-Z][a-z])", "$1_$2"),
+                            @"[-\s]",
+                            "_")
+                        .ToLower();
+        }
+
         public static string RemoveFromEnd(this string input, string suffix)
         {
             if (input.EndsWith(suffix))

--- a/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
 
         /// <summary>
         /// Replaces underscores with double underscore, adds underscore between camel
-        /// case, converts hypehns to underscore.
+        /// case, converts hyphens to underscore. It does the same as ToUnderscore but 
+        /// adds the double underscore capability.
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>


### PR DESCRIPTION
This change only impacts 2 entities in beta. It basically makes the underscoring rule also be applicable to existing underscores. This fix unblocks beta generation for PHP. This fixes [PHP#167](https://github.com/microsoftgraph/msgraph-sdk-php/issues/167).

This change fixes the generation scenario where two different member names are similar by having camelcase with preceding underscores like this:

        <Member Name="remoteControlSoftware" Value="25" />
        <Member Name="remote_Control_Software" Value="33" />

The above member names *were* both being generated as REMOTE_CONTROL_SOFTWARE. This fix differentiates the two as seen in image 1. Image 2 shows the other enum affected by this template change.

**Image 1. Change made to WindowsMalwareCategory.php by this change. This is the target that is blocking beta generation**
![image](https://user-images.githubusercontent.com/8527305/56442956-5bc1d180-62a7-11e9-9d51-d43c4c4bb654.png)

**Image 2. Change made to DeviceManagementSubscriptions.php by this change.**
![image](https://user-images.githubusercontent.com/8527305/56443139-1f42a580-62a8-11e9-9d82-b82b600273be.png)
