### PR TITLE
Add element reorder capability

### DIFF
--- a/src/Typewriter/MetadataDefinitionType.cs
+++ b/src/Typewriter/MetadataDefinitionType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+namespace Typewriter
+{
+    public enum MetadataDefinitionType
+    {
+        EnumType,
+        ComplexType,
+        EntityType,
+        Action,
+        Function,
+        Property,
+        NavigationProperty,
+        Member,
+        EntitySet,
+        EntityContainer,
+        Singleton,
+        NavigationPropertyBinding,
+        Annotations,
+        Annotation,
+        Record,
+        PropertyValue
+    }
+}

--- a/src/Typewriter/MetadataPreprocessor.cs
+++ b/src/Typewriter/MetadataPreprocessor.cs
@@ -77,10 +77,6 @@ namespace Typewriter
             AddContainsTarget("appVulnerabilityMobileApp");
 
             ReorderElements(MetadataDefinitionType.Action,
-                            "forward",
-                            new List<string>() { "bindingParameter", "Comment", "ToRecipients" },
-                            "microsoft.graph.post");
-            ReorderElements(MetadataDefinitionType.Action,
                             "accept",
                             new List<string>() { "bindingParameter", "Comment", "SendResponse" },
                             "microsoft.graph.event");

--- a/src/Typewriter/MetadataPreprocessor.cs
+++ b/src/Typewriter/MetadataPreprocessor.cs
@@ -224,18 +224,20 @@ namespace Typewriter
                 metadataDefinitionType == MetadataDefinitionType.Action || 
                 metadataDefinitionType == MetadataDefinitionType.Function)
             {
-                throw new ArgumentNullException(nameof(bindingParameterType), "The binding parameter type must be set in case an Action" +
+                throw new ArgumentNullException(nameof(bindingParameterType), 
+                    "The binding parameter type must be set in the case of an Action" +
                     " or Function with the same name and parameter list.");
             }
             
             // Validate that the specified new element order is meaningful.
             if (newElementOrder.Count < 2)
             {
-                throw new ArgumentOutOfRangeException(nameof(newElementOrder), "ReorderElements: expected 2 or more elements to reorder.");
+                throw new ArgumentOutOfRangeException(nameof(newElementOrder), 
+                    "ReorderElements: expected 2 or more elements to reorder.");
             }
 
-            // Sort the newElementOrder so we can compare the sequence to the potential overloads returned for the
-            // the targetGlobalElementName. We should only ever find a single match.
+            // Sort the newElementOrder so we can compare the sequence to the potential overloads
+            // returned for the the targetGlobalElementName. We should only ever find a single match.
             var newElementsAlphaOrdered = newElementOrder.OrderByDescending(x => x.ToString());
 
             try
@@ -261,7 +263,10 @@ namespace Typewriter
                 }
                 else // We are reordering an Action or Function and must match the bindingParameterType.
                 {
-                    targetElement = results.Where(e => e.Elements().Any(a => a.Attribute("Type").Value == bindingParameterType)).FirstOrDefault();
+                    targetElement = results.Where(e => e.Elements()
+                                                        .Take(1)
+                                                        .Any(a => a.Attribute("Type").Value == bindingParameterType))
+                                           .FirstOrDefault();
                 }
 
                 // There wasn't a match. We need to check our inputs.

--- a/src/Typewriter/Options.cs
+++ b/src/Typewriter/Options.cs
@@ -1,4 +1,6 @@
-﻿using CommandLine;
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+using CommandLine;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -72,7 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ApiDoctor.Publishing">
-      <Version>1.0.0-CI-20181115-192733</Version>
+      <Version>1.0.0-CI-20191014-182007</Version>
     </PackageReference>
     <PackageReference Include="CommandLineParser">
       <Version>2.2.1</Version>

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -46,6 +46,7 @@
     <Compile Include="DocAnnotationWriter.cs" />
     <Compile Include="FileWriter.cs" />
     <Compile Include="Generator.cs" />
+    <Compile Include="MetadataDefinitionType.cs" />
     <Compile Include="MetadataPreprocessor.cs" />
     <Compile Include="MetadataResolver.cs" />
     <Compile Include="Options.cs" />

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
@@ -53,7 +53,8 @@ namespace Typewriter.Test
 
             bool doesntContainTargetBefore = MetadataPreprocessor.GetXMetadata().Descendants()
                     .Where(x => x.Name.LocalName == "NavigationProperty")
-                    .Where(x => x.Attribute("ContainsTarget") == null || x.Attribute("ContainsTarget").Value.Equals("false"))
+                    .Where(x => x.Attribute("ContainsTarget") == null || 
+                                x.Attribute("ContainsTarget").Value.Equals("false"))
                     .Where(x => x.Attribute("Type").Value == $"Collection(microsoft.graph.{navPropTypeToProcess})")
                     .Any();
 
@@ -131,27 +132,32 @@ namespace Typewriter.Test
             // Specify the metadata definition to reorder and the new element order specification.
             var targetMetadataDefType = MetadataDefinitionType.Action;
             var targetMetadataDefName = "forward";
-            var newParameterOrder = new List<string>() { "bindingParameter", "Comment", "ToRecipients" };
+            var newParameterOrder = new List<string>() { "bindingParameter",
+                                                         "Comment",
+                                                         "ToRecipients" };
             var bindingParameterType = "microsoft.graph.onenotePage";
 
             // Check whether an element exists in the metadata that matches our reordered element list before we reorder.
             var isTargetDefinitionInMetadataBefore = MetadataPreprocessor.GetXMetadata().Descendants()
-                                                 .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-                                                 .Where(x => x.Attribute("Name").Value == targetMetadataDefName) // Returns all Action elements named forward.
-                                                 .Where(el => el.Descendants().FirstOrDefault(x => x.Attribute("Type").Value == bindingParameterType) != null)
-                                                 .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
-                                                    .SequenceEqual(newParameterOrder)).Any();
+                    .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                    .Where(x => x.Attribute("Name").Value == targetMetadataDefName) // Returns all Action elements named forward.
+                    .Where(el => el.Descendants().FirstOrDefault(x => x.Attribute("Type").Value == bindingParameterType) != null)
+                    .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
+                        .SequenceEqual(newParameterOrder)).Any();
 
             // Make a call to reorder the parameters for the target action in the metadata loaded into memory. 
-            MetadataPreprocessor.ReorderElements(targetMetadataDefType, targetMetadataDefName, newParameterOrder, bindingParameterType);
+            MetadataPreprocessor.ReorderElements(targetMetadataDefType, 
+                                                 targetMetadataDefName, 
+                                                 newParameterOrder, 
+                                                 bindingParameterType);
 
             // Query the updated metadata for the results that match the reordered element.
             var results = MetadataPreprocessor.GetXMetadata().Descendants()
-                                                             .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-                                                             .Where(x => x.Attribute("Name").Value == targetMetadataDefName) // Returns all Action elements named forward.
-                                                             .Where(el => el.Descendants().FirstOrDefault(x => x.Attribute("Type").Value == bindingParameterType) != null)
-                                                             .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
-                                                                .SequenceEqual(newParameterOrder));
+                    .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                    .Where(x => x.Attribute("Name").Value == targetMetadataDefName) // Returns all Action elements named forward.
+                    .Where(el => el.Descendants().FirstOrDefault(x => x.Attribute("Type").Value == bindingParameterType) != null)
+                    .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
+                        .SequenceEqual(newParameterOrder));
 
             Assert.IsFalse(isTargetDefinitionInMetadataBefore);
             // Added multiple elements with the same binding parameter - we want to make sure there is only one in the results.
@@ -159,7 +165,10 @@ namespace Typewriter.Test
             Assert.AreEqual(newParameterOrder.Count(),
                 results.FirstOrDefault().Elements().Count(),
                 "The reordered element list doesn't match the count of elements in the input new order list.");
-            Assert.IsTrue(results.FirstOrDefault().Elements().Select(a => a.Attribute("Name").Value).SequenceEqual(newParameterOrder),
+            Assert.IsTrue(results.FirstOrDefault()
+                                 .Elements()
+                                 .Select(a => a.Attribute("Name").Value)
+                                 .SequenceEqual(newParameterOrder),
                           "The element list was not reordered as expected.");
         }
 
@@ -182,24 +191,32 @@ namespace Typewriter.Test
             // Specify the metadata definition to reorder and the new element order specification.
             var targetMetadataDefType = MetadataDefinitionType.ComplexType;
             var targetMetadataDefName = "thumbnail";
-            var newParameterOrder = new List<string>() { "width", "url", "sourceItemId", "height", "content" };
+            var newParameterOrder = new List<string>() { "width",
+                                                         "url",
+                                                         "sourceItemId",
+                                                         "height",
+                                                         "content" };
 
-            // Check whether an element exists in the metadata that matches our reordered element list before we reorder.
+            // Check whether an element exists in the metadata that
+            // matches our reordered element list before we reorder.
             var isTargetDefinitionInMetadataBefore = MetadataPreprocessor.GetXMetadata().Descendants()
-                                                 .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-                                                 .Where(x => x.Attribute("Name").Value == targetMetadataDefName) 
-                                                 .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
-                                                    .SequenceEqual(newParameterOrder)).Any();
+                    .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                    .Where(x => x.Attribute("Name").Value == targetMetadataDefName) 
+                    .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
+                        .SequenceEqual(newParameterOrder)).Any();
 
-            // Make a call to reorder the parameters for the target complex type in the metadata loaded into memory. 
-            MetadataPreprocessor.ReorderElements(targetMetadataDefType, targetMetadataDefName, newParameterOrder);
+            // Make a call to reorder the parameters for the target 
+            // complex type in the metadata loaded into memory. 
+            MetadataPreprocessor.ReorderElements(targetMetadataDefType, 
+                                                 targetMetadataDefName, 
+                                                 newParameterOrder);
 
             // Query the updated metadata for the results that match the reordered element.
             var results = MetadataPreprocessor.GetXMetadata().Descendants()
-                                                             .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-                                                             .Where(x => x.Attribute("Name").Value == targetMetadataDefName) 
-                                                             .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
-                                                                .SequenceEqual(newParameterOrder));
+                    .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                    .Where(x => x.Attribute("Name").Value == targetMetadataDefName) 
+                    .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
+                        .SequenceEqual(newParameterOrder));
 
             Assert.IsFalse(isTargetDefinitionInMetadataBefore);
             Assert.IsTrue(results.Count() == 1, $"Expected: A single result item. Actual: found {results.Count()} items.");
@@ -213,9 +230,10 @@ namespace Typewriter.Test
         [TestMethod]
         public void It_does_not_reorder_when_element_list_does_not_match_in_a_complextype()
         {
-            /* The element to attempt to reorder from the resources/dirtymetadata.xml file. The element
-             * list, newParameterOrder does not match the thumbnail type in the metadata (missing 'content' element) so 
-             * we expect that the reorder attempt fails.
+            /* The element to attempt to reorder from the resources/dirtymetadata.xml file. 
+             * The element list, newParameterOrder does not match the thumbnail type 
+             * in the metadata (missing 'content' element) so we expect that the 
+             * reorder attempt fails.
               <ComplexType Name="thumbnail">
                 <Property Name="content" Type="Edm.Stream" />
                 <Property Name="height" Type="Edm.Int32" />
@@ -225,22 +243,30 @@ namespace Typewriter.Test
               </ComplexType>
              */
 
-            // Specify the metadata definition to reorder and the new element order specification.
+            // Specify the metadata definition to reorder and the new 
+            // element order specification.
             var targetMetadataDefType = MetadataDefinitionType.ComplexType;
             var targetMetadataDefName = "thumbnail";
-            var newParameterOrder = new List<string>() { "width", "url", "sourceItemId", "height" };
+            var newParameterOrder = new List<string>() { "width",
+                                                         "url",
+                                                         "sourceItemId",
+                                                         "height" };
 
-            // Make a call to reorder the parameters for the target complex type in the metadata loaded into memory. 
-            MetadataPreprocessor.ReorderElements(targetMetadataDefType, targetMetadataDefName, newParameterOrder);
+            // Make a call to reorder the parameters for the target 
+            // complex type in the metadata loaded into memory. 
+            MetadataPreprocessor.ReorderElements(targetMetadataDefType, 
+                                                 targetMetadataDefName, 
+                                                 newParameterOrder);
 
             // Query the updated metadata for the results that match the reordered element.
             var results = MetadataPreprocessor.GetXMetadata().Descendants()
-                                                             .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-                                                             .Where(x => x.Attribute("Name").Value == targetMetadataDefName)
-                                                             .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
-                                                                .SequenceEqual(newParameterOrder));
+                    .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                    .Where(x => x.Attribute("Name").Value == targetMetadataDefName)
+                    .Where(el => el.Elements().Select(a => a.Attribute("Name").Value)
+                        .SequenceEqual(newParameterOrder));
 
-            Assert.IsTrue(results.Count() == 0, $"Expected: Zero results. Actual: found {results.Count()} items.");
+            Assert.IsTrue(results.Count() == 0, 
+                          $"Expected: Zero results. Actual: found {results.Count()} items.");
         }
     }
 }

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -109,6 +110,25 @@ namespace Typewriter.Test
                 .Where(x => x.Attribute("String").Value.Equals("navigable")).Any();
 
             Assert.IsTrue(foundAnnotationAfter, "Expected: thumbnailComplexType set with an annotation. Actual: annotation wasn't found.");
+        }
+
+        public void It_reorders_elements()
+        {
+            // Arrange - Specify the new element
+            var targetMetadataDefType = MetadataDefinitionType.Action;
+            var targetMetadataDefName = "forward";
+            var newElementOrder = new List<string>() { "bindingParameter", "Comment", "ToRecipients" };
+            var bindingParameterType = "onenotePage";
+            var fullBindingParameterType = $"microsoft.graph.{bindingParameterType}";
+
+            // Act
+            MetadataPreprocessor.ReorderElements(targetMetadataDefType, targetMetadataDefName, newElementOrder, bindingParameterType);
+
+            //MetadataPreprocessor.GetXMetadata().Descendants().Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+            //                                                 .Where(x => x.Attribute("Name").Value == targetMetadataDefName)
+            //                                                 .Where(x => x.Elements().Where(parameter => parameter.Attribute("Type").Value == fullBindingParameterType));
+
+
         }
     }
 }

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Xml.Linq;
 
 namespace Typewriter.Test

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_metadata_preprocessor.cs
@@ -112,22 +112,35 @@ namespace Typewriter.Test
             Assert.IsTrue(foundAnnotationAfter, "Expected: thumbnailComplexType set with an annotation. Actual: annotation wasn't found.");
         }
 
+        [TestMethod]
         public void It_reorders_elements()
         {
-            // Arrange - Specify the new element
+            /* The element to reorder from the testMetadata file.
+            <Action Name="forward" IsBound="true">
+                <Parameter Name="bindingParameter" Type="microsoft.graph.onenotePage" />
+                <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+                <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+            </Action>
+             */
+
+
+            // Arrange - Specify the element
             var targetMetadataDefType = MetadataDefinitionType.Action;
             var targetMetadataDefName = "forward";
             var newElementOrder = new List<string>() { "bindingParameter", "Comment", "ToRecipients" };
-            var bindingParameterType = "onenotePage";
-            var fullBindingParameterType = $"microsoft.graph.{bindingParameterType}";
+            var bindingParameterType = "microsoft.graph.onenotePage";
 
             // Act
             MetadataPreprocessor.ReorderElements(targetMetadataDefType, targetMetadataDefName, newElementOrder, bindingParameterType);
 
-            //MetadataPreprocessor.GetXMetadata().Descendants().Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
-            //                                                 .Where(x => x.Attribute("Name").Value == targetMetadataDefName)
-            //                                                 .Where(x => x.Elements().Where(parameter => parameter.Attribute("Type").Value == fullBindingParameterType));
+            var results = MetadataPreprocessor.GetXMetadata().Descendants()
+                                                             .Where(x => x.Name.LocalName == targetMetadataDefType.ToString())
+                                                             .Where(x => x.Attribute("Name").Value == targetMetadataDefName) // Returns all Action elements named forward.
+                                                             .Where(el => el.Descendants().FirstOrDefault(x => x.Attribute("Type").Value == bindingParameterType) != null);
 
+            // TODO: complete test
+            results.Select(a => a.Attribute("Name").Value).OrderByDescending(e => e.ToString())
+                                                          .SequenceEqual(newElementOrder);
 
         }
     }

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -48,7 +48,6 @@
         <Parameter Name="Details" Type="Edm.String" Unicode="false" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
-
       <Action Name="forward" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
@@ -59,15 +58,12 @@
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
-
- 
       <Action Name="forward" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="TestProperty" Type="Edm.String" Nullable="true"/>
       </Action>
-
 
       <EntityContainer Name="GraphService">
         <Singleton Name="testSingleton" Type="microsoft.graph.testSingleton"/>

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -45,13 +45,22 @@
       <Action Name="forward" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.onenotePage" />
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+        <Parameter Name="Details" Type="Edm.String" Unicode="false" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
+
       <Action Name="forward" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
       </Action>
+      <Action Name="forward" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.onenotePage" />
+        <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+      </Action>
+
+ 
       <Action Name="forward" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
         <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -29,6 +29,10 @@
         <Property Name="url" Type="Edm.String" />
         <Property Name="width" Type="Edm.Int32" />
       </ComplexType>
+      <ComplexType Name="recipient">
+        <Property Name="name" Type="Edm.String" />
+        <Property Name="email" Type="Edm.String" />
+      </ComplexType>
       <ComplexType Name="emptyComplexType" Abstract="true"/>
       <EntityType Name="onenotePage" HasStream="true" BaseType="microsoft.graph.entity">
         <Property Name="content" Type="Edm.Stream" />
@@ -37,6 +41,25 @@
       <EntityType Name="plannerGroup" BaseType="microsoft.graph.entity">
         <NavigationProperty Name="plans" Type="Collection(microsoft.graph.plannerPlan)" />
       </EntityType>
+
+      <Action Name="forward" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.onenotePage" />
+        <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+      </Action>
+      <Action Name="forward" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
+        <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+      </Action>
+      <Action Name="forward" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
+        <Parameter Name="ToRecipients" Type="Collection(microsoft.graph.recipient)" Nullable="false" />
+        <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
+        <Parameter Name="TestProperty" Type="Edm.String" Nullable="true"/>
+      </Action>
+
+
       <EntityContainer Name="GraphService">
         <Singleton Name="testSingleton" Type="microsoft.graph.testSingleton"/>
         <Singleton Name="testSingleton2" Type="microsoft.graph.testSingleton2"/>


### PR DESCRIPTION
Fixes #222.

Enables us to reorder elements in any global metadata element. 

- [ ] Squash and merge.
- [ ] Review metadata changes to make sure we've captured all of the reordered Actions.
