### PR TITLE
Removing the Type Definition header from the TypeScript Template

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -13,7 +13,6 @@
 
     var maxLineLength = 120;
 #>
-// Type definitions for non-npm package microsoft-graph <VERSION_STRING>
 // Project: https://github.com/microsoftgraph/msgraph-typescript-typings
 // Definitions by: Microsoft Graph Team <https://github.com/microsoftgraph>
 //                 Michael Mainer <https://github.com/MIchaelMainer>


### PR DESCRIPTION
![MicrosoftTeams-image](https://user-images.githubusercontent.com/23219007/89836991-d659d480-db1c-11ea-91f1-b0d0b0fc1f80.png)
