### PR TITLE
Add contains target for new Intune entities.

### DIFF
--- a/src/Typewriter/MetadataPreprocessor.cs
+++ b/src/Typewriter/MetadataPreprocessor.cs
@@ -62,9 +62,12 @@ namespace Typewriter
             AddContainsTarget("managedDeviceCertificateState");
             AddContainsTarget("deviceManagementSettingInstance");
 
-            AddContainsTarget("onPremisesAgentGroup"); 
+            AddContainsTarget("onPremisesAgentGroup");
             AddContainsTarget("onPremisesAgent");
             AddContainsTarget("publishedResource");
+
+            AddContainsTarget("appVulnerabilityManagedDevice");
+            AddContainsTarget("appVulnerabilityMobileApp");
 
             return xMetadata.ToString();
         }


### PR DESCRIPTION
This PR fixes broken beta build by setting`ContainsTarget="true"` to indicate containment for new Intune entities.