### PR TITLE
Disambiguation for base and cstor on EntityType

### DIFF
--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -8,9 +8,10 @@ var entityName = entity.Name.ToCheckedCase();
 
 var typeDeclaration = entityName;
 
+
 // In the case a entity type name ends with "Request", we will have a collision with the Request objects
-// when we generate. For example, there are entities named EventMessage and EventMessageRequest. Those entities 
-// lead to the generation of an EventMessageRequest and EventMessageRequestRequest request objects in the same 
+// when we generate. For example, there are entities named EventMessage and EventMessageRequest. Those entities
+// lead to the generation of an EventMessageRequest and EventMessageRequestRequest request objects in the same
 // namespace as the entities. We add 'Object' to the end of the name to disambiguate the entity.
 // This change needs to sync with changes for the *Request templates.
 
@@ -19,10 +20,18 @@ if (typeDeclaration.EndsWith("Request"))
     typeDeclaration = String.Concat(typeDeclaration, "Object");
 }
 
+string cstorTypeDeclaration = typeDeclaration;
 
 if (entity.Base != null)
 {
-    typeDeclaration = string.Format("{0} : {1}", typeDeclaration, entity.Base.Name.ToCheckedCase());
+    var baseTypeDeclaration = entity.Base.Name.ToCheckedCase();
+
+    if (baseTypeDeclaration.EndsWith("Request"))
+    {
+        baseTypeDeclaration = String.Concat(baseTypeDeclaration, "Object");
+    }
+
+    typeDeclaration = string.Format("{0} : {1}", typeDeclaration, baseTypeDeclaration);
 }
 
 var attributeStringBuilder = new StringBuilder();
@@ -60,7 +69,7 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
 		///<summary>
 		/// The internal <#=entityName#> constructor
 		///</summary>
-        protected internal <#=entityName#>()
+        protected internal <#=cstorTypeDeclaration#>()
         {
             // Don't allow initialization of abstract entity types
         }

--- a/src/Typewriter/MetadataPreprocessor.cs
+++ b/src/Typewriter/MetadataPreprocessor.cs
@@ -55,6 +55,11 @@ namespace Typewriter
             AddContainsTarget("itemActivity");
             AddContainsTarget("labelPolicy");
 
+            // RoleManagement singleton
+            AddContainsTarget("unifiedRoleDefinition");
+
+            
+
             // Intune
             AddContainsTarget("windows81TrustedRootCertificate");
             AddContainsTarget("iosTrustedRootCertificate");


### PR DESCRIPTION
This is related to 9850b8342e0d7649ab4a6ae69ce197dc2f0dd2a6
Fixes #212

When running this against https://github.com/microsoftgraph/msgraph-metadata/blob/a59f43e83cda8f097d7a5e6dd71516438fcb2267/beta_metadata.xml with the generator before and after changes, we see the changes in the following files:
* ScheduleChangeRequest.cs
* ShiftChangeRequest.cs
* SwapShiftsChangeRequest.cs
* TimeOffRequest.cs

The following example shows the potential changes made by this update:
![image](https://user-images.githubusercontent.com/8527305/63302808-f3a1ed00-c292-11e9-9890-2696271977d5.png)

@bilalgce This may have implications for Java.

- [x] Validate by merging changes into .NET SDK and build