### PR TITLE
Adds constructor to GraphServiceClient template

### DIFF
--- a/Templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/CSharp/Requests/EntityClient.cs.tt
@@ -44,7 +44,8 @@ namespace <#=entityContainer.Namespace.GetNamespaceName()#>
         /// <summary>
         /// Instantiates a new <#=clientName#>.
         /// </summary>
-        /// <param name="httpClient">Http client to use in making requests</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> to use for making requests to Microsoft Graph. Use the <see cref="GraphClientFactory"/>
+        /// to get a pre-configured HttpClient that is optimized for use with the Microsoft Graph service API. </param>
         public <#=clientName#>(
             HttpClient httpClient)
             : base("<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>", httpClient)

--- a/Templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/CSharp/Requests/EntityClient.cs.tt
@@ -8,6 +8,7 @@ var clientName = entityContainer.Name.ToCheckedCase() + "Client";
 
 namespace <#=entityContainer.Namespace.GetNamespaceName()#>
 {
+    using System.Net.Http;
 
     /// <summary>
     /// The type <#=clientName#>.
@@ -37,6 +38,16 @@ namespace <#=entityContainer.Namespace.GetNamespaceName()#>
             IAuthenticationProvider authenticationProvider,
             IHttpProvider httpProvider = null)
             : base(baseUrl, authenticationProvider, httpProvider)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates a new <#=clientName#>.
+        /// </summary>
+        /// <param name="httpClient">Http client to use in making requests</param>
+        public <#=clientName#>(
+            HttpClient httpClient)
+            : base("<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>", httpClient)
         {
         }
     <#


### PR DESCRIPTION
This PR modifies the template for the GraphServiceClient to add a new constructor to add support for the following scenario

```
  HttpClient client = GraphClientFactory.Create(...);
  var graphServiceClient = new GraphServiceClient(client);
```

This PR is related to 
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/38 (predecessor) 
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/27