### PR TITLE
Fix Java generation - support methods that return enums, disambiguate entities that end in "Request"

### DIFF
--- a/Templates/Java/BaseJavaModel.template.tt
+++ b/Templates/Java/BaseJavaModel.template.tt
@@ -937,7 +937,7 @@ import java.util.EnumSet;", host.CurrentModel.NamespaceName());
 import {0}.concurrency.*;
 import {0}.core.*;
 import {0}.models.extensions.*;
-import {0}.models.generated.*;
+import {0}.models.generated.*;{2}
 import {0}.http.*;
 import {0}.requests.extensions.*;
 import {0}.options.*;
@@ -945,9 +945,13 @@ import {0}.serializer.*;
 
 import java.util.Arrays;
 import java.util.EnumSet;";
+
+        // We need this for disambiguation of generated model class/interfaces references.
+        string fullyQualifiedImport = host.GetFullyQualifiedImportStatementForModel(); 
+
         return string.Format(format,
             host.CurrentModel.NamespaceName(),
-            host.TemplateInfo.OutputParentDirectory.Replace("_", "."));
+            host.TemplateInfo.OutputParentDirectory.Replace("_", "."), fullyQualifiedImport);
         }
 
     /// Creates a class declaration

--- a/Templates/Java/requests_extensions/BaseMethodCollectionResponse.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionResponse.java.tt
@@ -28,7 +28,7 @@ import com.google.gson.annotations.*;
     }
 
 <#=CreateRawJsonObject()#>
-<# if ( ! ((c as OdcmMethod).ReturnType is OdcmPrimitiveType) ) { #>
+<# if ( ! ((c as OdcmMethod).ReturnType is OdcmPrimitiveType) && ! ((c as OdcmMethod).ReturnType is OdcmEnum) ) { #>
 <#=    UpdateListPropertiesWithinSetRawObject(new [] { "value" })#>
 <# } else { #>
     }

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
         /// <param name="host">The T4Host that orchestrates applying templates to the OdcmModel.</param>
         /// <returns>A boolean value that indicates whether the current type needs to be disambiguated.</returns>
         public static bool DoesCurrentTypeNeedDisambiguation(this CustomT4Host host)
-        {
+        {   
             // At this point this is only applicable to OdcmProperty.
             // Challenging this assumption will require a lot more investigation.
             if (!(host.CurrentType is OdcmProperty))
@@ -165,7 +165,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             var requestSuffix = "Request";
             var currentTypeName = (host.CurrentType as OdcmProperty).Type.Name;
             int index = currentTypeName.IndexOf(requestSuffix);
-            if (index == -1)
+            if (index == -1 || !currentTypeName.EndsWith(requestSuffix))
                 return false; // Doesn't need disambiguation
 
             // If it does end in "Request", let's capture the base name to check if an entity of that name 

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -140,15 +140,15 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
 
         /// <summary>
         /// This extension method determines whether the current type needs to be disambiguated.
-        /// If does need dismabiguation, we then provide a fully qualified import statement
-        /// for the model
+        /// If the current type needs dismabiguation, we then provide a fully qualified 
+        /// import statement for the model.
         /// This currently operates only on entities whose name ends in "Request". We do this
-        /// because Every entity results in a request object. So, assume we have the following
+        /// because every entity results in a request object. For example, assume we have the following
         /// two entities: timeOff and timeOffRequest. The timeOff entity will trigger the generation
         /// of classes named model.timeOff and request.timeOffRequest. The timeOffRequest entity
         /// will trigger the generation of a model.timeOffRequest and request.timeOffRequestRequest.
-        /// The request.timeOffRequest and model.timeOffRequest will result in a name collision in
-        /// a few files. 
+        /// The request.timeOffRequest and model.timeOffRequest classes will result in a name collision in
+        /// a few files.
         /// Assumptions: 1) host.CurrentType is an OdcmProperty.
         /// </summary>
         /// <param name="host">The T4Host that orchestrates applying templates to the OdcmModel.</param>
@@ -161,7 +161,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
                 return false; 
 
             // We only support "Request" dismabiguation at this point. Check whether the
-            // current typeends in "Request".
+            // current type ends in "Request".
             var requestSuffix = "Request";
             var currentTypeName = (host.CurrentType as OdcmProperty).Type.Name;
             int index = currentTypeName.IndexOf(requestSuffix);
@@ -175,15 +175,16 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             // Search across namespaces, looking only at EntityType, to determine whether this type requires 
             // disambiguation. This needs to be supported across namespaces.
             var classes = host.CurrentModel.Namespaces.SelectMany(n => n.Classes);
-            var requiresDisambiguation = classes.Where(entity => entity.Kind == OdcmClassKind.Entity
+            var shouldDisambiguate = classes.Where(entity => entity.Kind == OdcmClassKind.Entity
                                                        && entity.Name == entityNameToCheckForCollision).Any();
 
-            return requiresDisambiguation;
+            return shouldDisambiguate;
         }
 
         /// <summary>
-        /// An extension method to get an import statement for the fully qualified name of current type.
-        /// Assumptions: 1) host.CurrentType is an OdcmProperty. 2) the generated namespace of the current type is in models.generated.
+        /// An extension method to get an import statement for the fully qualified name of the current type.
+        /// Assumptions: 1) host.CurrentType is an OdcmProperty. 2) the generated namespace of the current type 
+        /// is in models.generated output namespace (in the generated file, not in the metadata).
         /// This method should support multiple namespaces.
         /// This currently (6/2020) applies to the following templates:
         ///   BaseEntityCollectionRequest.java.tt

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -74,6 +74,41 @@ namespace Typewriter.Test
             Assert.IsTrue(isExpectedNamespaceSet, $"The expected namespace, {testNamespace}, was not set in the generated test file.");
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        [TestMethod]
+        public void It_generates_Java_models_with_disambiguated_import()
+        {
+            const string outputDirectory = "outputJava";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "Java",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\requests\extensions\TimeOffRequestCollectionRequest.java");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            // Check that the namespace applied at the CLI was added to the document.
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool isExpectedImportStatementFound = false;
+            string expected = "import com.microsoft.graph.models.generated.TimeOffRequest;";
+            foreach (var line in lines)
+            {
+                if (line.Contains(expected))
+                {
+                    isExpectedImportStatementFound = true;
+                    break;
+                }
+            }
+            Assert.IsTrue(isExpectedImportStatementFound, $"The expected statement was not found. Expected: {expected}");
+        }
+
         [TestMethod]
         public void It_generates_dotNet_client_with_default_beta_baseUrl()
         {

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -49,6 +49,19 @@
         <Property Name="email" Type="Edm.String" />
       </ComplexType>
       <ComplexType Name="emptyComplexType" Abstract="true"/>
+      
+      <EntityType Name="timeOffRequest" BaseType="microsoft.graph.entity">
+        <Property Name="name" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="timeOff" BaseType="microsoft.graph.entity">
+        <Property Name="name" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="schedule" BaseType="microsoft.graph.entity">
+        <Property Name="enabled" Type="Edm.Boolean" />
+        <NavigationProperty Name="timesOff" Type="Collection(microsoft.graph.timeOff)" ContainsTarget="true" />
+        <NavigationProperty Name="timeOffRequests" Type="Collection(microsoft.graph.timeOffRequest)" ContainsTarget="true" />
+      </EntityType>
+      
       <EntityType Name="onenotePage" HasStream="true" BaseType="microsoft.graph.entity">
         <Property Name="content" Type="Edm.Stream" />
         <NavigationProperty Name="parentNotebook" Type="microsoft.graph.notebook" ContainsTarget="true" />


### PR DESCRIPTION
The changes in this PR affect the following files:

![image](https://user-images.githubusercontent.com/8527305/84552324-3838c200-acc5-11ea-8e12-f82ce02e0c1e.png)

The files marked in blue are changed but aren't affected by the change. They now have an additional unused import (there are many, and represent a different set of challenges). We could add a template exclusion list to the code, but that does not feel right.

## Support methods that return enums. 
The change in  BaseMethodCollectionResponse .java.tt results in us not generating setters for instance annotations for enum return types; because enum values don't have instance annotations. This only impacts the generated CalendarAllowedCalendarSharingRolesCollectionResponse.java.

![image](https://user-images.githubusercontent.com/8527305/84552279-09bae700-acc5-11ea-9c34-10da55f659b7.png)

## Disambiguate model references when the mode name ends in "Request"
The metadata has entities named timeOff and timeOffRequest. The entity named timeOff results in us generating files named models.timeOff and requests.timeOffRequest. The entity named timeOffRequest results in us generating files named models.timeOffRequest and requests.timeOffRequestRequest. This results in a name collision. The changes in this PR result in the following generated code change which address this issue:

![image](https://user-images.githubusercontent.com/8527305/84552596-3b807d80-acc6-11ea-990e-ce32e5d61930.png)

