### PR TITLE
Init OData.Type on complex and entity types.

### DIFF
--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -43,10 +43,8 @@ namespace <#=complex.Namespace.GetNamespaceName()#>
     public <#=classType#> <#=typeDeclaration#>
     {
 <#
-// Generate a constructor to initialize the @odata.type property when this type is not abstract and if this 
-// type's base is abstract and the base is referenced as the type of a structural property. We need this
-// to disambiguate the type of the descendant class being sent. 
-if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
+// Generate a constructor to initialize the @odata.type property when this type is not abstract.
+if (!complex.IsAbstract)
 {
 #>        /// <summary>
         /// Initializes a new instance of the <see cref="<#=complexTypeName#>"/> class.

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -75,7 +75,19 @@ namespace <#=entity.Namespace.GetNamespaceName()#>
         }
     <#
         }
+		else
+		{
+	#>
 
+		///<summary>
+		/// The <#=entityName#> constructor
+		///</summary>
+        public <#=cstorTypeDeclaration#>()
+        {
+            this.ODataType = "<#=entity.FullName#>";
+        }
+	<#
+		}
         foreach(var property in entity.Properties)
         {
             var propertyType = property.IsTypeNullable() || property.IsCollection()

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -6,6 +6,7 @@ namespace Typewriter.Test
 {
     /// <summary>
     /// End to end tests that check the results of running Typewriter from the CLI.
+    /// IMPORTANT: Typewriter MUST be built before as the templates need to be compiled before running the tests.
     /// </summary>
     [TestClass]
     public class Given_a_valid_metadata_file_to_Typewriter
@@ -139,6 +140,145 @@ namespace Typewriter.Test
                 }
             }
             Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We are not correctly handling the \r\n coming from the annotations.");
+        }
+
+        [TestMethod]
+        public void It_generates_dotNet_odatatype_initialization_for_complextypes()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\Thumbnail.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            string testString = "this.ODataType = \"microsoft.graph.thumbnail\";";
+            bool hasCstorString = false;
+            string testCstorString = "public Thumbnail()";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                }
+                if (line.Contains(testCstorString))
+                {
+                    hasCstorString = true;
+                }
+            }
+
+            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the setter code in the cstor.");
+            Assert.IsTrue(hasCstorString, $"The expected test token cstor string, '{testCstorString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+        }
+
+        [TestMethod]
+        public void It_doesnt_generate_odatatype_initialization_for_abstract_complextypes()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\EmptyComplexType.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            string testString = "this.ODataType = \"microsoft.graph.emptyComplexType\";";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                    break;
+                }
+            }
+
+            Assert.IsFalse(hasTestString, $"The unexpected test token string, '{testString}', was set in the generated test file. We incorrectly generated the setter code in the cstor.");
+        }
+
+
+        [TestMethod]
+        public void It_generates_dotNet_odatatype_initialization_for_entitytypes()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\TestType.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            string testString = "this.ODataType = \"microsoft.graph.testType\";";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+        }
+
+        [TestMethod]
+        public void It_doesnt_generate_odatatype_initialization_for_abstract_entitytypes()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\Entity.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            bool hasTestODataInitString = false;
+            string testString = "protected internal Entity()";
+            string testODataInitString = "this.ODataType = \"microsoft.graph.entity\"";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                }
+                if (line.Contains(testODataInitString))
+                {
+                    hasTestODataInitString = true;
+                }
+            }
+            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+            Assert.IsFalse(hasTestODataInitString, $"The unexpected test token string, '{testODataInitString}', was set in the generated test file. We didn't properly generate the cstor code.");
         }
     }
 }

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -2,7 +2,7 @@
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:DataServices>
     <Schema Namespace="microsoft.graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <EntityType Name="entity">
+      <EntityType Name="entity" Abstract="true">
         <Key>
           <PropertyRef Name="id"/>
         </Key>
@@ -29,6 +29,7 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
       </ComplexType>
+      <ComplexType Name="emptyComplexType" Abstract="true"/>
       <EntityType Name="onenotePage" HasStream="true" BaseType="microsoft.graph.entity">
         <Property Name="content" Type="Edm.Stream" />
         <NavigationProperty Name="parentNotebook" Type="microsoft.graph.notebook" ContainsTarget="true" />


### PR DESCRIPTION
**modified:   Templates/CSharp/Model/ComplexType.cs.tt**

Add public cstor and ODataType initialization for
non-abstract complextypes.

**modified:   Templates/CSharp/Model/EntityType.cs.tt**

Add public cstor and ODataType initialization for
non-abstract entitytypes.

modified:   test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
modified:   test/Typewriter.Test/Resources/dirtyMetadata.xml

Address:
Fixes microsoftgraph/msgraph-sdk-dotnet-core#36

Examples:
![image](https://user-images.githubusercontent.com/8527305/64750631-73a42700-d4ce-11e9-8a74-3f5ecc0f6686.png)
![image](https://user-images.githubusercontent.com/8527305/64750668-8fa7c880-d4ce-11e9-9abc-845f5d0c6c88.png)
