### PR TITLE
Set typescript owners in template

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -16,12 +16,10 @@
 // Type definitions for non-npm package microsoft-graph <VERSION_STRING>
 // Project: https://github.com/microsoftgraph/msgraph-typescript-typings
 // Definitions by: Microsoft Graph Team <https://github.com/microsoftgraph>
-//                 Muthurathinam Muthusamy <https://github.com/muthurathinam>
-//                 Darrel Miller <https://github.com/darrelmiller>
-//                 Nimeesh Patel <https://github.com/nimeesh-msft>
 //                 Michael Mainer <https://github.com/MIchaelMainer>
-//                 Nakul Sabharwal <https://github.com/NakulSabharwal>
 //                 Peter Ombwa <https://github.com/peombwa>
+//                 Mustafa Zengin <https://github.com/zengin>
+//                 DeVere Dyett <https://github.com/dyett>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -19,7 +19,7 @@
 //                 Michael Mainer <https://github.com/MIchaelMainer>
 //                 Peter Ombwa <https://github.com/peombwa>
 //                 Mustafa Zengin <https://github.com/zengin>
-//                 DeVere Dyett <https://github.com/dyett>
+//                 DeVere Dyett <https://github.com/ddyett>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 


### PR DESCRIPTION
These values are used by DefinatelyTyped for accepting and signing off PRs. 