### PR TITLE
Support disambiguated objects for OData MethodRequestBody

### DIFF
--- a/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/IRequestBuilder.Base.template.tt
@@ -137,7 +137,11 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
-
+                // Adds support for classes ending in "Request" that have been dismabiguated.
+                if (paramTypeString.EndsWith("Request"))
+                {   
+                    paramTypeString = String.Concat(paramTypeString, "Object");
+                }
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);

--- a/Templates/CSharp/Base/RequestBuilder.Base.template.tt
+++ b/Templates/CSharp/Base/RequestBuilder.Base.template.tt
@@ -188,6 +188,11 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
                 var paramVariableName = param.Name.GetSanitizedParameterName();
                 var paramTypeString = param.Type.GetTypeString();
 
+                // Adds support for classes ending in "Request" that have been dismabiguated.
+                if (paramTypeString.EndsWith("Request"))
+                {   
+                    paramTypeString = String.Concat(paramTypeString, "Object");
+                }
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);

--- a/Templates/CSharp/Model/MethodRequestBody.cs.tt
+++ b/Templates/CSharp/Model/MethodRequestBody.cs.tt
@@ -34,7 +34,12 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     foreach (var param in method.Parameters)
     {
         var paramTypeString = param.Type.GetTypeString();
-
+        
+        // Adds support for classes ending in "Request" that have been dismabiguated.
+        if (paramTypeString.EndsWith("Request"))
+        {   
+            paramTypeString = String.Concat(paramTypeString, "Object");
+        }
         if (param.IsCollection)
         {
             paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);


### PR DESCRIPTION
ComplexTypes ending with 'Request' are disambiguated by appending
'Object' to their name. We need to support this for optional Action
and Function arguments.

	modified:   Templates/CSharp/Base/IRequestBuilder.Base.template.tt
	modified:   Templates/CSharp/Base/RequestBuilder.Base.template.tt
	modified:   Templates/CSharp/Model/MethodRequestBody.cs.tt

This change was used to generate the beta update, but was not added to the PR.