### PR TITLE
Removed whitespace being generated by Inflector library on namespaces

### DIFF
--- a/.nuget/nuget.config
+++ b/.nuget/nuget.config
@@ -3,4 +3,7 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <config>
+    <add key="repositoryPath" value="..\packages" />
+  </config>
 </configuration>

--- a/.nuget/nuget.config
+++ b/.nuget/nuget.config
@@ -3,7 +3,4 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
-  <config>
-    <add key="repositoryPath" value="..\packages" />
-  </config>
 </configuration>

--- a/GraphODataTemplateWriter.Test/TypeHelperTests.cs
+++ b/GraphODataTemplateWriter.Test/TypeHelperTests.cs
@@ -91,5 +91,25 @@ namespace GraphODataTemplateWriter.Test
 
             Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
         }
-    }
+
+        [TestMethod]
+        public void Namespace_Shouldnt_Contain_Whitespace_For_CSharp()
+        {
+            var testNamespace = new OdcmNamespace("Microsoft.OutlookServices");
+
+            var namespaceName = TypeHelperCSharp.GetNamespaceName(testNamespace);
+
+            Assert.AreEqual(namespaceName, "Microsoft.OutlookServices");
+        }
+
+        [TestMethod]
+        public void Namespace_Should_PascalCase_For_CSharp()
+        {
+            var testNamespace = new OdcmNamespace("microsoft.graph");
+
+            var namespaceName = TypeHelperCSharp.GetNamespaceName(testNamespace);
+
+            Assert.AreEqual(namespaceName, "Microsoft.Graph");
+        }
+     }
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 
         public static string GetNamespaceName(this OdcmNamespace namespaceObject)
         {
-            return Inflector.Inflector.Titleize(namespaceObject.Name);
+            return Inflector.Inflector.Titleize(namespaceObject.Name).Replace(" ", "");
         }
 
         public static string GetToLowerFirstCharName(this OdcmProperty property)

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -478,7 +478,7 @@ namespace Typewriter.Test
             {
                 Output = outputDirectory,
                 GenerationMode = GenerationMode.Transform,
-                Transform = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/mm/xslt/transforms/csdl/preprocess_csdl.xsl"
+                Transform = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl"
 
             };
 


### PR DESCRIPTION
When namespaces contained already PascalCased tokens, such as 'Microsoft.OfficeShared.Etc', the namespace generation would convert the namespace to 'Microsoft.Office Shared.Etc'.

This PR simply removes the whitespace that Inflector's Titleize method adds to the namespace.

Using Inflector's Pascalize method doesn't work due to the regex used not recognizing the '.' character as a token delimiter.