### PR TITLE
PHP Namespaces support

### DIFF
--- a/GraphODataTemplateWriter.Test/TypeHelperTests.cs
+++ b/GraphODataTemplateWriter.Test/TypeHelperTests.cs
@@ -111,5 +111,45 @@ namespace GraphODataTemplateWriter.Test
 
             Assert.AreEqual(namespaceName, "Microsoft.Graph");
         }
-     }
+
+        [TestMethod]
+        public void PHPMainNamespace_Generated_For_V1()
+        {
+            var testNamespace = "microsoft.graph";
+            const string expectedPHPNamespace = "Microsoft\\Graph";
+
+            var actualPHPNamespace = TypeHelperPHP.GetPHPNamespace(testNamespace);
+            Assert.AreEqual(expectedPHPNamespace, actualPHPNamespace);
+        }
+
+        [TestMethod]
+        public void PHPMainNamespace_Generated_For_Beta()
+        {
+            var testNamespace = "microsoft.graph";
+            const string expectedPHPNamespace = "Beta\\Microsoft\\Graph";
+
+            var actualPHPNamespace = TypeHelperPHP.GetPHPNamespace(testNamespace, "Beta");
+            Assert.AreEqual(expectedPHPNamespace, actualPHPNamespace);
+        }
+
+        [TestMethod]
+        public void PHPSubNamespace_Generated_For_V1()
+        {
+            var testNamespace = "microsoft.graph.callRecords";
+            const string expectedPHPNamespace = "Microsoft\\Graph\\CallRecords";
+
+            var actualPHPNamespace = TypeHelperPHP.GetPHPNamespace(testNamespace);
+            Assert.AreEqual(expectedPHPNamespace, actualPHPNamespace);
+        }
+
+        [TestMethod]
+        public void PHPSubNamespace_Generated_For_Beta()
+        {
+            var testNamespace = "microsoft.graph.callRecords";
+            const string expectedPHPNamespace = "Beta\\Microsoft\\Graph\\CallRecords";
+
+            var actualPHPNamespace = TypeHelperPHP.GetPHPNamespace(testNamespace, "Beta");
+            Assert.AreEqual(expectedPHPNamespace, actualPHPNamespace);
+        }
+    }
 }

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -10,6 +10,10 @@ OdcmClass complex      = (OdcmClass)host.CurrentType;
 String complexName     = complex.Name.SanitizeEntityName();
 String targetNamespace = TypeHelperPHP.GetPHPNamespace(complex, settings);
 String complexBaseName = TypeHelperPHP.GetBaseTypeFullName(complex.Base, targetNamespace, settings);
+if (complexBaseName.Contains("\\"))
+{
+    complexBaseName = "\\" + complexBaseName;
+}
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(complexName.ToCheckedCase()))#>
@@ -21,7 +25,7 @@ if (complex.Base != null) {
 class <#=complexName.ToCheckedCase()#> extends <#=complexBaseName#>
 <#
 } else {
-    var entityTypeFullName = targetNamespace == "Microsoft\\Graph\\Model" ? "Entity" : "Microsoft\\Graph\\Model\\Entity";
+    var entityTypeFullName = TypeHelperPHP.GetPHPEntityTypeReference(targetNamespace, settings);
 #>
 class <#=complexName.ToCheckedCase()#> extends <#=entityTypeFullName#>
 <#

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -8,17 +8,11 @@ CodeWriterPHP writer   = (CodeWriterPHP) host.CodeWriter;
 TemplateWriterSettings settings = ConfigurationService.Settings;
 OdcmClass complex      = (OdcmClass)host.CurrentType;
 String complexName     = complex.Name.SanitizeEntityName();
-string targetNamespace = @"Microsoft\Graph\Model";
 String complexBaseName = "";
 if (complex.Base != null)
 	complexBaseName = complex.Base.Name.SanitizeEntityName();
 
-// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
-// documentation for more information on how the TemplateWriterSettings.Properties is used.
-if (settings.Properties.ContainsKey("php.namespace"))
-{
-    targetNamespace = settings.Properties["php.namespace"];
-}      
+string targetNamespace          = TypeHelperPHP.GetPHPNamespace(complex, settings);
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(complexName.ToCheckedCase()))#>
@@ -129,20 +123,24 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
     {
         if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
 <#
+var propertyTypeString = property.Type.GetTypeString();
+var camelCasePropertyName = property.Name.ToCamelize();
 // Check whether this type is a generated model type or a PHP type
-if (property.Type.GetTypeString()[0] == '\\') { #>
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=property.Type.GetTypeString()#>")) {
-<# } else { #>
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=targetNamespace#>\<#=property.Type.GetTypeString()#>")) {
+if (propertyTypeString[0] == '\\') { #>
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyTypeString#>")) {
+<# } else {
+    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
+#>
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyNamespace#>\<#=propertyTypeString#>")) {
 <# } #>
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+                return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
-<# if (property.Type.GetTypeString() == "\\GuzzleHttp\\Psr7\\Stream") { #>
-                $this->_propDict["<#=property.Name.ToCamelize()#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=property.Name.ToCamelize()#>"]);
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+<# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
+                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
+                return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
-                $this->_propDict["<#=property.Name.ToCamelize()#>"] = new <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=property.Name.ToCamelize()#>"]);
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeString.SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
+                return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } #>
             }
         }

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -47,6 +47,18 @@ if (complex.IsBaseAbstractAndReferencedAsPropertyType() && !complex.IsAbstract)
 }
 foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString() != "bytes")){
     var propertyName = property.Name.SanitizePropertyName(complexName);
+    var camelCasePropertyName = property.Name.ToCamelize();
+    var propertyTypeString = property.Type.GetTypeString();
+    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
+
+    // Check whether this type is a generated model type or a PHP type
+    var fullPropertyTypeName = propertyTypeString[0] == '\\' || propertyTypeString.IsPHPPrimitiveType()
+                                ? propertyTypeString
+                                : string.Join("\\", propertyNamespace, propertyTypeString.SanitizeEntityName().ToCheckedCase());
+
+    var propertyTypeReference = propertyNamespace == targetNamespace && !propertyTypeString.IsPHPPrimitiveType()
+                                ? propertyTypeString.SanitizeEntityName().ToCheckedCase()
+                                : fullPropertyTypeName;
     if (!property.Type.IsComplex()) {
 #>
     /**
@@ -56,7 +68,7 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=property.Type.GetTypeString()#> The <#=propertyName#>
+    * @return <#=propertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
@@ -84,7 +96,7 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=property.Type.GetTypeString()#> $val The value of the <#=propertyName#>
+    * @param <#=propertyTypeReference#> $val The value of the <#=propertyName#>
     *
     * @return <#=complexName.ToCheckedCase()#>
     */
@@ -115,29 +127,19 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> The <#=propertyName#>
+    * @return <#=propertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
         if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
-<#
-var propertyTypeString = property.Type.GetTypeString();
-var camelCasePropertyName = property.Name.ToCamelize();
-// Check whether this type is a generated model type or a PHP type
-if (propertyTypeString[0] == '\\') { #>
-            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyTypeString#>")) {
-<# } else {
-    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
-#>
-            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyNamespace#>\<#=propertyTypeString#>")) {
-<# } #>
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=fullPropertyTypeName#>")) {
                 return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
 <# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
                 $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
-                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeString.SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
+                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeReference#>($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } #>
             }
@@ -152,7 +154,7 @@ if (propertyTypeString[0] == '\\') { #>
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=property.Type.GetTypeString()#> $val The value to assign to the <#=property.Name#>
+    * @param <#=propertyTypeReference#> $val The value to assign to the <#=property.Name#>
     *
     * @return <#=complexName.ToCheckedCase()#> The <#=complexName.ToCheckedCase()#>
     */

--- a/Templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/PHP/Model/ComplexType.php.tt
@@ -8,11 +8,8 @@ CodeWriterPHP writer   = (CodeWriterPHP) host.CodeWriter;
 TemplateWriterSettings settings = ConfigurationService.Settings;
 OdcmClass complex      = (OdcmClass)host.CurrentType;
 String complexName     = complex.Name.SanitizeEntityName();
-String complexBaseName = "";
-if (complex.Base != null)
-	complexBaseName = complex.Base.Name.SanitizeEntityName();
-
-string targetNamespace          = TypeHelperPHP.GetPHPNamespace(complex, settings);
+String targetNamespace = TypeHelperPHP.GetPHPNamespace(complex, settings);
+String complexBaseName = TypeHelperPHP.GetBaseTypeFullName(complex.Base, targetNamespace, settings);
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(complexName.ToCheckedCase()))#>
@@ -21,11 +18,12 @@ namespace <#=targetNamespace#>;
 <#
 if (complex.Base != null) {
 #>
-class <#=complexName.ToCheckedCase()#> extends <#=complexBaseName.ToCheckedCase()#>
+class <#=complexName.ToCheckedCase()#> extends <#=complexBaseName#>
 <#
 } else {
+    var entityTypeFullName = targetNamespace == "Microsoft\\Graph\\Model" ? "Entity" : "Microsoft\\Graph\\Model\\Entity";
 #>
-class <#=complexName.ToCheckedCase()#> extends Entity
+class <#=complexName.ToCheckedCase()#> extends <#=entityTypeFullName#>
 <#
 }
 #>

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -8,12 +8,8 @@ CodeWriterPHP writer	        = (CodeWriterPHP) host.CodeWriter;
 OdcmClass entity                = host.CurrentType.AsOdcmClass();
 TemplateWriterSettings settings = ConfigurationService.Settings;
 String entityName               = entity.Name.SanitizeEntityName();
-String entityBaseName           = "";
-
-if (entity.Base != null)
-	entityBaseName = entity.Base.Name.SanitizeEntityName();
-
-string targetNamespace          = TypeHelperPHP.GetPHPNamespace(entity, settings);
+String targetNamespace          = TypeHelperPHP.GetPHPNamespace(entity, settings);
+String entityBaseName           = TypeHelperPHP.GetBaseTypeFullName(entity.Base, targetNamespace, settings);
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(entityName.ToCheckedCase()))#>
@@ -27,7 +23,7 @@ class <#=entity.Name.ToCheckedCase()#> implements \JsonSerializable
 <#
 } else {
 #>
-class <#=entityName.ToCheckedCase()#> extends <#=entityBaseName.ToCheckedCase() #>
+class <#=entityName.ToCheckedCase()#> extends <#=entityBaseName#>
 <# 
 }
 #>

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -8,18 +8,12 @@ CodeWriterPHP writer	        = (CodeWriterPHP) host.CodeWriter;
 OdcmClass entity                = host.CurrentType.AsOdcmClass();
 TemplateWriterSettings settings = ConfigurationService.Settings;
 String entityName               = entity.Name.SanitizeEntityName();
-string targetNamespace          = @"Microsoft\Graph\Model";
 String entityBaseName           = "";
 
 if (entity.Base != null)
 	entityBaseName = entity.Base.Name.SanitizeEntityName();
 
-// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
-// documentation for more information on how the TemplateWriterSettings.Properties is used.
-if (settings.Properties.ContainsKey("php.namespace"))
-{
-    targetNamespace = settings.Properties["php.namespace"];
-}      
+string targetNamespace          = TypeHelperPHP.GetPHPNamespace(entity, settings);
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(entityName.ToCheckedCase()))#>
@@ -127,21 +121,25 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     public function get<#=propertyName.ToCheckedCase()#>()
     {
         if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
-<# 
+<#
+var propertyTypeString = property.Type.GetTypeString();
+var camelCasePropertyName = property.Name.ToCamelize();
 // Check whether this type is a generated model type or a PHP type
-if (property.Type.GetTypeString()[0] == '\\') { #>
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=property.Type.GetTypeString()#>")) {
-<# } else { #>
-            if (is_a($this->_propDict["<#=property.Name.ToCamelize()#>"], "<#=targetNamespace#>\<#=property.Type.GetTypeString()#>")) {
+if (propertyTypeString[0] == '\\') { #>
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyTypeString#>")) {
+<# } else {
+    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
+#>
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyNamespace#>\<#=propertyTypeString#>")) {
 <# } #>
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+                return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
-<# if (property.Type.GetTypeString() == "\\GuzzleHttp\\Psr7\\Stream") { #>
-                $this->_propDict["<#=property.Name.ToCamelize()#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=property.Name.ToCamelize()#>"]);
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+<# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
+                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
+                return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
-                $this->_propDict["<#=property.Name.ToCamelize()#>"] = new <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=property.Name.ToCamelize()#>"]);
-                return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
+                return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } #>
             }
         }

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -71,13 +71,13 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     var camelCasePropertyName = property.Name.ToCamelize();
     var propertyTypeString = property.Type.GetTypeString();
     var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
-    
+
     // Check whether this type is a generated model type or a PHP type
     var fullPropertyTypeName = propertyTypeString[0] == '\\' || propertyTypeString.IsPHPPrimitiveType()
                                 ? propertyTypeString
                                 : string.Join("\\", propertyNamespace, propertyTypeString.SanitizeEntityName().ToCheckedCase());
 
-    var docsPropertyTypeReference = propertyNamespace == targetNamespace && !propertyTypeString.IsPHPPrimitiveType()
+    var propertyTypeReference = propertyNamespace == targetNamespace && !propertyTypeString.IsPHPPrimitiveType()
                                 ? propertyTypeString.SanitizeEntityName().ToCheckedCase()
                                 : fullPropertyTypeName;
     if (property.Type.IsComplex()) {
@@ -109,7 +109,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
+    * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
     * @return <#=entityCheckedCase#>
     */
@@ -129,7 +129,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=docsPropertyTypeReference#> The <#=propertyName#>
+    * @return <#=propertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
@@ -141,7 +141,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
                 $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
-                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeString.SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
+                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeReference#>($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } #>
             }
@@ -156,7 +156,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
+    * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
     * @return <#=entityCheckedCase#>
     */
@@ -183,7 +183,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=docsPropertyTypeReference#> The <#=propertyName#>
+    * @return <#=propertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
@@ -211,7 +211,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
+    * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
     * @return <#=entityCheckedCase#>
     */

--- a/Templates/PHP/Model/EntityType.php.tt
+++ b/Templates/PHP/Model/EntityType.php.tt
@@ -8,8 +8,13 @@ CodeWriterPHP writer	        = (CodeWriterPHP) host.CodeWriter;
 OdcmClass entity                = host.CurrentType.AsOdcmClass();
 TemplateWriterSettings settings = ConfigurationService.Settings;
 String entityName               = entity.Name.SanitizeEntityName();
+String entityCheckedCase        = entity.Name.ToCheckedCase();
 String targetNamespace          = TypeHelperPHP.GetPHPNamespace(entity, settings);
 String entityBaseName           = TypeHelperPHP.GetBaseTypeFullName(entity.Base, targetNamespace, settings);
+if (entityBaseName.Contains("\\"))
+{
+    entityBaseName = "\\" + entityBaseName;
+}
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(entityName.ToCheckedCase()))#>
@@ -17,9 +22,9 @@ namespace <#=targetNamespace#>;
 
 <#=writer.GetClassBlock(entityName.ToCheckedCase().ToString(), "Model")#>
 <#
-if (entity.Name.ToCheckedCase() == "Entity") {
+if (entityCheckedCase == "Entity") {
 #>
-class <#=entity.Name.ToCheckedCase()#> implements \JsonSerializable
+class <#=entityCheckedCase#> implements \JsonSerializable
 <#
 } else {
 #>
@@ -29,7 +34,7 @@ class <#=entityName.ToCheckedCase()#> extends <#=entityBaseName#>
 #>
 {
 <#
-if (entity.Name.ToCheckedCase() == "Entity") {
+if (entityCheckedCase == "Entity") {
 #>
     /**
     * The array of properties available
@@ -40,7 +45,7 @@ if (entity.Name.ToCheckedCase() == "Entity") {
     protected $_propDict;
     
     /**
-    * Construct a new <#=entity.Name.ToCheckedCase()#>
+    * Construct a new <#=entityCheckedCase#>
     *
     * @param array $propDict A list of properties to set
     */
@@ -62,7 +67,19 @@ if (entity.Name.ToCheckedCase() == "Entity") {
 <#
 }
 foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString() != "bytes")){
-	String propertyName = property.Name.SanitizePropertyName(entityName).ToCamelize();
+    String propertyName = property.Name.SanitizePropertyName(entityName).ToCamelize();
+    var camelCasePropertyName = property.Name.ToCamelize();
+    var propertyTypeString = property.Type.GetTypeString();
+    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
+    
+    // Check whether this type is a generated model type or a PHP type
+    var fullPropertyTypeName = propertyTypeString[0] == '\\' || propertyTypeString.IsPHPPrimitiveType()
+                                ? propertyTypeString
+                                : string.Join("\\", propertyNamespace, propertyTypeString.SanitizeEntityName().ToCheckedCase());
+
+    var docsPropertyTypeReference = propertyNamespace == targetNamespace && !propertyTypeString.IsPHPPrimitiveType()
+                                ? propertyTypeString.SanitizeEntityName().ToCheckedCase()
+                                : fullPropertyTypeName;
     if (property.Type.IsComplex()) {
         if (property.IsCollection()) {
 #>
@@ -78,8 +95,8 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
      */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
-        if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
-           return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+        if (array_key_exists("<#=camelCasePropertyName#>", $this->_propDict)) {
+           return $this->_propDict["<#=camelCasePropertyName#>"];
         } else {
             return null;
         }
@@ -92,13 +109,13 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> $val The <#=propertyName#>
+    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entity.Name.ToCheckedCase()#>
+    * @return <#=entityCheckedCase#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
-		$this->_propDict["<#=property.Name.ToCamelize()#>"] = $val;
+		$this->_propDict["<#=camelCasePropertyName#>"] = $val;
         return $this;
     }
     
@@ -112,29 +129,19 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> The <#=propertyName#>
+    * @return <#=docsPropertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
-        if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
-<#
-var propertyTypeString = property.Type.GetTypeString();
-var camelCasePropertyName = property.Name.ToCamelize();
-// Check whether this type is a generated model type or a PHP type
-if (propertyTypeString[0] == '\\') { #>
-            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyTypeString#>")) {
-<# } else {
-    var propertyNamespace = TypeHelperPHP.GetPHPNamespace(property.Type, settings);
-#>
-            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=propertyNamespace#>\<#=propertyTypeString#>")) {
-<# } #>
+        if (array_key_exists("<#=camelCasePropertyName#>", $this->_propDict)) {
+            if (is_a($this->_propDict["<#=camelCasePropertyName#>"], "<#=fullPropertyTypeName#>")) {
                 return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
 <# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
                 $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
-                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
+                $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeString.SanitizeEntityName().ToCheckedCase()#>($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } #>
             }
@@ -149,18 +156,18 @@ if (propertyTypeString[0] == '\\') { #>
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=property.Type.GetTypeString().SanitizeEntityName().ToCheckedCase()#> $val The <#=propertyName#>
+    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entity.Name.ToCheckedCase()#>
+    * @return <#=entityCheckedCase#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
-<#  if (property.Type.GetTypeString() == "bool") { #>
-        $this->_propDict["<#=property.Name.ToCamelize()#>"] = boolval($val);
-<#  } else if (property.Type.GetTypeString() == "int") { #>
-        $this->_propDict["<#=property.Name.ToCamelize()#>"] = intval($val);
+<#  if (propertyTypeString == "bool") { #>
+        $this->_propDict["<#=camelCasePropertyName#>"] = boolval($val);
+<#  } else if (propertyTypeString == "int") { #>
+        $this->_propDict["<#=camelCasePropertyName#>"] = intval($val);
 <# } else { #>
-        $this->_propDict["<#=property.Name.ToCamelize()#>"] = $val;
+        $this->_propDict["<#=camelCasePropertyName#>"] = $val;
 <# } #>
         return $this;
     }
@@ -176,19 +183,19 @@ if (propertyTypeString[0] == '\\') { #>
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=property.Type.GetTypeString()#> The <#=propertyName#>
+    * @return <#=docsPropertyTypeReference#> The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
-        if (array_key_exists("<#=property.Name.ToCamelize()#>", $this->_propDict)) {
+        if (array_key_exists("<#=camelCasePropertyName#>", $this->_propDict)) {
 <#
-            if (property.Type.GetTypeString() == "\\DateTime") {
+            if (propertyTypeString == "\\DateTime") {
 #>
-            return new \DateTime($this->_propDict["<#=property.Name.ToCamelize()#>"]);
+            return new \DateTime($this->_propDict["<#=camelCasePropertyName#>"]);
 <#
             } else {
 #>
-            return $this->_propDict["<#=property.Name.ToCamelize()#>"];
+            return $this->_propDict["<#=camelCasePropertyName#>"];
 <#
             }
 #>
@@ -204,23 +211,23 @@ if (propertyTypeString[0] == '\\') { #>
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=property.Type.GetTypeString()#> $val The <#=propertyName#>
+    * @param <#=docsPropertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entity.Name.ToCheckedCase()#>
+    * @return <#=entityCheckedCase#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
 <#
-    if (property.Type.GetTypeString() == "\\DateTime") {
+    if (propertyTypeString == "\\DateTime") {
 #>
-        $this->_propDict["<#=property.Name.ToCamelize()#>"] 
+        $this->_propDict["<#=camelCasePropertyName#>"] 
             = $val->format(\DateTime::ISO8601) . "Z";
 <#
       } else {
 #>
-<#  if (property.Type.GetTypeString() == "bool") { #>
+<#  if (propertyTypeString == "bool") { #>
         $this->_propDict["<#=property.Name#>"] = boolval($val);
-<#  } else if (property.Type.GetTypeString() == "int") { #>
+<#  } else if (propertyTypeString == "int") { #>
         $this->_propDict["<#=property.Name#>"] = intval($val);
 <# } else { #>
         $this->_propDict["<#=property.Name#>"] = $val;
@@ -234,7 +241,7 @@ if (propertyTypeString[0] == '\\') { #>
 <#
 		}
 	}
-	if (entity.Name.ToCheckedCase() == "Entity") {
+	if (entityCheckedCase == "Entity") {
 #>
     /**
     * Gets the ODataType

--- a/Templates/PHP/Model/EnumType.php.tt
+++ b/Templates/PHP/Model/EnumType.php.tt
@@ -6,15 +6,9 @@ CustomT4Host host               = (CustomT4Host) Host;
 OdcmModel model                 = host.CurrentModel;
 CodeWriterPHP writer            = (CodeWriterPHP) host.CodeWriter;
 TemplateWriterSettings settings = ConfigurationService.Settings;
-string targetNamespace          = @"Microsoft\Graph\Model";
 var enumT                       = host.CurrentType.AsOdcmEnum();
 
-// TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
-// documentation for more information on how the TemplateWriterSettings.Properties is used.
-if (settings.Properties.ContainsKey("php.namespace"))
-{
-    targetNamespace = settings.Properties["php.namespace"];
-}      
+string targetNamespace          = TypeHelperPHP.GetPHPNamespace(enumT, settings);
 
 #>
 <#=writer.WriteHeader(writer.GetDocBlock(enumT.Name.ToCheckedCase()))#>

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -82,6 +82,22 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
             }
         }
 
+        public static bool IsPHPPrimitiveType(this string type)
+        {
+            switch (type)
+            {
+                case "string":
+                    return true;
+                case "int":
+                    return true;
+                case "bool":
+                    return true;
+                case "float":
+                    return true;
+                default:
+                    return false;
+            }
+        }
 
         public static string GetTypeString(this OdcmParameter parameter)
         {

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -241,5 +241,23 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
 
             return string.Join("\\", baseNamespace, baseTypeName);
         }
+
+        public static string GetPHPEntityTypeReference(string @namespace, TemplateWriterSettings settings)
+        {
+            switch (@namespace)
+            {
+                case "Microsoft\\Graph\\Model":
+                    return "Entity";
+                case "Beta\\Microsoft\\Graph\\Model":
+                    return "Entity";
+                default:
+                    if (settings.Properties.ContainsKey("php.namespacePrefix"))
+                    {
+                        return $"\\{settings.Properties["php.namespacePrefix"]}\\Microsoft\\Graph\\Model\\Entity";
+                    }
+
+                    return "\\Microsoft\\Graph\\Model\\Entity";
+            }
+        }
     }
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -242,6 +242,17 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
             return string.Join("\\", baseNamespace, baseTypeName);
         }
 
+        /// <summary>
+        /// Gets either fully qualified or plain type name for entity
+        /// </summary>
+        /// <param name="namespace">namespace of the file which references Entity</param>
+        /// <param name="settings">settings in case namespacePrefix is set</param>
+        /// <returns>
+        /// if the namespace is shared
+        ///     Entity
+        /// if from another namespace:
+        ///     <\OptionalNamespacePrefix>\Microsoft\Graph\Model\Entity e.g. \Beta\Microsoft\Graph\Model\Entity or \Microsoft\Graph\Model\Entity
+        /// </returns>
         public static string GetPHPEntityTypeReference(string @namespace, TemplateWriterSettings settings)
         {
             switch (@namespace)

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -201,5 +201,29 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
 
             return GetPHPNamespace(@namespace, namespacePrefix) + @"\Model";
         }
+
+        /// <summary>
+        /// Creates a base type reference for class declaration
+        /// </summary>
+        /// <param name="base">base odcm type</param>
+        /// <param name="childNamespace">child classes namespace (i.e. in which context the namespace is referenced)</param>
+        /// <param name="settings">settings in case namespacePrefix is set</param>
+        /// <returns>Either fully qualified or plain type name of a base type</returns>
+        public static string GetBaseTypeFullName(OdcmType @base, string childNamespace, TemplateWriterSettings settings)
+        {
+            if (@base == null)
+            {
+                return string.Empty;
+            }
+
+            var baseNamespace = GetPHPNamespace(@base, settings);
+            var baseTypeName = @base.Name.SanitizeEntityName().ToCheckedCase();
+            if (baseNamespace == childNamespace)
+            {
+                return baseTypeName;
+            }
+
+            return string.Join("\\", baseNamespace, baseTypeName);
+        }
     }
 }

--- a/src/GraphODataTemplateWriter/PathWriters/PHPPathWriter.cs
+++ b/src/GraphODataTemplateWriter/PathWriters/PHPPathWriter.cs
@@ -24,6 +24,20 @@ namespace Microsoft.Graph.ODataTemplateWriter.PathWriters
             return filePath;
         }
 
+        public override string WritePath(ITemplateInfo template, string @namespace, string entityTypeName)
+        {
+            // for backwards compatibility e.g. we want folders to be com/Microsoft/Graph/Model for default namespace.
+            // TODO: maybe we can break this assumption by modifying the pipelines which copy the files after generation.
+            // maybe remove this.
+            var theNamespace = "com." + @namespace + ".Model";
+            var namespacePath = this.CreatePathFromNamespace(theNamespace);
+
+            var fileName = Extensions.StringExtensions.ToCheckedCase(this.TransformFileName(template, TypeHelperPHP.SanitizeEntityName(entityTypeName)));
+
+            String filePath = Path.Combine(namespacePath, fileName);
+            return filePath;
+        }
+
         private string CreateNamespace(string folderName)
         {
             var @namespace = this.Model.GetNamespace();

--- a/src/GraphODataTemplateWriter/PathWriters/PHPPathWriter.cs
+++ b/src/GraphODataTemplateWriter/PathWriters/PHPPathWriter.cs
@@ -26,10 +26,18 @@ namespace Microsoft.Graph.ODataTemplateWriter.PathWriters
 
         public override string WritePath(ITemplateInfo template, string @namespace, string entityTypeName)
         {
+            var namespacePrefix = string.Empty;
+            // TemplateWriterSettings.Properties are set at the Typewriter command line. Check the command line 
+            // documentation for more information on how the TemplateWriterSettings.Properties is used.
+            if (ConfigurationService.Settings.Properties.ContainsKey("php.namespacePrefix"))
+            {
+                namespacePrefix = ConfigurationService.Settings.Properties["php.namespacePrefix"] + ".";
+            }
+
             // for backwards compatibility e.g. we want folders to be com/Microsoft/Graph/Model for default namespace.
             // TODO: maybe we can break this assumption by modifying the pipelines which copy the files after generation.
             // maybe remove this.
-            var theNamespace = "com." + @namespace + ".Model";
+            var theNamespace = $"com.{namespacePrefix}{@namespace}.Model";
             var namespacePath = this.CreatePathFromNamespace(theNamespace);
 
             var fileName = Extensions.StringExtensions.ToCheckedCase(this.TransformFileName(template, TypeHelperPHP.SanitizeEntityName(entityTypeName)));

--- a/src/Typewriter/Options.cs
+++ b/src/Typewriter/Options.cs
@@ -75,7 +75,7 @@ namespace Typewriter
 
         [Option('p', "properties",  HelpText = "A space separated list of properties in the form of 'key:value'. These properties can be accessed in the " +
             "templates from the TemplateWriterSettings object returned by ConfigurationService.Settings. The suggested convention for specifying a key should be " +
-            "the targeted template language name and the property name. For example, php.namespace:Microsoft\\Graph\\Beta\\Model would be a property to be consumed in the PHP templates.")]
+            "the targeted template language name and the property name. For example, php.namespacePrefix:Beta would be a property to be consumed in the PHP templates.")]
         public IEnumerable<string> Properties { get; set; }
 
         [Option('t', "transform", HelpText = "Specify the URI to the XSLT that will preprocess the metadata. Overrides the" +

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -44,20 +44,20 @@ namespace Typewriter.Test
         [TestMethod]
         public void It_generates_PHP_models_with_a_property()
         {
-            const string testNamespace = "TEST.NAMESPACE";
+            const string testNamespace = "Beta";
             const string outputDirectory = "output";
             
             Options options = new Options()
             {
                 Output = outputDirectory,
                 Language = "PHP",
-                Properties = new List<string>() { $"php.namespace:{testNamespace}" },
+                Properties = new List<string>() { $"php.namespacePrefix:{testNamespace}" },
                 GenerationMode = GenerationMode.Files
             };
 
             Generator.GenerateFiles(testMetadata, options);
 
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Model\Entity.php");
+            FileInfo fileInfo = new FileInfo(outputDirectory + @"\com\Beta\Microsoft\Graph\Model\Entity.php");
             Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
 
             // Check that the namespace applied at the CLI was added to the document.

--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -12,7 +12,8 @@ namespace Typewriter.Test
     {
         CSharp,
         Java,
-        TypeScript
+        TypeScript,
+        PHP
     }
 
     public static class MultipleNamespacesTestRunner
@@ -25,7 +26,7 @@ namespace Typewriter.Test
         private const string MetadataMultipleNamespacesFile = "MetadataMultipleNamespaces.xml";
 
         // contains microsoft.graph and microsoft.graph.callRecords
-        // TypeScript relies on the assumption that all namespaces will be a subnamespace to microsoft.graph
+        // TypeScript and PHP rely on the assumption that all namespaces will be a subnamespace to microsoft.graph
         // and generation process creates a single file with nested namespaces
         private const string MetadataWithSubNamespacesFile = "MetadataWithSubNamespaces.xml";
 
@@ -40,6 +41,8 @@ namespace Typewriter.Test
                     case TestLanguage.Java:
                         return MetadataMultipleNamespacesFile;
                     case TestLanguage.TypeScript:
+                        return MetadataWithSubNamespacesFile;
+                    case TestLanguage.PHP:
                         return MetadataWithSubNamespacesFile;
                     default:
                         throw new ArgumentException("unexpected test language", nameof(testLanguage));
@@ -138,6 +141,9 @@ namespace Typewriter.Test
                     break;
                 case TestLanguage.TypeScript:
                     extension = "*.ts";
+                    break;
+                case TestLanguage.PHP:
+                    extension = "*.php";
                     break;
                 default:
                     throw new ArgumentException("unexpected test language", nameof(language));

--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -30,7 +30,7 @@ namespace Typewriter.Test
         // and generation process creates a single file with nested namespaces
         private const string MetadataWithSubNamespacesFile = "MetadataWithSubNamespaces.xml";
 
-        public static void Run(TestLanguage language)
+        public static void Run(TestLanguage language, bool isPhpBeta = false)
         {
             string getMetadataFile(TestLanguage testLanguage)
             {
@@ -51,14 +51,20 @@ namespace Typewriter.Test
 
             // Arrange
             var languageStr = language.ToString();
-            var outputDirectoryName = OutputDirectoryPrefix + languageStr;
-            var testDataDirectoryName = TestDataDirectoryPrefix + languageStr;
+            var directoryPostfix = isPhpBeta ? "PHPBeta" : languageStr;
+            var outputDirectoryName = OutputDirectoryPrefix + directoryPostfix;
+            var testDataDirectoryName = TestDataDirectoryPrefix + directoryPostfix;
 
             var currentDirectory = Directory.GetCurrentDirectory();
             var outputDirectory = Path.Combine(currentDirectory, outputDirectoryName);
             var dataDirectory = Path.Combine(currentDirectory, testDataDirectoryName);
             var metadataFile = Path.Combine(currentDirectory, MetadataDirectoryName, getMetadataFile(language));
             var typewriterParameters = $"-v Info -m {metadataFile} -o {outputDirectory} -g Files -l {languageStr}";
+
+            if (isPhpBeta)
+            {
+                typewriterParameters += " -p php.namespacePrefix:Beta";
+            }
 
             // Act
             if (Directory.Exists(outputDirectory))

--- a/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
+++ b/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Typewriter.Test
+{
+    [TestClass]
+    public class PHPMultipleNamespacesTests
+    {
+        [TestMethod]
+        public void Test()
+        {
+            MultipleNamespacesTestRunner.Run(TestLanguage.PHP);
+        }
+    }
+}

--- a/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
+++ b/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
@@ -10,5 +10,11 @@ namespace Typewriter.Test
         {
             MultipleNamespacesTestRunner.Run(TestLanguage.PHP);
         }
+
+        [TestMethod]
+        public void TestBeta()
+        {
+            MultipleNamespacesTestRunner.Run(TestLanguage.PHP, isPhpBeta: true);
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallRecord.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallRecord.php
@@ -1,0 +1,348 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* CallRecord File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* CallRecord class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class CallRecord extends \Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the version
+    *
+    * @return int The version
+    */
+    public function getVersion()
+    {
+        if (array_key_exists("version", $this->_propDict)) {
+            return $this->_propDict["version"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the version
+    *
+    * @param int $val The version
+    *
+    * @return CallRecord
+    */
+    public function setVersion($val)
+    {
+        $this->_propDict["version"] = intval($val);
+        return $this;
+    }
+    
+    /**
+    * Gets the type
+    *
+    * @return CallType The type
+    */
+    public function getType()
+    {
+        if (array_key_exists("type", $this->_propDict)) {
+            if (is_a($this->_propDict["type"], "Microsoft\Graph\CallRecords\Model\CallType")) {
+                return $this->_propDict["type"];
+            } else {
+                $this->_propDict["type"] = new CallType($this->_propDict["type"]);
+                return $this->_propDict["type"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the type
+    *
+    * @param CallType $val The type
+    *
+    * @return CallRecord
+    */
+    public function setType($val)
+    {
+        $this->_propDict["type"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the modalities
+     *
+     * @return array The modalities
+     */
+    public function getModalities()
+    {
+        if (array_key_exists("modalities", $this->_propDict)) {
+           return $this->_propDict["modalities"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the modalities
+    *
+    * @param Modality $val The modalities
+    *
+    * @return CallRecord
+    */
+    public function setModalities($val)
+    {
+		$this->_propDict["modalities"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the lastModifiedDateTime
+    *
+    * @return \DateTime The lastModifiedDateTime
+    */
+    public function getLastModifiedDateTime()
+    {
+        if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], "\DateTime")) {
+                return $this->_propDict["lastModifiedDateTime"];
+            } else {
+                $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);
+                return $this->_propDict["lastModifiedDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the lastModifiedDateTime
+    *
+    * @param \DateTime $val The lastModifiedDateTime
+    *
+    * @return CallRecord
+    */
+    public function setLastModifiedDateTime($val)
+    {
+        $this->_propDict["lastModifiedDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return CallRecord
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return CallRecord
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the organizer
+    *
+    * @return Microsoft\Graph\Model\IdentitySet The organizer
+    */
+    public function getOrganizer()
+    {
+        if (array_key_exists("organizer", $this->_propDict)) {
+            if (is_a($this->_propDict["organizer"], "Microsoft\Graph\Model\IdentitySet")) {
+                return $this->_propDict["organizer"];
+            } else {
+                $this->_propDict["organizer"] = new Microsoft\Graph\Model\IdentitySet($this->_propDict["organizer"]);
+                return $this->_propDict["organizer"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the organizer
+    *
+    * @param Microsoft\Graph\Model\IdentitySet $val The organizer
+    *
+    * @return CallRecord
+    */
+    public function setOrganizer($val)
+    {
+        $this->_propDict["organizer"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the participants
+     *
+     * @return array The participants
+     */
+    public function getParticipants()
+    {
+        if (array_key_exists("participants", $this->_propDict)) {
+           return $this->_propDict["participants"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the participants
+    *
+    * @param Microsoft\Graph\Model\IdentitySet $val The participants
+    *
+    * @return CallRecord
+    */
+    public function setParticipants($val)
+    {
+		$this->_propDict["participants"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the joinWebUrl
+    *
+    * @return string The joinWebUrl
+    */
+    public function getJoinWebUrl()
+    {
+        if (array_key_exists("joinWebUrl", $this->_propDict)) {
+            return $this->_propDict["joinWebUrl"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the joinWebUrl
+    *
+    * @param string $val The joinWebUrl
+    *
+    * @return CallRecord
+    */
+    public function setJoinWebUrl($val)
+    {
+        $this->_propDict["joinWebUrl"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the sessions
+     *
+     * @return array The sessions
+     */
+    public function getSessions()
+    {
+        if (array_key_exists("sessions", $this->_propDict)) {
+           return $this->_propDict["sessions"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the sessions
+    *
+    * @param Session $val The sessions
+    *
+    * @return CallRecord
+    */
+    public function setSessions($val)
+    {
+		$this->_propDict["sessions"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the recipients
+     *
+     * @return array The recipients
+     */
+    public function getRecipients()
+    {
+        if (array_key_exists("recipients", $this->_propDict)) {
+           return $this->_propDict["recipients"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the recipients
+    *
+    * @param Microsoft\Graph\Model\EntityType2 $val The recipients
+    *
+    * @return CallRecord
+    */
+    public function setRecipients($val)
+    {
+		$this->_propDict["recipients"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallType.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* CallType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* CallType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class CallType extends Enum
+{
+    /**
+    * The Enum CallType
+    */
+    const UNKNOWN = "unknown";
+    const GROUP_CALL = "groupCall";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ClientPlatform.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ClientPlatform.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ClientPlatform File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* ClientPlatform class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ClientPlatform extends Enum
+{
+    /**
+    * The Enum ClientPlatform
+    */
+    const UNKNOWN = "unknown";
+    const WINDOWS = "windows";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ClientUserAgent.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ClientUserAgent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ClientUserAgent File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* ClientUserAgent class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ClientUserAgent extends UserAgent
+{
+
+    /**
+    * Gets the platform
+    *
+    * @return ClientPlatform The platform
+    */
+    public function getPlatform()
+    {
+        if (array_key_exists("platform", $this->_propDict)) {
+            if (is_a($this->_propDict["platform"], "Microsoft\Graph\CallRecords\Model\ClientPlatform")) {
+                return $this->_propDict["platform"];
+            } else {
+                $this->_propDict["platform"] = new ClientPlatform($this->_propDict["platform"]);
+                return $this->_propDict["platform"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the platform
+    *
+    * @param ClientPlatform $val The value to assign to the platform
+    *
+    * @return ClientUserAgent The ClientUserAgent
+    */
+    public function setPlatform($val)
+    {
+        $this->_propDict["platform"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the productFamily
+    *
+    * @return ProductFamily The productFamily
+    */
+    public function getProductFamily()
+    {
+        if (array_key_exists("productFamily", $this->_propDict)) {
+            if (is_a($this->_propDict["productFamily"], "Microsoft\Graph\CallRecords\Model\ProductFamily")) {
+                return $this->_propDict["productFamily"];
+            } else {
+                $this->_propDict["productFamily"] = new ProductFamily($this->_propDict["productFamily"]);
+                return $this->_propDict["productFamily"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the productFamily
+    *
+    * @param ProductFamily $val The value to assign to the productFamily
+    *
+    * @return ClientUserAgent The ClientUserAgent
+    */
+    public function setProductFamily($val)
+    {
+        $this->_propDict["productFamily"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/DeviceInfo.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/DeviceInfo.php
@@ -1,0 +1,109 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* DeviceInfo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* DeviceInfo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class DeviceInfo extends Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the captureDeviceName
+    *
+    * @return string The captureDeviceName
+    */
+    public function getCaptureDeviceName()
+    {
+        if (array_key_exists("captureDeviceName", $this->_propDict)) {
+            return $this->_propDict["captureDeviceName"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the captureDeviceName
+    *
+    * @param string $val The value of the captureDeviceName
+    *
+    * @return DeviceInfo
+    */
+    public function setCaptureDeviceName($val)
+    {
+        $this->_propDict["captureDeviceName"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the sentSignalLevel
+    *
+    * @return int The sentSignalLevel
+    */
+    public function getSentSignalLevel()
+    {
+        if (array_key_exists("sentSignalLevel", $this->_propDict)) {
+            return $this->_propDict["sentSignalLevel"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the sentSignalLevel
+    *
+    * @param int $val The value of the sentSignalLevel
+    *
+    * @return DeviceInfo
+    */
+    public function setSentSignalLevel($val)
+    {
+        $this->_propDict["sentSignalLevel"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the speakerGlitchRate
+    *
+    * @return Microsoft\Graph\Model\Single The speakerGlitchRate
+    */
+    public function getSpeakerGlitchRate()
+    {
+        if (array_key_exists("speakerGlitchRate", $this->_propDict)) {
+            if (is_a($this->_propDict["speakerGlitchRate"], "Microsoft\Graph\Model\Single")) {
+                return $this->_propDict["speakerGlitchRate"];
+            } else {
+                $this->_propDict["speakerGlitchRate"] = new Microsoft\Graph\Model\Single($this->_propDict["speakerGlitchRate"]);
+                return $this->_propDict["speakerGlitchRate"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the speakerGlitchRate
+    *
+    * @param Microsoft\Graph\Model\Single $val The value to assign to the speakerGlitchRate
+    *
+    * @return DeviceInfo The DeviceInfo
+    */
+    public function setSpeakerGlitchRate($val)
+    {
+        $this->_propDict["speakerGlitchRate"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Endpoint.php
@@ -1,0 +1,57 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Endpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* Endpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Endpoint extends Microsoft\Graph\Model\Entity
+{
+
+    /**
+    * Gets the userAgent
+    *
+    * @return UserAgent The userAgent
+    */
+    public function getUserAgent()
+    {
+        if (array_key_exists("userAgent", $this->_propDict)) {
+            if (is_a($this->_propDict["userAgent"], "Microsoft\Graph\CallRecords\Model\UserAgent")) {
+                return $this->_propDict["userAgent"];
+            } else {
+                $this->_propDict["userAgent"] = new UserAgent($this->_propDict["userAgent"]);
+                return $this->_propDict["userAgent"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the userAgent
+    *
+    * @param UserAgent $val The value to assign to the userAgent
+    *
+    * @return Endpoint The Endpoint
+    */
+    public function setUserAgent($val)
+    {
+        $this->_propDict["userAgent"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FailureInfo.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FailureInfo.php
@@ -1,0 +1,83 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* FailureInfo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* FailureInfo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class FailureInfo extends Microsoft\Graph\Model\Entity
+{
+
+    /**
+    * Gets the stage
+    *
+    * @return FailureStage The stage
+    */
+    public function getStage()
+    {
+        if (array_key_exists("stage", $this->_propDict)) {
+            if (is_a($this->_propDict["stage"], "Microsoft\Graph\CallRecords\Model\FailureStage")) {
+                return $this->_propDict["stage"];
+            } else {
+                $this->_propDict["stage"] = new FailureStage($this->_propDict["stage"]);
+                return $this->_propDict["stage"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the stage
+    *
+    * @param FailureStage $val The value to assign to the stage
+    *
+    * @return FailureInfo The FailureInfo
+    */
+    public function setStage($val)
+    {
+        $this->_propDict["stage"] = $val;
+         return $this;
+    }
+    /**
+    * Gets the reason
+    *
+    * @return string The reason
+    */
+    public function getReason()
+    {
+        if (array_key_exists("reason", $this->_propDict)) {
+            return $this->_propDict["reason"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the reason
+    *
+    * @param string $val The value of the reason
+    *
+    * @return FailureInfo
+    */
+    public function setReason($val)
+    {
+        $this->_propDict["reason"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FailureStage.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FailureStage.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* FailureStage File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* FailureStage class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class FailureStage extends Enum
+{
+    /**
+    * The Enum FailureStage
+    */
+    const UNKNOWN = "unknown";
+    const CALL_SETUP = "callSetup";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FeedbackTokenSet.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/FeedbackTokenSet.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* FeedbackTokenSet File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* FeedbackTokenSet class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class FeedbackTokenSet extends Microsoft\Graph\Model\Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Media.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Media.php
@@ -1,0 +1,145 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Media File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* Media class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Media extends Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the label
+    *
+    * @return string The label
+    */
+    public function getLabel()
+    {
+        if (array_key_exists("label", $this->_propDict)) {
+            return $this->_propDict["label"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the label
+    *
+    * @param string $val The value of the label
+    *
+    * @return Media
+    */
+    public function setLabel($val)
+    {
+        $this->_propDict["label"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the callerNetwork
+    *
+    * @return NetworkInfo The callerNetwork
+    */
+    public function getCallerNetwork()
+    {
+        if (array_key_exists("callerNetwork", $this->_propDict)) {
+            if (is_a($this->_propDict["callerNetwork"], "Microsoft\Graph\CallRecords\Model\NetworkInfo")) {
+                return $this->_propDict["callerNetwork"];
+            } else {
+                $this->_propDict["callerNetwork"] = new NetworkInfo($this->_propDict["callerNetwork"]);
+                return $this->_propDict["callerNetwork"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the callerNetwork
+    *
+    * @param NetworkInfo $val The value to assign to the callerNetwork
+    *
+    * @return Media The Media
+    */
+    public function setCallerNetwork($val)
+    {
+        $this->_propDict["callerNetwork"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the callerDevice
+    *
+    * @return DeviceInfo The callerDevice
+    */
+    public function getCallerDevice()
+    {
+        if (array_key_exists("callerDevice", $this->_propDict)) {
+            if (is_a($this->_propDict["callerDevice"], "Microsoft\Graph\CallRecords\Model\DeviceInfo")) {
+                return $this->_propDict["callerDevice"];
+            } else {
+                $this->_propDict["callerDevice"] = new DeviceInfo($this->_propDict["callerDevice"]);
+                return $this->_propDict["callerDevice"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the callerDevice
+    *
+    * @param DeviceInfo $val The value to assign to the callerDevice
+    *
+    * @return Media The Media
+    */
+    public function setCallerDevice($val)
+    {
+        $this->_propDict["callerDevice"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the streams
+    *
+    * @return MediaStream The streams
+    */
+    public function getStreams()
+    {
+        if (array_key_exists("streams", $this->_propDict)) {
+            if (is_a($this->_propDict["streams"], "Microsoft\Graph\CallRecords\Model\MediaStream")) {
+                return $this->_propDict["streams"];
+            } else {
+                $this->_propDict["streams"] = new MediaStream($this->_propDict["streams"]);
+                return $this->_propDict["streams"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the streams
+    *
+    * @param MediaStream $val The value to assign to the streams
+    *
+    * @return Media The Media
+    */
+    public function setStreams($val)
+    {
+        $this->_propDict["streams"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/MediaStream.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/MediaStream.php
@@ -1,0 +1,228 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* MediaStream File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* MediaStream class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class MediaStream extends Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the streamId
+    *
+    * @return string The streamId
+    */
+    public function getStreamId()
+    {
+        if (array_key_exists("streamId", $this->_propDict)) {
+            return $this->_propDict["streamId"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the streamId
+    *
+    * @param string $val The value of the streamId
+    *
+    * @return MediaStream
+    */
+    public function setStreamId($val)
+    {
+        $this->_propDict["streamId"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The value to assign to the startDateTime
+    *
+    * @return MediaStream The MediaStream
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the streamDirection
+    *
+    * @return MediaStreamDirection The streamDirection
+    */
+    public function getStreamDirection()
+    {
+        if (array_key_exists("streamDirection", $this->_propDict)) {
+            if (is_a($this->_propDict["streamDirection"], "Microsoft\Graph\CallRecords\Model\MediaStreamDirection")) {
+                return $this->_propDict["streamDirection"];
+            } else {
+                $this->_propDict["streamDirection"] = new MediaStreamDirection($this->_propDict["streamDirection"]);
+                return $this->_propDict["streamDirection"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the streamDirection
+    *
+    * @param MediaStreamDirection $val The value to assign to the streamDirection
+    *
+    * @return MediaStream The MediaStream
+    */
+    public function setStreamDirection($val)
+    {
+        $this->_propDict["streamDirection"] = $val;
+         return $this;
+    }
+    /**
+    * Gets the packetUtilization
+    *
+    * @return int The packetUtilization
+    */
+    public function getPacketUtilization()
+    {
+        if (array_key_exists("packetUtilization", $this->_propDict)) {
+            return $this->_propDict["packetUtilization"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the packetUtilization
+    *
+    * @param int $val The value of the packetUtilization
+    *
+    * @return MediaStream
+    */
+    public function setPacketUtilization($val)
+    {
+        $this->_propDict["packetUtilization"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the wasMediaBypassed
+    *
+    * @return bool The wasMediaBypassed
+    */
+    public function getWasMediaBypassed()
+    {
+        if (array_key_exists("wasMediaBypassed", $this->_propDict)) {
+            return $this->_propDict["wasMediaBypassed"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the wasMediaBypassed
+    *
+    * @param bool $val The value of the wasMediaBypassed
+    *
+    * @return MediaStream
+    */
+    public function setWasMediaBypassed($val)
+    {
+        $this->_propDict["wasMediaBypassed"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the lowVideoProcessingCapabilityRatio
+    *
+    * @return Microsoft\Graph\Model\Single The lowVideoProcessingCapabilityRatio
+    */
+    public function getLowVideoProcessingCapabilityRatio()
+    {
+        if (array_key_exists("lowVideoProcessingCapabilityRatio", $this->_propDict)) {
+            if (is_a($this->_propDict["lowVideoProcessingCapabilityRatio"], "Microsoft\Graph\Model\Single")) {
+                return $this->_propDict["lowVideoProcessingCapabilityRatio"];
+            } else {
+                $this->_propDict["lowVideoProcessingCapabilityRatio"] = new Microsoft\Graph\Model\Single($this->_propDict["lowVideoProcessingCapabilityRatio"]);
+                return $this->_propDict["lowVideoProcessingCapabilityRatio"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the lowVideoProcessingCapabilityRatio
+    *
+    * @param Microsoft\Graph\Model\Single $val The value to assign to the lowVideoProcessingCapabilityRatio
+    *
+    * @return MediaStream The MediaStream
+    */
+    public function setLowVideoProcessingCapabilityRatio($val)
+    {
+        $this->_propDict["lowVideoProcessingCapabilityRatio"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the averageAudioNetworkJitter
+    *
+    * @return Microsoft\Graph\Model\Duration The averageAudioNetworkJitter
+    */
+    public function getAverageAudioNetworkJitter()
+    {
+        if (array_key_exists("averageAudioNetworkJitter", $this->_propDict)) {
+            if (is_a($this->_propDict["averageAudioNetworkJitter"], "Microsoft\Graph\Model\Duration")) {
+                return $this->_propDict["averageAudioNetworkJitter"];
+            } else {
+                $this->_propDict["averageAudioNetworkJitter"] = new Microsoft\Graph\Model\Duration($this->_propDict["averageAudioNetworkJitter"]);
+                return $this->_propDict["averageAudioNetworkJitter"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the averageAudioNetworkJitter
+    *
+    * @param Microsoft\Graph\Model\Duration $val The value to assign to the averageAudioNetworkJitter
+    *
+    * @return MediaStream The MediaStream
+    */
+    public function setAverageAudioNetworkJitter($val)
+    {
+        $this->_propDict["averageAudioNetworkJitter"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/MediaStreamDirection.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/MediaStreamDirection.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* MediaStreamDirection File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* MediaStreamDirection class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class MediaStreamDirection extends Enum
+{
+    /**
+    * The Enum MediaStreamDirection
+    */
+    const CALLER_TO_CALLEE = "callerToCallee";
+    const CALLEE_TO_CALLER = "calleeToCaller";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Modality.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Modality.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Modality File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* Modality class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Modality extends Enum
+{
+    /**
+    * The Enum Modality
+    */
+    const AUDIO = "audio";
+    const VIDEO = "video";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/NetworkConnectionType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/NetworkConnectionType.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* NetworkConnectionType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* NetworkConnectionType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class NetworkConnectionType extends Enum
+{
+    /**
+    * The Enum NetworkConnectionType
+    */
+    const UNKNOWN = "unknown";
+    const WIRED = "wired";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/NetworkInfo.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/NetworkInfo.php
@@ -1,0 +1,202 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* NetworkInfo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* NetworkInfo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class NetworkInfo extends Microsoft\Graph\Model\Entity
+{
+
+    /**
+    * Gets the connectionType
+    *
+    * @return NetworkConnectionType The connectionType
+    */
+    public function getConnectionType()
+    {
+        if (array_key_exists("connectionType", $this->_propDict)) {
+            if (is_a($this->_propDict["connectionType"], "Microsoft\Graph\CallRecords\Model\NetworkConnectionType")) {
+                return $this->_propDict["connectionType"];
+            } else {
+                $this->_propDict["connectionType"] = new NetworkConnectionType($this->_propDict["connectionType"]);
+                return $this->_propDict["connectionType"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the connectionType
+    *
+    * @param NetworkConnectionType $val The value to assign to the connectionType
+    *
+    * @return NetworkInfo The NetworkInfo
+    */
+    public function setConnectionType($val)
+    {
+        $this->_propDict["connectionType"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the wifiBand
+    *
+    * @return WifiBand The wifiBand
+    */
+    public function getWifiBand()
+    {
+        if (array_key_exists("wifiBand", $this->_propDict)) {
+            if (is_a($this->_propDict["wifiBand"], "Microsoft\Graph\CallRecords\Model\WifiBand")) {
+                return $this->_propDict["wifiBand"];
+            } else {
+                $this->_propDict["wifiBand"] = new WifiBand($this->_propDict["wifiBand"]);
+                return $this->_propDict["wifiBand"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the wifiBand
+    *
+    * @param WifiBand $val The value to assign to the wifiBand
+    *
+    * @return NetworkInfo The NetworkInfo
+    */
+    public function setWifiBand($val)
+    {
+        $this->_propDict["wifiBand"] = $val;
+         return $this;
+    }
+    /**
+    * Gets the basicServiceSetIdentifier
+    *
+    * @return string The basicServiceSetIdentifier
+    */
+    public function getBasicServiceSetIdentifier()
+    {
+        if (array_key_exists("basicServiceSetIdentifier", $this->_propDict)) {
+            return $this->_propDict["basicServiceSetIdentifier"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the basicServiceSetIdentifier
+    *
+    * @param string $val The value of the basicServiceSetIdentifier
+    *
+    * @return NetworkInfo
+    */
+    public function setBasicServiceSetIdentifier($val)
+    {
+        $this->_propDict["basicServiceSetIdentifier"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the wifiRadioType
+    *
+    * @return WifiRadioType The wifiRadioType
+    */
+    public function getWifiRadioType()
+    {
+        if (array_key_exists("wifiRadioType", $this->_propDict)) {
+            if (is_a($this->_propDict["wifiRadioType"], "Microsoft\Graph\CallRecords\Model\WifiRadioType")) {
+                return $this->_propDict["wifiRadioType"];
+            } else {
+                $this->_propDict["wifiRadioType"] = new WifiRadioType($this->_propDict["wifiRadioType"]);
+                return $this->_propDict["wifiRadioType"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the wifiRadioType
+    *
+    * @param WifiRadioType $val The value to assign to the wifiRadioType
+    *
+    * @return NetworkInfo The NetworkInfo
+    */
+    public function setWifiRadioType($val)
+    {
+        $this->_propDict["wifiRadioType"] = $val;
+         return $this;
+    }
+    /**
+    * Gets the wifiSignalStrength
+    *
+    * @return int The wifiSignalStrength
+    */
+    public function getWifiSignalStrength()
+    {
+        if (array_key_exists("wifiSignalStrength", $this->_propDict)) {
+            return $this->_propDict["wifiSignalStrength"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the wifiSignalStrength
+    *
+    * @param int $val The value of the wifiSignalStrength
+    *
+    * @return NetworkInfo
+    */
+    public function setWifiSignalStrength($val)
+    {
+        $this->_propDict["wifiSignalStrength"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the bandwidthLowEventRatio
+    *
+    * @return Microsoft\Graph\Model\Single The bandwidthLowEventRatio
+    */
+    public function getBandwidthLowEventRatio()
+    {
+        if (array_key_exists("bandwidthLowEventRatio", $this->_propDict)) {
+            if (is_a($this->_propDict["bandwidthLowEventRatio"], "Microsoft\Graph\Model\Single")) {
+                return $this->_propDict["bandwidthLowEventRatio"];
+            } else {
+                $this->_propDict["bandwidthLowEventRatio"] = new Microsoft\Graph\Model\Single($this->_propDict["bandwidthLowEventRatio"]);
+                return $this->_propDict["bandwidthLowEventRatio"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the bandwidthLowEventRatio
+    *
+    * @param Microsoft\Graph\Model\Single $val The value to assign to the bandwidthLowEventRatio
+    *
+    * @return NetworkInfo The NetworkInfo
+    */
+    public function setBandwidthLowEventRatio($val)
+    {
+        $this->_propDict["bandwidthLowEventRatio"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Option.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Option.php
@@ -1,0 +1,27 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Option File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* Option class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Option extends \Microsoft\Graph\Model\Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ParticipantEndpoint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ParticipantEndpoint.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ParticipantEndpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* ParticipantEndpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ParticipantEndpoint extends Endpoint
+{
+
+    /**
+    * Gets the identity
+    *
+    * @return Microsoft\Graph\Model\IdentitySet The identity
+    */
+    public function getIdentity()
+    {
+        if (array_key_exists("identity", $this->_propDict)) {
+            if (is_a($this->_propDict["identity"], "Microsoft\Graph\Model\IdentitySet")) {
+                return $this->_propDict["identity"];
+            } else {
+                $this->_propDict["identity"] = new Microsoft\Graph\Model\IdentitySet($this->_propDict["identity"]);
+                return $this->_propDict["identity"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the identity
+    *
+    * @param Microsoft\Graph\Model\IdentitySet $val The value to assign to the identity
+    *
+    * @return ParticipantEndpoint The ParticipantEndpoint
+    */
+    public function setIdentity($val)
+    {
+        $this->_propDict["identity"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the feedback
+    *
+    * @return UserFeedback The feedback
+    */
+    public function getFeedback()
+    {
+        if (array_key_exists("feedback", $this->_propDict)) {
+            if (is_a($this->_propDict["feedback"], "Microsoft\Graph\CallRecords\Model\UserFeedback")) {
+                return $this->_propDict["feedback"];
+            } else {
+                $this->_propDict["feedback"] = new UserFeedback($this->_propDict["feedback"]);
+                return $this->_propDict["feedback"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the feedback
+    *
+    * @param UserFeedback $val The value to assign to the feedback
+    *
+    * @return ParticipantEndpoint The ParticipantEndpoint
+    */
+    public function setFeedback($val)
+    {
+        $this->_propDict["feedback"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Photo.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Photo.php
@@ -1,0 +1,89 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Photo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* Photo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Photo extends \Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Photo
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the option
+    *
+    * @return Option The option
+    */
+    public function getOption()
+    {
+        if (array_key_exists("option", $this->_propDict)) {
+            if (is_a($this->_propDict["option"], "Microsoft\Graph\CallRecords\Model\Option")) {
+                return $this->_propDict["option"];
+            } else {
+                $this->_propDict["option"] = new Option($this->_propDict["option"]);
+                return $this->_propDict["option"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the option
+    *
+    * @param Option $val The option
+    *
+    * @return Photo
+    */
+    public function setOption($val)
+    {
+        $this->_propDict["option"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ProductFamily.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ProductFamily.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ProductFamily File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* ProductFamily class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ProductFamily extends Enum
+{
+    /**
+    * The Enum ProductFamily
+    */
+    const UNKNOWN = "unknown";
+    const TEAMS = "teams";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Segment.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Segment.php
@@ -1,0 +1,331 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Segment File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* Segment class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Segment extends \Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return Segment
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return Segment
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the caller
+    *
+    * @return Endpoint The caller
+    */
+    public function getCaller()
+    {
+        if (array_key_exists("caller", $this->_propDict)) {
+            if (is_a($this->_propDict["caller"], "Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["caller"];
+            } else {
+                $this->_propDict["caller"] = new Endpoint($this->_propDict["caller"]);
+                return $this->_propDict["caller"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the caller
+    *
+    * @param Endpoint $val The caller
+    *
+    * @return Segment
+    */
+    public function setCaller($val)
+    {
+        $this->_propDict["caller"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the callee
+    *
+    * @return Endpoint The callee
+    */
+    public function getCallee()
+    {
+        if (array_key_exists("callee", $this->_propDict)) {
+            if (is_a($this->_propDict["callee"], "Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["callee"];
+            } else {
+                $this->_propDict["callee"] = new Endpoint($this->_propDict["callee"]);
+                return $this->_propDict["callee"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the callee
+    *
+    * @param Endpoint $val The callee
+    *
+    * @return Segment
+    */
+    public function setCallee($val)
+    {
+        $this->_propDict["callee"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Segment
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the media
+     *
+     * @return array The media
+     */
+    public function getMedia()
+    {
+        if (array_key_exists("media", $this->_propDict)) {
+           return $this->_propDict["media"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the media
+    *
+    * @param Media $val The media
+    *
+    * @return Segment
+    */
+    public function setMedia($val)
+    {
+		$this->_propDict["media"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the refTypes
+     *
+     * @return array The refTypes
+     */
+    public function getRefTypes()
+    {
+        if (array_key_exists("refTypes", $this->_propDict)) {
+           return $this->_propDict["refTypes"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the refTypes
+    *
+    * @param Microsoft\Graph\Model\EntityType3 $val The refTypes
+    *
+    * @return Segment
+    */
+    public function setRefTypes($val)
+    {
+		$this->_propDict["refTypes"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the refType
+    *
+    * @return Microsoft\Graph\Model\Call The refType
+    */
+    public function getRefType()
+    {
+        if (array_key_exists("refType", $this->_propDict)) {
+            if (is_a($this->_propDict["refType"], "Microsoft\Graph\Model\Call")) {
+                return $this->_propDict["refType"];
+            } else {
+                $this->_propDict["refType"] = new Microsoft\Graph\Model\Call($this->_propDict["refType"]);
+                return $this->_propDict["refType"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the refType
+    *
+    * @param Microsoft\Graph\Model\Call $val The refType
+    *
+    * @return Segment
+    */
+    public function setRefType($val)
+    {
+        $this->_propDict["refType"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the sessionRef
+    *
+    * @return Session The sessionRef
+    */
+    public function getSessionRef()
+    {
+        if (array_key_exists("sessionRef", $this->_propDict)) {
+            if (is_a($this->_propDict["sessionRef"], "Microsoft\Graph\CallRecords\Model\Session")) {
+                return $this->_propDict["sessionRef"];
+            } else {
+                $this->_propDict["sessionRef"] = new Session($this->_propDict["sessionRef"]);
+                return $this->_propDict["sessionRef"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the sessionRef
+    *
+    * @param Session $val The sessionRef
+    *
+    * @return Segment
+    */
+    public function setSessionRef($val)
+    {
+        $this->_propDict["sessionRef"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the photo
+    *
+    * @return Photo The photo
+    */
+    public function getPhoto()
+    {
+        if (array_key_exists("photo", $this->_propDict)) {
+            if (is_a($this->_propDict["photo"], "Microsoft\Graph\CallRecords\Model\Photo")) {
+                return $this->_propDict["photo"];
+            } else {
+                $this->_propDict["photo"] = new Photo($this->_propDict["photo"]);
+                return $this->_propDict["photo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the photo
+    *
+    * @param Photo $val The photo
+    *
+    * @return Segment
+    */
+    public function setPhoto($val)
+    {
+        $this->_propDict["photo"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceEndpoint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceEndpoint.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ServiceEndpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* ServiceEndpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ServiceEndpoint extends Endpoint
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceRole.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceRole.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ServiceRole File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* ServiceRole class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ServiceRole extends Enum
+{
+    /**
+    * The Enum ServiceRole
+    */
+    const UNKNOWN = "unknown";
+    const CUSTOM_BOT = "customBot";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceUserAgent.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/ServiceUserAgent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ServiceUserAgent File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* ServiceUserAgent class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ServiceUserAgent extends UserAgent
+{
+
+    /**
+    * Gets the role
+    *
+    * @return ServiceRole The role
+    */
+    public function getRole()
+    {
+        if (array_key_exists("role", $this->_propDict)) {
+            if (is_a($this->_propDict["role"], "Microsoft\Graph\CallRecords\Model\ServiceRole")) {
+                return $this->_propDict["role"];
+            } else {
+                $this->_propDict["role"] = new ServiceRole($this->_propDict["role"]);
+                return $this->_propDict["role"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the role
+    *
+    * @param ServiceRole $val The value to assign to the role
+    *
+    * @return ServiceUserAgent The ServiceUserAgent
+    */
+    public function setRole($val)
+    {
+        $this->_propDict["role"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Session.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Session.php
@@ -1,0 +1,238 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Session File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* Session class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Session extends \Microsoft\Graph\Model\Entity
+{
+
+     /** 
+     * Gets the modalities
+     *
+     * @return array The modalities
+     */
+    public function getModalities()
+    {
+        if (array_key_exists("modalities", $this->_propDict)) {
+           return $this->_propDict["modalities"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the modalities
+    *
+    * @param Modality $val The modalities
+    *
+    * @return Session
+    */
+    public function setModalities($val)
+    {
+		$this->_propDict["modalities"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return Session
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return Session
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the caller
+    *
+    * @return Endpoint The caller
+    */
+    public function getCaller()
+    {
+        if (array_key_exists("caller", $this->_propDict)) {
+            if (is_a($this->_propDict["caller"], "Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["caller"];
+            } else {
+                $this->_propDict["caller"] = new Endpoint($this->_propDict["caller"]);
+                return $this->_propDict["caller"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the caller
+    *
+    * @param Endpoint $val The caller
+    *
+    * @return Session
+    */
+    public function setCaller($val)
+    {
+        $this->_propDict["caller"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the callee
+    *
+    * @return Endpoint The callee
+    */
+    public function getCallee()
+    {
+        if (array_key_exists("callee", $this->_propDict)) {
+            if (is_a($this->_propDict["callee"], "Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["callee"];
+            } else {
+                $this->_propDict["callee"] = new Endpoint($this->_propDict["callee"]);
+                return $this->_propDict["callee"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the callee
+    *
+    * @param Endpoint $val The callee
+    *
+    * @return Session
+    */
+    public function setCallee($val)
+    {
+        $this->_propDict["callee"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Session
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the segments
+     *
+     * @return array The segments
+     */
+    public function getSegments()
+    {
+        if (array_key_exists("segments", $this->_propDict)) {
+           return $this->_propDict["segments"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the segments
+    *
+    * @param Segment $val The segments
+    *
+    * @return Session
+    */
+    public function setSegments($val)
+    {
+		$this->_propDict["segments"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity1 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+/**
+* SingletonEntity1 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity1 extends \Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the testSingleNav
+    *
+    * @return Microsoft\Graph\Model\TestType The testSingleNav
+    */
+    public function getTestSingleNav()
+    {
+        if (array_key_exists("testSingleNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav"], "Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testSingleNav"];
+            } else {
+                $this->_propDict["testSingleNav"] = new Microsoft\Graph\Model\TestType($this->_propDict["testSingleNav"]);
+                return $this->_propDict["testSingleNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav
+    *
+    * @param Microsoft\Graph\Model\TestType $val The testSingleNav
+    *
+    * @return SingletonEntity1
+    */
+    public function setTestSingleNav($val)
+    {
+        $this->_propDict["testSingleNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserAgent.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserAgent.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* UserAgent File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* UserAgent class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class UserAgent extends Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the headerValue
+    *
+    * @return string The headerValue
+    */
+    public function getHeaderValue()
+    {
+        if (array_key_exists("headerValue", $this->_propDict)) {
+            return $this->_propDict["headerValue"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the headerValue
+    *
+    * @param string $val The value of the headerValue
+    *
+    * @return UserAgent
+    */
+    public function setHeaderValue($val)
+    {
+        $this->_propDict["headerValue"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the applicationVersion
+    *
+    * @return string The applicationVersion
+    */
+    public function getApplicationVersion()
+    {
+        if (array_key_exists("applicationVersion", $this->_propDict)) {
+            return $this->_propDict["applicationVersion"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the applicationVersion
+    *
+    * @param string $val The value of the applicationVersion
+    *
+    * @return UserAgent
+    */
+    public function setApplicationVersion($val)
+    {
+        $this->_propDict["applicationVersion"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserFeedback.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserFeedback.php
@@ -1,0 +1,114 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* UserFeedback File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+/**
+* UserFeedback class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class UserFeedback extends Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the text
+    *
+    * @return string The text
+    */
+    public function getText()
+    {
+        if (array_key_exists("text", $this->_propDict)) {
+            return $this->_propDict["text"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the text
+    *
+    * @param string $val The value of the text
+    *
+    * @return UserFeedback
+    */
+    public function setText($val)
+    {
+        $this->_propDict["text"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the rating
+    *
+    * @return UserFeedbackRating The rating
+    */
+    public function getRating()
+    {
+        if (array_key_exists("rating", $this->_propDict)) {
+            if (is_a($this->_propDict["rating"], "Microsoft\Graph\CallRecords\Model\UserFeedbackRating")) {
+                return $this->_propDict["rating"];
+            } else {
+                $this->_propDict["rating"] = new UserFeedbackRating($this->_propDict["rating"]);
+                return $this->_propDict["rating"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the rating
+    *
+    * @param UserFeedbackRating $val The value to assign to the rating
+    *
+    * @return UserFeedback The UserFeedback
+    */
+    public function setRating($val)
+    {
+        $this->_propDict["rating"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the tokens
+    *
+    * @return FeedbackTokenSet The tokens
+    */
+    public function getTokens()
+    {
+        if (array_key_exists("tokens", $this->_propDict)) {
+            if (is_a($this->_propDict["tokens"], "Microsoft\Graph\CallRecords\Model\FeedbackTokenSet")) {
+                return $this->_propDict["tokens"];
+            } else {
+                $this->_propDict["tokens"] = new FeedbackTokenSet($this->_propDict["tokens"]);
+                return $this->_propDict["tokens"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the tokens
+    *
+    * @param FeedbackTokenSet $val The value to assign to the tokens
+    *
+    * @return UserFeedback The UserFeedback
+    */
+    public function setTokens($val)
+    {
+        $this->_propDict["tokens"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserFeedbackRating.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/UserFeedbackRating.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* UserFeedbackRating File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* UserFeedbackRating class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class UserFeedbackRating extends Enum
+{
+    /**
+    * The Enum UserFeedbackRating
+    */
+    const NOT_RATED = "notRated";
+    const BAD = "bad";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/WifiBand.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/WifiBand.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* WifiBand File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* WifiBand class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class WifiBand extends Enum
+{
+    /**
+    * The Enum WifiBand
+    */
+    const UNKNOWN = "unknown";
+    const FREQUENCY24_G_HZ = "frequency24GHz";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/WifiRadioType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/WifiRadioType.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* WifiRadioType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* WifiRadioType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class WifiRadioType extends Enum
+{
+    /**
+    * The Enum WifiRadioType
+    */
+    const UNKNOWN = "unknown";
+    const WIFI80211A = "wifi80211a";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Call.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Call.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Call File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* Call class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Call extends Entity
+{
+    /**
+    * Gets the subject
+    *
+    * @return string The subject
+    */
+    public function getSubject()
+    {
+        if (array_key_exists("subject", $this->_propDict)) {
+            return $this->_propDict["subject"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the subject
+    *
+    * @param string $val The subject
+    *
+    * @return Call
+    */
+    public function setSubject($val)
+    {
+        $this->_propDict["subject"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/CloudCommunications.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/CloudCommunications.php
@@ -1,0 +1,83 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* CloudCommunications File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* CloudCommunications class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class CloudCommunications extends Entity
+{
+
+     /** 
+     * Gets the calls
+     *
+     * @return array The calls
+     */
+    public function getCalls()
+    {
+        if (array_key_exists("calls", $this->_propDict)) {
+           return $this->_propDict["calls"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the calls
+    *
+    * @param Call $val The calls
+    *
+    * @return CloudCommunications
+    */
+    public function setCalls($val)
+    {
+		$this->_propDict["calls"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the callRecords
+     *
+     * @return array The callRecords
+     */
+    public function getCallRecords()
+    {
+        if (array_key_exists("callRecords", $this->_propDict)) {
+           return $this->_propDict["callRecords"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the callRecords
+    *
+    * @param Microsoft\Graph\CallRecords\Model\CallRecord $val The callRecords
+    *
+    * @return CloudCommunications
+    */
+    public function setCallRecords($val)
+    {
+		$this->_propDict["callRecords"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/DerivedComplexTypeRequest.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/DerivedComplexTypeRequest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* DerivedComplexTypeRequest File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* DerivedComplexTypeRequest class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest
+{
+    /**
+    * Gets the property1
+    *
+    * @return string The property1
+    */
+    public function getProperty1()
+    {
+        if (array_key_exists("property1", $this->_propDict)) {
+            return $this->_propDict["property1"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the property1
+    *
+    * @param string $val The value of the property1
+    *
+    * @return DerivedComplexTypeRequest
+    */
+    public function setProperty1($val)
+    {
+        $this->_propDict["property1"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the property2
+    *
+    * @return string The property2
+    */
+    public function getProperty2()
+    {
+        if (array_key_exists("property2", $this->_propDict)) {
+            return $this->_propDict["property2"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the property2
+    *
+    * @param string $val The value of the property2
+    *
+    * @return DerivedComplexTypeRequest
+    */
+    public function setProperty2($val)
+    {
+        $this->_propDict["property2"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the enumProperty
+    *
+    * @return Enum1 The enumProperty
+    */
+    public function getEnumProperty()
+    {
+        if (array_key_exists("enumProperty", $this->_propDict)) {
+            if (is_a($this->_propDict["enumProperty"], "Microsoft\Graph\Model\Enum1")) {
+                return $this->_propDict["enumProperty"];
+            } else {
+                $this->_propDict["enumProperty"] = new Enum1($this->_propDict["enumProperty"]);
+                return $this->_propDict["enumProperty"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the enumProperty
+    *
+    * @param Enum1 $val The value to assign to the enumProperty
+    *
+    * @return DerivedComplexTypeRequest The DerivedComplexTypeRequest
+    */
+    public function setEnumProperty($val)
+    {
+        $this->_propDict["enumProperty"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EmptyBaseComplexTypeRequest.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EmptyBaseComplexTypeRequest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* EmptyBaseComplexTypeRequest File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* EmptyBaseComplexTypeRequest class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class EmptyBaseComplexTypeRequest extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EmptyComplexType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EmptyComplexType.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* EmptyComplexType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* EmptyComplexType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class EmptyComplexType extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Endpoint.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Endpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* Endpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Endpoint extends Entity
+{
+    /**
+    * Gets the property1
+    *
+    * @return int The property1
+    */
+    public function getProperty1()
+    {
+        if (array_key_exists("property1", $this->_propDict)) {
+            return $this->_propDict["property1"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the property1
+    *
+    * @param int $val The property1
+    *
+    * @return Endpoint
+    */
+    public function setProperty1($val)
+    {
+        $this->_propDict["property1"] = intval($val);
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -1,0 +1,123 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Entity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* Entity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Entity implements \JsonSerializable
+{
+    /**
+    * The array of properties available
+    * to the model
+    *
+    * @var array(string => string)
+    */
+    protected $_propDict;
+    
+    /**
+    * Construct a new Entity
+    *
+    * @param array $propDict A list of properties to set
+    */
+    function __construct($propDict = array())
+    {
+		$this->_propDict = $propDict;
+    }
+
+    /**
+    * Gets the property dictionary of the Entity
+    *
+    * @return array The list of properties
+    */
+    public function getProperties()
+    {
+        return $this->_propDict;
+    }
+    
+    /**
+    * Gets the id
+    *
+    * @return string The id
+    */
+    public function getId()
+    {
+        if (array_key_exists("id", $this->_propDict)) {
+            return $this->_propDict["id"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the id
+    *
+    * @param string $val The id
+    *
+    * @return Entity
+    */
+    public function setId($val)
+    {
+        $this->_propDict["id"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the ODataType
+    *
+    * @return string The ODataType
+    */
+    public function getODataType()
+    {
+        return $this->_propDict["@odata.type"];
+    }
+    
+    /**
+    * Sets the ODataType
+    *
+    * @param string The ODataType
+    *
+    * @return Entity
+    */
+    public function setODataType($val)
+    {
+        $this->_propDict["@odata.type"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Serializes the object by property array
+	* Manually serialize DateTime into RFC3339 format
+    *
+    * @return array The list of properties
+    */
+    public function jsonSerialize()
+    {
+        $serializableProperties = $this->getProperties();
+        foreach ($serializableProperties as $property => $val) {
+            if (is_a($val, "\DateTime")) {
+                $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
+            } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
+                $serializableProperties[$property] = $val->value();
+            }
+        }
+        return $serializableProperties;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EntityType2.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EntityType2.php
@@ -1,0 +1,27 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* EntityType2 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* EntityType2 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class EntityType2 extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EntityType3.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/EntityType3.php
@@ -1,0 +1,27 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* EntityType3 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* EntityType3 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class EntityType3 extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Enum1.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Enum1.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Enum1 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* Enum1 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Enum1 extends Enum
+{
+    /**
+    * The Enum Enum1
+    */
+    const VALUE0 = "value0";
+    const VALUE1 = "value1";
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Identity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Identity.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Identity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* Identity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Identity extends Entity
+{
+    /**
+    * Gets the displayName
+    *
+    * @return string The displayName
+    */
+    public function getDisplayName()
+    {
+        if (array_key_exists("displayName", $this->_propDict)) {
+            return $this->_propDict["displayName"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the displayName
+    *
+    * @param string $val The value of the displayName
+    *
+    * @return Identity
+    */
+    public function setDisplayName($val)
+    {
+        $this->_propDict["displayName"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the id
+    *
+    * @return string The id
+    */
+    public function getId()
+    {
+        if (array_key_exists("id", $this->_propDict)) {
+            return $this->_propDict["id"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the id
+    *
+    * @param string $val The value of the id
+    *
+    * @return Identity
+    */
+    public function setId($val)
+    {
+        $this->_propDict["id"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/IdentitySet.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/IdentitySet.php
@@ -1,0 +1,119 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* IdentitySet File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* IdentitySet class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class IdentitySet extends Entity
+{
+
+    /**
+    * Gets the application
+    *
+    * @return Identity The application
+    */
+    public function getApplication()
+    {
+        if (array_key_exists("application", $this->_propDict)) {
+            if (is_a($this->_propDict["application"], "Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["application"];
+            } else {
+                $this->_propDict["application"] = new Identity($this->_propDict["application"]);
+                return $this->_propDict["application"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the application
+    *
+    * @param Identity $val The value to assign to the application
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setApplication($val)
+    {
+        $this->_propDict["application"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the device
+    *
+    * @return Identity The device
+    */
+    public function getDevice()
+    {
+        if (array_key_exists("device", $this->_propDict)) {
+            if (is_a($this->_propDict["device"], "Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["device"];
+            } else {
+                $this->_propDict["device"] = new Identity($this->_propDict["device"]);
+                return $this->_propDict["device"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the device
+    *
+    * @param Identity $val The value to assign to the device
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setDevice($val)
+    {
+        $this->_propDict["device"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the user
+    *
+    * @return Identity The user
+    */
+    public function getUser()
+    {
+        if (array_key_exists("user", $this->_propDict)) {
+            if (is_a($this->_propDict["user"], "Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["user"];
+            } else {
+                $this->_propDict["user"] = new Identity($this->_propDict["user"]);
+                return $this->_propDict["user"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the user
+    *
+    * @param Identity $val The value to assign to the user
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setUser($val)
+    {
+        $this->_propDict["user"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
@@ -1,0 +1,64 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* OnenotePage File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* OnenotePage class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class OnenotePage extends Entity
+{
+    /**
+    * Gets the content
+    * The OneNotePage content.
+///
+/// Test token string
+    *
+    * @return \GuzzleHttp\Psr7\Stream The content
+    */
+    public function getContent()
+    {
+        if (array_key_exists("content", $this->_propDict)) {
+            if (is_a($this->_propDict["content"], "\GuzzleHttp\Psr7\Stream")) {
+                return $this->_propDict["content"];
+            } else {
+                $this->_propDict["content"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["content"]);
+                return $this->_propDict["content"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the content
+    * The OneNotePage content.
+///
+/// Test token string
+    *
+    * @param \GuzzleHttp\Psr7\Stream $val The content
+    *
+    * @return OnenotePage
+    */
+    public function setContent($val)
+    {
+        $this->_propDict["content"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/PlannerGroup.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/PlannerGroup.php
@@ -1,0 +1,27 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* PlannerGroup File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* PlannerGroup class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class PlannerGroup extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Recipient.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Recipient.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Recipient File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* Recipient class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Recipient extends Entity
+{
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the name
+    *
+    * @param string $val The value of the name
+    *
+    * @return Recipient
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the email
+    *
+    * @return string The email
+    */
+    public function getEmail()
+    {
+        if (array_key_exists("email", $this->_propDict)) {
+            return $this->_propDict["email"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the email
+    *
+    * @param string $val The value of the email
+    *
+    * @return Recipient
+    */
+    public function setEmail($val)
+    {
+        $this->_propDict["email"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/ResponseObject.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/ResponseObject.php
@@ -1,0 +1,26 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ResponseObject File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+/**
+* ResponseObject class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ResponseObject extends Entity
+{
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Schedule.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Schedule.php
@@ -1,0 +1,110 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Schedule File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* Schedule class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Schedule extends Entity
+{
+    /**
+    * Gets the enabled
+    *
+    * @return bool The enabled
+    */
+    public function getEnabled()
+    {
+        if (array_key_exists("enabled", $this->_propDict)) {
+            return $this->_propDict["enabled"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the enabled
+    *
+    * @param bool $val The enabled
+    *
+    * @return Schedule
+    */
+    public function setEnabled($val)
+    {
+        $this->_propDict["enabled"] = boolval($val);
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the timesOff
+     *
+     * @return array The timesOff
+     */
+    public function getTimesOff()
+    {
+        if (array_key_exists("timesOff", $this->_propDict)) {
+           return $this->_propDict["timesOff"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the timesOff
+    *
+    * @param TimeOff $val The timesOff
+    *
+    * @return Schedule
+    */
+    public function setTimesOff($val)
+    {
+		$this->_propDict["timesOff"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the timeOffRequests
+     *
+     * @return array The timeOffRequests
+     */
+    public function getTimeOffRequests()
+    {
+        if (array_key_exists("timeOffRequests", $this->_propDict)) {
+           return $this->_propDict["timeOffRequests"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the timeOffRequests
+    *
+    * @param TimeOffRequest $val The timeOffRequests
+    *
+    * @return Schedule
+    */
+    public function setTimeOffRequests($val)
+    {
+		$this->_propDict["timeOffRequests"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity1.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity1 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* SingletonEntity1 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity1 extends Entity
+{
+    /**
+    * Gets the testSingleNav
+    *
+    * @return TestType The testSingleNav
+    */
+    public function getTestSingleNav()
+    {
+        if (array_key_exists("testSingleNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav"], "Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testSingleNav"];
+            } else {
+                $this->_propDict["testSingleNav"] = new TestType($this->_propDict["testSingleNav"]);
+                return $this->_propDict["testSingleNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav
+    *
+    * @param TestType $val The testSingleNav
+    *
+    * @return SingletonEntity1
+    */
+    public function setTestSingleNav($val)
+    {
+        $this->_propDict["testSingleNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity2.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity2.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity2 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* SingletonEntity2 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity2 extends Entity
+{
+    /**
+    * Gets the testSingleNav2
+    *
+    * @return EntityType3 The testSingleNav2
+    */
+    public function getTestSingleNav2()
+    {
+        if (array_key_exists("testSingleNav2", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav2"], "Microsoft\Graph\Model\EntityType3")) {
+                return $this->_propDict["testSingleNav2"];
+            } else {
+                $this->_propDict["testSingleNav2"] = new EntityType3($this->_propDict["testSingleNav2"]);
+                return $this->_propDict["testSingleNav2"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav2
+    *
+    * @param EntityType3 $val The testSingleNav2
+    *
+    * @return SingletonEntity2
+    */
+    public function setTestSingleNav2($val)
+    {
+        $this->_propDict["testSingleNav2"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestEntity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestEntity.php
@@ -1,0 +1,120 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TestEntity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* TestEntity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TestEntity extends Entity
+{
+    /**
+    * Gets the testNav
+    *
+    * @return TestType The testNav
+    */
+    public function getTestNav()
+    {
+        if (array_key_exists("testNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testNav"], "Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testNav"];
+            } else {
+                $this->_propDict["testNav"] = new TestType($this->_propDict["testNav"]);
+                return $this->_propDict["testNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testNav
+    *
+    * @param TestType $val The testNav
+    *
+    * @return TestEntity
+    */
+    public function setTestNav($val)
+    {
+        $this->_propDict["testNav"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the testInvalidNav
+    *
+    * @return EntityType2 The testInvalidNav
+    */
+    public function getTestInvalidNav()
+    {
+        if (array_key_exists("testInvalidNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testInvalidNav"], "Microsoft\Graph\Model\EntityType2")) {
+                return $this->_propDict["testInvalidNav"];
+            } else {
+                $this->_propDict["testInvalidNav"] = new EntityType2($this->_propDict["testInvalidNav"]);
+                return $this->_propDict["testInvalidNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testInvalidNav
+    *
+    * @param EntityType2 $val The testInvalidNav
+    *
+    * @return TestEntity
+    */
+    public function setTestInvalidNav($val)
+    {
+        $this->_propDict["testInvalidNav"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the testExplicitNav
+    *
+    * @return EntityType3 The testExplicitNav
+    */
+    public function getTestExplicitNav()
+    {
+        if (array_key_exists("testExplicitNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testExplicitNav"], "Microsoft\Graph\Model\EntityType3")) {
+                return $this->_propDict["testExplicitNav"];
+            } else {
+                $this->_propDict["testExplicitNav"] = new EntityType3($this->_propDict["testExplicitNav"]);
+                return $this->_propDict["testExplicitNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testExplicitNav
+    *
+    * @param EntityType3 $val The testExplicitNav
+    *
+    * @return TestEntity
+    */
+    public function setTestExplicitNav($val)
+    {
+        $this->_propDict["testExplicitNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TestType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* TestType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TestType extends Entity
+{
+    /**
+    * Gets the propertyAlpha
+    *
+    * @return DerivedComplexTypeRequest The propertyAlpha
+    */
+    public function getPropertyAlpha()
+    {
+        if (array_key_exists("propertyAlpha", $this->_propDict)) {
+            if (is_a($this->_propDict["propertyAlpha"], "Microsoft\Graph\Model\DerivedComplexTypeRequest")) {
+                return $this->_propDict["propertyAlpha"];
+            } else {
+                $this->_propDict["propertyAlpha"] = new DerivedComplexTypeRequest($this->_propDict["propertyAlpha"]);
+                return $this->_propDict["propertyAlpha"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the propertyAlpha
+    *
+    * @param DerivedComplexTypeRequest $val The propertyAlpha
+    *
+    * @return TestType
+    */
+    public function setPropertyAlpha($val)
+    {
+        $this->_propDict["propertyAlpha"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOff.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOff.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TimeOff File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* TimeOff class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TimeOff extends Entity
+{
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the name
+    *
+    * @param string $val The name
+    *
+    * @return TimeOff
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOffRequest.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOffRequest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TimeOffRequest File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\Model;
+
+/**
+* TimeOffRequest class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TimeOffRequest extends Entity
+{
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the name
+    *
+    * @param string $val The name
+    *
+    * @return TimeOffRequest
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallRecord.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallRecord.php
@@ -1,0 +1,348 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* CallRecord File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+/**
+* CallRecord class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the version
+    *
+    * @return int The version
+    */
+    public function getVersion()
+    {
+        if (array_key_exists("version", $this->_propDict)) {
+            return $this->_propDict["version"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the version
+    *
+    * @param int $val The version
+    *
+    * @return CallRecord
+    */
+    public function setVersion($val)
+    {
+        $this->_propDict["version"] = intval($val);
+        return $this;
+    }
+    
+    /**
+    * Gets the type
+    *
+    * @return CallType The type
+    */
+    public function getType()
+    {
+        if (array_key_exists("type", $this->_propDict)) {
+            if (is_a($this->_propDict["type"], "Beta\Microsoft\Graph\CallRecords\Model\CallType")) {
+                return $this->_propDict["type"];
+            } else {
+                $this->_propDict["type"] = new CallType($this->_propDict["type"]);
+                return $this->_propDict["type"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the type
+    *
+    * @param CallType $val The type
+    *
+    * @return CallRecord
+    */
+    public function setType($val)
+    {
+        $this->_propDict["type"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the modalities
+     *
+     * @return array The modalities
+     */
+    public function getModalities()
+    {
+        if (array_key_exists("modalities", $this->_propDict)) {
+           return $this->_propDict["modalities"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the modalities
+    *
+    * @param Modality $val The modalities
+    *
+    * @return CallRecord
+    */
+    public function setModalities($val)
+    {
+		$this->_propDict["modalities"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the lastModifiedDateTime
+    *
+    * @return \DateTime The lastModifiedDateTime
+    */
+    public function getLastModifiedDateTime()
+    {
+        if (array_key_exists("lastModifiedDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["lastModifiedDateTime"], "\DateTime")) {
+                return $this->_propDict["lastModifiedDateTime"];
+            } else {
+                $this->_propDict["lastModifiedDateTime"] = new \DateTime($this->_propDict["lastModifiedDateTime"]);
+                return $this->_propDict["lastModifiedDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the lastModifiedDateTime
+    *
+    * @param \DateTime $val The lastModifiedDateTime
+    *
+    * @return CallRecord
+    */
+    public function setLastModifiedDateTime($val)
+    {
+        $this->_propDict["lastModifiedDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return CallRecord
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return CallRecord
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the organizer
+    *
+    * @return Beta\Microsoft\Graph\Model\IdentitySet The organizer
+    */
+    public function getOrganizer()
+    {
+        if (array_key_exists("organizer", $this->_propDict)) {
+            if (is_a($this->_propDict["organizer"], "Beta\Microsoft\Graph\Model\IdentitySet")) {
+                return $this->_propDict["organizer"];
+            } else {
+                $this->_propDict["organizer"] = new Beta\Microsoft\Graph\Model\IdentitySet($this->_propDict["organizer"]);
+                return $this->_propDict["organizer"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the organizer
+    *
+    * @param Beta\Microsoft\Graph\Model\IdentitySet $val The organizer
+    *
+    * @return CallRecord
+    */
+    public function setOrganizer($val)
+    {
+        $this->_propDict["organizer"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the participants
+     *
+     * @return array The participants
+     */
+    public function getParticipants()
+    {
+        if (array_key_exists("participants", $this->_propDict)) {
+           return $this->_propDict["participants"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the participants
+    *
+    * @param Beta\Microsoft\Graph\Model\IdentitySet $val The participants
+    *
+    * @return CallRecord
+    */
+    public function setParticipants($val)
+    {
+		$this->_propDict["participants"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the joinWebUrl
+    *
+    * @return string The joinWebUrl
+    */
+    public function getJoinWebUrl()
+    {
+        if (array_key_exists("joinWebUrl", $this->_propDict)) {
+            return $this->_propDict["joinWebUrl"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the joinWebUrl
+    *
+    * @param string $val The joinWebUrl
+    *
+    * @return CallRecord
+    */
+    public function setJoinWebUrl($val)
+    {
+        $this->_propDict["joinWebUrl"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the sessions
+     *
+     * @return array The sessions
+     */
+    public function getSessions()
+    {
+        if (array_key_exists("sessions", $this->_propDict)) {
+           return $this->_propDict["sessions"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the sessions
+    *
+    * @param Session $val The sessions
+    *
+    * @return CallRecord
+    */
+    public function setSessions($val)
+    {
+		$this->_propDict["sessions"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the recipients
+     *
+     * @return array The recipients
+     */
+    public function getRecipients()
+    {
+        if (array_key_exists("recipients", $this->_propDict)) {
+           return $this->_propDict["recipients"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the recipients
+    *
+    * @param Beta\Microsoft\Graph\Model\EntityType2 $val The recipients
+    *
+    * @return CallRecord
+    */
+    public function setRecipients($val)
+    {
+		$this->_propDict["recipients"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallType.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* CallType File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* CallType class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class CallType extends Enum
 {
+    /**
+    * The Enum CallType
+    */
+    const UNKNOWN = "unknown";
+    const GROUP_CALL = "groupCall";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ClientPlatform.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ClientPlatform.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* ClientPlatform File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* ClientPlatform class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class ClientPlatform extends Enum
 {
+    /**
+    * The Enum ClientPlatform
+    */
+    const UNKNOWN = "unknown";
+    const WINDOWS = "windows";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ClientUserAgent.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ClientUserAgent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ClientUserAgent File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+/**
+* ClientUserAgent class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ClientUserAgent extends UserAgent
+{
+
+    /**
+    * Gets the platform
+    *
+    * @return ClientPlatform The platform
+    */
+    public function getPlatform()
+    {
+        if (array_key_exists("platform", $this->_propDict)) {
+            if (is_a($this->_propDict["platform"], "Beta\Microsoft\Graph\CallRecords\Model\ClientPlatform")) {
+                return $this->_propDict["platform"];
+            } else {
+                $this->_propDict["platform"] = new ClientPlatform($this->_propDict["platform"]);
+                return $this->_propDict["platform"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the platform
+    *
+    * @param ClientPlatform $val The value to assign to the platform
+    *
+    * @return ClientUserAgent The ClientUserAgent
+    */
+    public function setPlatform($val)
+    {
+        $this->_propDict["platform"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the productFamily
+    *
+    * @return ProductFamily The productFamily
+    */
+    public function getProductFamily()
+    {
+        if (array_key_exists("productFamily", $this->_propDict)) {
+            if (is_a($this->_propDict["productFamily"], "Beta\Microsoft\Graph\CallRecords\Model\ProductFamily")) {
+                return $this->_propDict["productFamily"];
+            } else {
+                $this->_propDict["productFamily"] = new ProductFamily($this->_propDict["productFamily"]);
+                return $this->_propDict["productFamily"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the productFamily
+    *
+    * @param ProductFamily $val The value to assign to the productFamily
+    *
+    * @return ClientUserAgent The ClientUserAgent
+    */
+    public function setProductFamily($val)
+    {
+        $this->_propDict["productFamily"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/DeviceInfo.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/DeviceInfo.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * DeviceInfo class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class DeviceInfo extends \Microsoft\Graph\Model\Entity
+class DeviceInfo extends \Beta\Microsoft\Graph\Model\Entity
 {
     /**
     * Gets the captureDeviceName
@@ -79,15 +79,15 @@ class DeviceInfo extends \Microsoft\Graph\Model\Entity
     /**
     * Gets the speakerGlitchRate
     *
-    * @return Microsoft\Graph\Model\Single The speakerGlitchRate
+    * @return Beta\Microsoft\Graph\Model\Single The speakerGlitchRate
     */
     public function getSpeakerGlitchRate()
     {
         if (array_key_exists("speakerGlitchRate", $this->_propDict)) {
-            if (is_a($this->_propDict["speakerGlitchRate"], "Microsoft\Graph\Model\Single")) {
+            if (is_a($this->_propDict["speakerGlitchRate"], "Beta\Microsoft\Graph\Model\Single")) {
                 return $this->_propDict["speakerGlitchRate"];
             } else {
-                $this->_propDict["speakerGlitchRate"] = new Microsoft\Graph\Model\Single($this->_propDict["speakerGlitchRate"]);
+                $this->_propDict["speakerGlitchRate"] = new Beta\Microsoft\Graph\Model\Single($this->_propDict["speakerGlitchRate"]);
                 return $this->_propDict["speakerGlitchRate"];
             }
         }
@@ -97,7 +97,7 @@ class DeviceInfo extends \Microsoft\Graph\Model\Entity
     /**
     * Sets the speakerGlitchRate
     *
-    * @param Microsoft\Graph\Model\Single $val The value to assign to the speakerGlitchRate
+    * @param Beta\Microsoft\Graph\Model\Single $val The value to assign to the speakerGlitchRate
     *
     * @return DeviceInfo The DeviceInfo
     */

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Endpoint.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * Endpoint class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class Endpoint extends \Microsoft\Graph\Model\Entity
+class Endpoint extends \Beta\Microsoft\Graph\Model\Entity
 {
 
     /**
@@ -32,7 +32,7 @@ class Endpoint extends \Microsoft\Graph\Model\Entity
     public function getUserAgent()
     {
         if (array_key_exists("userAgent", $this->_propDict)) {
-            if (is_a($this->_propDict["userAgent"], "Microsoft\Graph\CallRecords\Model\UserAgent")) {
+            if (is_a($this->_propDict["userAgent"], "Beta\Microsoft\Graph\CallRecords\Model\UserAgent")) {
                 return $this->_propDict["userAgent"];
             } else {
                 $this->_propDict["userAgent"] = new UserAgent($this->_propDict["userAgent"]);

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FailureInfo.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FailureInfo.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * FailureInfo class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FailureInfo extends \Microsoft\Graph\Model\Entity
+class FailureInfo extends \Beta\Microsoft\Graph\Model\Entity
 {
 
     /**
@@ -32,7 +32,7 @@ class FailureInfo extends \Microsoft\Graph\Model\Entity
     public function getStage()
     {
         if (array_key_exists("stage", $this->_propDict)) {
-            if (is_a($this->_propDict["stage"], "Microsoft\Graph\CallRecords\Model\FailureStage")) {
+            if (is_a($this->_propDict["stage"], "Beta\Microsoft\Graph\CallRecords\Model\FailureStage")) {
                 return $this->_propDict["stage"];
             } else {
                 $this->_propDict["stage"] = new FailureStage($this->_propDict["stage"]);

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FailureStage.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FailureStage.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* FailureStage File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* FailureStage class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class FailureStage extends Enum
 {
+    /**
+    * The Enum FailureStage
+    */
+    const UNKNOWN = "unknown";
+    const CALL_SETUP = "callSetup";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FeedbackTokenSet.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/FeedbackTokenSet.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * FeedbackTokenSet class
 *
@@ -21,6 +21,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class FeedbackTokenSet extends \Beta\Microsoft\Graph\Model\Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Media.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Media.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * Media class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class Media extends \Microsoft\Graph\Model\Entity
+class Media extends \Beta\Microsoft\Graph\Model\Entity
 {
     /**
     * Gets the label
@@ -58,7 +58,7 @@ class Media extends \Microsoft\Graph\Model\Entity
     public function getCallerNetwork()
     {
         if (array_key_exists("callerNetwork", $this->_propDict)) {
-            if (is_a($this->_propDict["callerNetwork"], "Microsoft\Graph\CallRecords\Model\NetworkInfo")) {
+            if (is_a($this->_propDict["callerNetwork"], "Beta\Microsoft\Graph\CallRecords\Model\NetworkInfo")) {
                 return $this->_propDict["callerNetwork"];
             } else {
                 $this->_propDict["callerNetwork"] = new NetworkInfo($this->_propDict["callerNetwork"]);
@@ -89,7 +89,7 @@ class Media extends \Microsoft\Graph\Model\Entity
     public function getCallerDevice()
     {
         if (array_key_exists("callerDevice", $this->_propDict)) {
-            if (is_a($this->_propDict["callerDevice"], "Microsoft\Graph\CallRecords\Model\DeviceInfo")) {
+            if (is_a($this->_propDict["callerDevice"], "Beta\Microsoft\Graph\CallRecords\Model\DeviceInfo")) {
                 return $this->_propDict["callerDevice"];
             } else {
                 $this->_propDict["callerDevice"] = new DeviceInfo($this->_propDict["callerDevice"]);
@@ -120,7 +120,7 @@ class Media extends \Microsoft\Graph\Model\Entity
     public function getStreams()
     {
         if (array_key_exists("streams", $this->_propDict)) {
-            if (is_a($this->_propDict["streams"], "Microsoft\Graph\CallRecords\Model\MediaStream")) {
+            if (is_a($this->_propDict["streams"], "Beta\Microsoft\Graph\CallRecords\Model\MediaStream")) {
                 return $this->_propDict["streams"];
             } else {
                 $this->_propDict["streams"] = new MediaStream($this->_propDict["streams"]);

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/MediaStream.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/MediaStream.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * MediaStream class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class MediaStream extends \Microsoft\Graph\Model\Entity
+class MediaStream extends \Beta\Microsoft\Graph\Model\Entity
 {
     /**
     * Gets the streamId
@@ -89,7 +89,7 @@ class MediaStream extends \Microsoft\Graph\Model\Entity
     public function getStreamDirection()
     {
         if (array_key_exists("streamDirection", $this->_propDict)) {
-            if (is_a($this->_propDict["streamDirection"], "Microsoft\Graph\CallRecords\Model\MediaStreamDirection")) {
+            if (is_a($this->_propDict["streamDirection"], "Beta\Microsoft\Graph\CallRecords\Model\MediaStreamDirection")) {
                 return $this->_propDict["streamDirection"];
             } else {
                 $this->_propDict["streamDirection"] = new MediaStreamDirection($this->_propDict["streamDirection"]);
@@ -167,15 +167,15 @@ class MediaStream extends \Microsoft\Graph\Model\Entity
     /**
     * Gets the lowVideoProcessingCapabilityRatio
     *
-    * @return Microsoft\Graph\Model\Single The lowVideoProcessingCapabilityRatio
+    * @return Beta\Microsoft\Graph\Model\Single The lowVideoProcessingCapabilityRatio
     */
     public function getLowVideoProcessingCapabilityRatio()
     {
         if (array_key_exists("lowVideoProcessingCapabilityRatio", $this->_propDict)) {
-            if (is_a($this->_propDict["lowVideoProcessingCapabilityRatio"], "Microsoft\Graph\Model\Single")) {
+            if (is_a($this->_propDict["lowVideoProcessingCapabilityRatio"], "Beta\Microsoft\Graph\Model\Single")) {
                 return $this->_propDict["lowVideoProcessingCapabilityRatio"];
             } else {
-                $this->_propDict["lowVideoProcessingCapabilityRatio"] = new Microsoft\Graph\Model\Single($this->_propDict["lowVideoProcessingCapabilityRatio"]);
+                $this->_propDict["lowVideoProcessingCapabilityRatio"] = new Beta\Microsoft\Graph\Model\Single($this->_propDict["lowVideoProcessingCapabilityRatio"]);
                 return $this->_propDict["lowVideoProcessingCapabilityRatio"];
             }
         }
@@ -185,7 +185,7 @@ class MediaStream extends \Microsoft\Graph\Model\Entity
     /**
     * Sets the lowVideoProcessingCapabilityRatio
     *
-    * @param Microsoft\Graph\Model\Single $val The value to assign to the lowVideoProcessingCapabilityRatio
+    * @param Beta\Microsoft\Graph\Model\Single $val The value to assign to the lowVideoProcessingCapabilityRatio
     *
     * @return MediaStream The MediaStream
     */
@@ -198,15 +198,15 @@ class MediaStream extends \Microsoft\Graph\Model\Entity
     /**
     * Gets the averageAudioNetworkJitter
     *
-    * @return Microsoft\Graph\Model\Duration The averageAudioNetworkJitter
+    * @return Beta\Microsoft\Graph\Model\Duration The averageAudioNetworkJitter
     */
     public function getAverageAudioNetworkJitter()
     {
         if (array_key_exists("averageAudioNetworkJitter", $this->_propDict)) {
-            if (is_a($this->_propDict["averageAudioNetworkJitter"], "Microsoft\Graph\Model\Duration")) {
+            if (is_a($this->_propDict["averageAudioNetworkJitter"], "Beta\Microsoft\Graph\Model\Duration")) {
                 return $this->_propDict["averageAudioNetworkJitter"];
             } else {
-                $this->_propDict["averageAudioNetworkJitter"] = new Microsoft\Graph\Model\Duration($this->_propDict["averageAudioNetworkJitter"]);
+                $this->_propDict["averageAudioNetworkJitter"] = new Beta\Microsoft\Graph\Model\Duration($this->_propDict["averageAudioNetworkJitter"]);
                 return $this->_propDict["averageAudioNetworkJitter"];
             }
         }
@@ -216,7 +216,7 @@ class MediaStream extends \Microsoft\Graph\Model\Entity
     /**
     * Sets the averageAudioNetworkJitter
     *
-    * @param Microsoft\Graph\Model\Duration $val The value to assign to the averageAudioNetworkJitter
+    * @param Beta\Microsoft\Graph\Model\Duration $val The value to assign to the averageAudioNetworkJitter
     *
     * @return MediaStream The MediaStream
     */

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/MediaStreamDirection.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/MediaStreamDirection.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* MediaStreamDirection File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* MediaStreamDirection class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class MediaStreamDirection extends Enum
 {
+    /**
+    * The Enum MediaStreamDirection
+    */
+    const CALLER_TO_CALLEE = "callerToCallee";
+    const CALLEE_TO_CALLER = "calleeToCaller";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Modality.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Modality.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* Modality File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* Modality class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class Modality extends Enum
 {
+    /**
+    * The Enum Modality
+    */
+    const AUDIO = "audio";
+    const VIDEO = "video";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/NetworkConnectionType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/NetworkConnectionType.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* NetworkConnectionType File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* NetworkConnectionType class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class NetworkConnectionType extends Enum
 {
+    /**
+    * The Enum NetworkConnectionType
+    */
+    const UNKNOWN = "unknown";
+    const WIRED = "wired";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/NetworkInfo.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/NetworkInfo.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * NetworkInfo class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class NetworkInfo extends \Microsoft\Graph\Model\Entity
+class NetworkInfo extends \Beta\Microsoft\Graph\Model\Entity
 {
 
     /**
@@ -32,7 +32,7 @@ class NetworkInfo extends \Microsoft\Graph\Model\Entity
     public function getConnectionType()
     {
         if (array_key_exists("connectionType", $this->_propDict)) {
-            if (is_a($this->_propDict["connectionType"], "Microsoft\Graph\CallRecords\Model\NetworkConnectionType")) {
+            if (is_a($this->_propDict["connectionType"], "Beta\Microsoft\Graph\CallRecords\Model\NetworkConnectionType")) {
                 return $this->_propDict["connectionType"];
             } else {
                 $this->_propDict["connectionType"] = new NetworkConnectionType($this->_propDict["connectionType"]);
@@ -63,7 +63,7 @@ class NetworkInfo extends \Microsoft\Graph\Model\Entity
     public function getWifiBand()
     {
         if (array_key_exists("wifiBand", $this->_propDict)) {
-            if (is_a($this->_propDict["wifiBand"], "Microsoft\Graph\CallRecords\Model\WifiBand")) {
+            if (is_a($this->_propDict["wifiBand"], "Beta\Microsoft\Graph\CallRecords\Model\WifiBand")) {
                 return $this->_propDict["wifiBand"];
             } else {
                 $this->_propDict["wifiBand"] = new WifiBand($this->_propDict["wifiBand"]);
@@ -120,7 +120,7 @@ class NetworkInfo extends \Microsoft\Graph\Model\Entity
     public function getWifiRadioType()
     {
         if (array_key_exists("wifiRadioType", $this->_propDict)) {
-            if (is_a($this->_propDict["wifiRadioType"], "Microsoft\Graph\CallRecords\Model\WifiRadioType")) {
+            if (is_a($this->_propDict["wifiRadioType"], "Beta\Microsoft\Graph\CallRecords\Model\WifiRadioType")) {
                 return $this->_propDict["wifiRadioType"];
             } else {
                 $this->_propDict["wifiRadioType"] = new WifiRadioType($this->_propDict["wifiRadioType"]);
@@ -172,15 +172,15 @@ class NetworkInfo extends \Microsoft\Graph\Model\Entity
     /**
     * Gets the bandwidthLowEventRatio
     *
-    * @return Microsoft\Graph\Model\Single The bandwidthLowEventRatio
+    * @return Beta\Microsoft\Graph\Model\Single The bandwidthLowEventRatio
     */
     public function getBandwidthLowEventRatio()
     {
         if (array_key_exists("bandwidthLowEventRatio", $this->_propDict)) {
-            if (is_a($this->_propDict["bandwidthLowEventRatio"], "Microsoft\Graph\Model\Single")) {
+            if (is_a($this->_propDict["bandwidthLowEventRatio"], "Beta\Microsoft\Graph\Model\Single")) {
                 return $this->_propDict["bandwidthLowEventRatio"];
             } else {
-                $this->_propDict["bandwidthLowEventRatio"] = new Microsoft\Graph\Model\Single($this->_propDict["bandwidthLowEventRatio"]);
+                $this->_propDict["bandwidthLowEventRatio"] = new Beta\Microsoft\Graph\Model\Single($this->_propDict["bandwidthLowEventRatio"]);
                 return $this->_propDict["bandwidthLowEventRatio"];
             }
         }
@@ -190,7 +190,7 @@ class NetworkInfo extends \Microsoft\Graph\Model\Entity
     /**
     * Sets the bandwidthLowEventRatio
     *
-    * @param Microsoft\Graph\Model\Single $val The value to assign to the bandwidthLowEventRatio
+    * @param Beta\Microsoft\Graph\Model\Single $val The value to assign to the bandwidthLowEventRatio
     *
     * @return NetworkInfo The NetworkInfo
     */

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Option.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Option.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* Option File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
 /**
-* FeedbackTokenSet class
+* Option class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class Option extends \Beta\Microsoft\Graph\Model\Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ParticipantEndpoint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ParticipantEndpoint.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ParticipantEndpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+/**
+* ParticipantEndpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ParticipantEndpoint extends Endpoint
+{
+
+    /**
+    * Gets the identity
+    *
+    * @return Beta\Microsoft\Graph\Model\IdentitySet The identity
+    */
+    public function getIdentity()
+    {
+        if (array_key_exists("identity", $this->_propDict)) {
+            if (is_a($this->_propDict["identity"], "Beta\Microsoft\Graph\Model\IdentitySet")) {
+                return $this->_propDict["identity"];
+            } else {
+                $this->_propDict["identity"] = new Beta\Microsoft\Graph\Model\IdentitySet($this->_propDict["identity"]);
+                return $this->_propDict["identity"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the identity
+    *
+    * @param Beta\Microsoft\Graph\Model\IdentitySet $val The value to assign to the identity
+    *
+    * @return ParticipantEndpoint The ParticipantEndpoint
+    */
+    public function setIdentity($val)
+    {
+        $this->_propDict["identity"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the feedback
+    *
+    * @return UserFeedback The feedback
+    */
+    public function getFeedback()
+    {
+        if (array_key_exists("feedback", $this->_propDict)) {
+            if (is_a($this->_propDict["feedback"], "Beta\Microsoft\Graph\CallRecords\Model\UserFeedback")) {
+                return $this->_propDict["feedback"];
+            } else {
+                $this->_propDict["feedback"] = new UserFeedback($this->_propDict["feedback"]);
+                return $this->_propDict["feedback"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the feedback
+    *
+    * @param UserFeedback $val The value to assign to the feedback
+    *
+    * @return ParticipantEndpoint The ParticipantEndpoint
+    */
+    public function setFeedback($val)
+    {
+        $this->_propDict["feedback"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Photo.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Photo.php
@@ -1,0 +1,89 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Photo File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+/**
+* Photo class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Photo extends \Beta\Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Beta\Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Photo
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the option
+    *
+    * @return Option The option
+    */
+    public function getOption()
+    {
+        if (array_key_exists("option", $this->_propDict)) {
+            if (is_a($this->_propDict["option"], "Beta\Microsoft\Graph\CallRecords\Model\Option")) {
+                return $this->_propDict["option"];
+            } else {
+                $this->_propDict["option"] = new Option($this->_propDict["option"]);
+                return $this->_propDict["option"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the option
+    *
+    * @param Option $val The option
+    *
+    * @return Photo
+    */
+    public function setOption($val)
+    {
+        $this->_propDict["option"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ProductFamily.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ProductFamily.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* ProductFamily File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* ProductFamily class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class ProductFamily extends Enum
 {
+    /**
+    * The Enum ProductFamily
+    */
+    const UNKNOWN = "unknown";
+    const TEAMS = "teams";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Segment.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Segment.php
@@ -1,0 +1,331 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Segment File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+/**
+* Segment class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Segment extends \Beta\Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return Segment
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return Segment
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the caller
+    *
+    * @return Endpoint The caller
+    */
+    public function getCaller()
+    {
+        if (array_key_exists("caller", $this->_propDict)) {
+            if (is_a($this->_propDict["caller"], "Beta\Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["caller"];
+            } else {
+                $this->_propDict["caller"] = new Endpoint($this->_propDict["caller"]);
+                return $this->_propDict["caller"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the caller
+    *
+    * @param Endpoint $val The caller
+    *
+    * @return Segment
+    */
+    public function setCaller($val)
+    {
+        $this->_propDict["caller"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the callee
+    *
+    * @return Endpoint The callee
+    */
+    public function getCallee()
+    {
+        if (array_key_exists("callee", $this->_propDict)) {
+            if (is_a($this->_propDict["callee"], "Beta\Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["callee"];
+            } else {
+                $this->_propDict["callee"] = new Endpoint($this->_propDict["callee"]);
+                return $this->_propDict["callee"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the callee
+    *
+    * @param Endpoint $val The callee
+    *
+    * @return Segment
+    */
+    public function setCallee($val)
+    {
+        $this->_propDict["callee"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Beta\Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Segment
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the media
+     *
+     * @return array The media
+     */
+    public function getMedia()
+    {
+        if (array_key_exists("media", $this->_propDict)) {
+           return $this->_propDict["media"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the media
+    *
+    * @param Media $val The media
+    *
+    * @return Segment
+    */
+    public function setMedia($val)
+    {
+		$this->_propDict["media"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the refTypes
+     *
+     * @return array The refTypes
+     */
+    public function getRefTypes()
+    {
+        if (array_key_exists("refTypes", $this->_propDict)) {
+           return $this->_propDict["refTypes"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the refTypes
+    *
+    * @param Beta\Microsoft\Graph\Model\EntityType3 $val The refTypes
+    *
+    * @return Segment
+    */
+    public function setRefTypes($val)
+    {
+		$this->_propDict["refTypes"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the refType
+    *
+    * @return Beta\Microsoft\Graph\Model\Call The refType
+    */
+    public function getRefType()
+    {
+        if (array_key_exists("refType", $this->_propDict)) {
+            if (is_a($this->_propDict["refType"], "Beta\Microsoft\Graph\Model\Call")) {
+                return $this->_propDict["refType"];
+            } else {
+                $this->_propDict["refType"] = new Beta\Microsoft\Graph\Model\Call($this->_propDict["refType"]);
+                return $this->_propDict["refType"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the refType
+    *
+    * @param Beta\Microsoft\Graph\Model\Call $val The refType
+    *
+    * @return Segment
+    */
+    public function setRefType($val)
+    {
+        $this->_propDict["refType"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the sessionRef
+    *
+    * @return Session The sessionRef
+    */
+    public function getSessionRef()
+    {
+        if (array_key_exists("sessionRef", $this->_propDict)) {
+            if (is_a($this->_propDict["sessionRef"], "Beta\Microsoft\Graph\CallRecords\Model\Session")) {
+                return $this->_propDict["sessionRef"];
+            } else {
+                $this->_propDict["sessionRef"] = new Session($this->_propDict["sessionRef"]);
+                return $this->_propDict["sessionRef"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the sessionRef
+    *
+    * @param Session $val The sessionRef
+    *
+    * @return Segment
+    */
+    public function setSessionRef($val)
+    {
+        $this->_propDict["sessionRef"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the photo
+    *
+    * @return Photo The photo
+    */
+    public function getPhoto()
+    {
+        if (array_key_exists("photo", $this->_propDict)) {
+            if (is_a($this->_propDict["photo"], "Beta\Microsoft\Graph\CallRecords\Model\Photo")) {
+                return $this->_propDict["photo"];
+            } else {
+                $this->_propDict["photo"] = new Photo($this->_propDict["photo"]);
+                return $this->_propDict["photo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the photo
+    *
+    * @param Photo $val The photo
+    *
+    * @return Segment
+    */
+    public function setPhoto($val)
+    {
+        $this->_propDict["photo"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceEndpoint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceEndpoint.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* ServiceEndpoint File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,9 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
-* FeedbackTokenSet class
+* ServiceEndpoint class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +21,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class ServiceEndpoint extends Endpoint
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceRole.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceRole.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* ServiceRole File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* ServiceRole class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class ServiceRole extends Enum
 {
+    /**
+    * The Enum ServiceRole
+    */
+    const UNKNOWN = "unknown";
+    const CUSTOM_BOT = "customBot";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceUserAgent.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/ServiceUserAgent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* ServiceUserAgent File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+/**
+* ServiceUserAgent class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class ServiceUserAgent extends UserAgent
+{
+
+    /**
+    * Gets the role
+    *
+    * @return ServiceRole The role
+    */
+    public function getRole()
+    {
+        if (array_key_exists("role", $this->_propDict)) {
+            if (is_a($this->_propDict["role"], "Beta\Microsoft\Graph\CallRecords\Model\ServiceRole")) {
+                return $this->_propDict["role"];
+            } else {
+                $this->_propDict["role"] = new ServiceRole($this->_propDict["role"]);
+                return $this->_propDict["role"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the role
+    *
+    * @param ServiceRole $val The value to assign to the role
+    *
+    * @return ServiceUserAgent The ServiceUserAgent
+    */
+    public function setRole($val)
+    {
+        $this->_propDict["role"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Session.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Session.php
@@ -1,0 +1,238 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Session File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+/**
+* Session class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Session extends \Beta\Microsoft\Graph\Model\Entity
+{
+
+     /** 
+     * Gets the modalities
+     *
+     * @return array The modalities
+     */
+    public function getModalities()
+    {
+        if (array_key_exists("modalities", $this->_propDict)) {
+           return $this->_propDict["modalities"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the modalities
+    *
+    * @param Modality $val The modalities
+    *
+    * @return Session
+    */
+    public function setModalities($val)
+    {
+		$this->_propDict["modalities"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the startDateTime
+    *
+    * @return \DateTime The startDateTime
+    */
+    public function getStartDateTime()
+    {
+        if (array_key_exists("startDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["startDateTime"], "\DateTime")) {
+                return $this->_propDict["startDateTime"];
+            } else {
+                $this->_propDict["startDateTime"] = new \DateTime($this->_propDict["startDateTime"]);
+                return $this->_propDict["startDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the startDateTime
+    *
+    * @param \DateTime $val The startDateTime
+    *
+    * @return Session
+    */
+    public function setStartDateTime($val)
+    {
+        $this->_propDict["startDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the endDateTime
+    *
+    * @return \DateTime The endDateTime
+    */
+    public function getEndDateTime()
+    {
+        if (array_key_exists("endDateTime", $this->_propDict)) {
+            if (is_a($this->_propDict["endDateTime"], "\DateTime")) {
+                return $this->_propDict["endDateTime"];
+            } else {
+                $this->_propDict["endDateTime"] = new \DateTime($this->_propDict["endDateTime"]);
+                return $this->_propDict["endDateTime"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the endDateTime
+    *
+    * @param \DateTime $val The endDateTime
+    *
+    * @return Session
+    */
+    public function setEndDateTime($val)
+    {
+        $this->_propDict["endDateTime"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the caller
+    *
+    * @return Endpoint The caller
+    */
+    public function getCaller()
+    {
+        if (array_key_exists("caller", $this->_propDict)) {
+            if (is_a($this->_propDict["caller"], "Beta\Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["caller"];
+            } else {
+                $this->_propDict["caller"] = new Endpoint($this->_propDict["caller"]);
+                return $this->_propDict["caller"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the caller
+    *
+    * @param Endpoint $val The caller
+    *
+    * @return Session
+    */
+    public function setCaller($val)
+    {
+        $this->_propDict["caller"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the callee
+    *
+    * @return Endpoint The callee
+    */
+    public function getCallee()
+    {
+        if (array_key_exists("callee", $this->_propDict)) {
+            if (is_a($this->_propDict["callee"], "Beta\Microsoft\Graph\CallRecords\Model\Endpoint")) {
+                return $this->_propDict["callee"];
+            } else {
+                $this->_propDict["callee"] = new Endpoint($this->_propDict["callee"]);
+                return $this->_propDict["callee"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the callee
+    *
+    * @param Endpoint $val The callee
+    *
+    * @return Session
+    */
+    public function setCallee($val)
+    {
+        $this->_propDict["callee"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the failureInfo
+    *
+    * @return FailureInfo The failureInfo
+    */
+    public function getFailureInfo()
+    {
+        if (array_key_exists("failureInfo", $this->_propDict)) {
+            if (is_a($this->_propDict["failureInfo"], "Beta\Microsoft\Graph\CallRecords\Model\FailureInfo")) {
+                return $this->_propDict["failureInfo"];
+            } else {
+                $this->_propDict["failureInfo"] = new FailureInfo($this->_propDict["failureInfo"]);
+                return $this->_propDict["failureInfo"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the failureInfo
+    *
+    * @param FailureInfo $val The failureInfo
+    *
+    * @return Session
+    */
+    public function setFailureInfo($val)
+    {
+        $this->_propDict["failureInfo"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the segments
+     *
+     * @return array The segments
+     */
+    public function getSegments()
+    {
+        if (array_key_exists("segments", $this->_propDict)) {
+           return $this->_propDict["segments"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the segments
+    *
+    * @param Segment $val The segments
+    *
+    * @return Session
+    */
+    public function setSegments($val)
+    {
+		$this->_propDict["segments"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity1 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+/**
+* SingletonEntity1 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity1 extends \Beta\Microsoft\Graph\Model\Entity
+{
+    /**
+    * Gets the testSingleNav
+    *
+    * @return Beta\Microsoft\Graph\Model\TestType The testSingleNav
+    */
+    public function getTestSingleNav()
+    {
+        if (array_key_exists("testSingleNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav"], "Beta\Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testSingleNav"];
+            } else {
+                $this->_propDict["testSingleNav"] = new Beta\Microsoft\Graph\Model\TestType($this->_propDict["testSingleNav"]);
+                return $this->_propDict["testSingleNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav
+    *
+    * @param Beta\Microsoft\Graph\Model\TestType $val The testSingleNav
+    *
+    * @return SingletonEntity1
+    */
+    public function setTestSingleNav($val)
+    {
+        $this->_propDict["testSingleNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserAgent.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserAgent.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * UserAgent class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class UserAgent extends \Microsoft\Graph\Model\Entity
+class UserAgent extends \Beta\Microsoft\Graph\Model\Entity
 {
     /**
     * Gets the headerValue

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserFeedback.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserFeedback.php
@@ -11,7 +11,7 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
 /**
 * UserFeedback class
 *
@@ -21,7 +21,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class UserFeedback extends \Microsoft\Graph\Model\Entity
+class UserFeedback extends \Beta\Microsoft\Graph\Model\Entity
 {
     /**
     * Gets the text
@@ -58,7 +58,7 @@ class UserFeedback extends \Microsoft\Graph\Model\Entity
     public function getRating()
     {
         if (array_key_exists("rating", $this->_propDict)) {
-            if (is_a($this->_propDict["rating"], "Microsoft\Graph\CallRecords\Model\UserFeedbackRating")) {
+            if (is_a($this->_propDict["rating"], "Beta\Microsoft\Graph\CallRecords\Model\UserFeedbackRating")) {
                 return $this->_propDict["rating"];
             } else {
                 $this->_propDict["rating"] = new UserFeedbackRating($this->_propDict["rating"]);
@@ -89,7 +89,7 @@ class UserFeedback extends \Microsoft\Graph\Model\Entity
     public function getTokens()
     {
         if (array_key_exists("tokens", $this->_propDict)) {
-            if (is_a($this->_propDict["tokens"], "Microsoft\Graph\CallRecords\Model\FeedbackTokenSet")) {
+            if (is_a($this->_propDict["tokens"], "Beta\Microsoft\Graph\CallRecords\Model\FeedbackTokenSet")) {
                 return $this->_propDict["tokens"];
             } else {
                 $this->_propDict["tokens"] = new FeedbackTokenSet($this->_propDict["tokens"]);

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserFeedbackRating.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/UserFeedbackRating.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* UserFeedbackRating File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* UserFeedbackRating class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class UserFeedbackRating extends Enum
 {
+    /**
+    * The Enum UserFeedbackRating
+    */
+    const NOT_RATED = "notRated";
+    const BAD = "bad";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/WifiBand.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/WifiBand.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* WifiBand File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* WifiBand class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class WifiBand extends Enum
 {
+    /**
+    * The Enum WifiBand
+    */
+    const UNKNOWN = "unknown";
+    const FREQUENCY24_G_HZ = "frequency24GHz";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/WifiRadioType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/WifiRadioType.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* WifiRadioType File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\CallRecords\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* WifiRadioType class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class WifiRadioType extends Enum
 {
+    /**
+    * The Enum WifiRadioType
+    */
+    const UNKNOWN = "unknown";
+    const WIFI80211A = "wifi80211a";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Call.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Call.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* Call File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* Call class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,33 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class Call extends Entity
 {
+    /**
+    * Gets the subject
+    *
+    * @return string The subject
+    */
+    public function getSubject()
+    {
+        if (array_key_exists("subject", $this->_propDict)) {
+            return $this->_propDict["subject"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the subject
+    *
+    * @param string $val The subject
+    *
+    * @return Call
+    */
+    public function setSubject($val)
+    {
+        $this->_propDict["subject"] = $val;
+        return $this;
+    }
+    
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/CloudCommunications.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/CloudCommunications.php
@@ -1,0 +1,83 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* CloudCommunications File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* CloudCommunications class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class CloudCommunications extends Entity
+{
+
+     /** 
+     * Gets the calls
+     *
+     * @return array The calls
+     */
+    public function getCalls()
+    {
+        if (array_key_exists("calls", $this->_propDict)) {
+           return $this->_propDict["calls"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the calls
+    *
+    * @param Call $val The calls
+    *
+    * @return CloudCommunications
+    */
+    public function setCalls($val)
+    {
+		$this->_propDict["calls"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the callRecords
+     *
+     * @return array The callRecords
+     */
+    public function getCallRecords()
+    {
+        if (array_key_exists("callRecords", $this->_propDict)) {
+           return $this->_propDict["callRecords"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the callRecords
+    *
+    * @param Beta\Microsoft\Graph\CallRecords\Model\CallRecord $val The callRecords
+    *
+    * @return CloudCommunications
+    */
+    public function setCallRecords($val)
+    {
+		$this->_propDict["callRecords"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/DerivedComplexTypeRequest.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/DerivedComplexTypeRequest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* DerivedComplexTypeRequest File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+/**
+* DerivedComplexTypeRequest class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest
+{
+    /**
+    * Gets the property1
+    *
+    * @return string The property1
+    */
+    public function getProperty1()
+    {
+        if (array_key_exists("property1", $this->_propDict)) {
+            return $this->_propDict["property1"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the property1
+    *
+    * @param string $val The value of the property1
+    *
+    * @return DerivedComplexTypeRequest
+    */
+    public function setProperty1($val)
+    {
+        $this->_propDict["property1"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the property2
+    *
+    * @return string The property2
+    */
+    public function getProperty2()
+    {
+        if (array_key_exists("property2", $this->_propDict)) {
+            return $this->_propDict["property2"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the property2
+    *
+    * @param string $val The value of the property2
+    *
+    * @return DerivedComplexTypeRequest
+    */
+    public function setProperty2($val)
+    {
+        $this->_propDict["property2"] = $val;
+        return $this;
+    }
+
+    /**
+    * Gets the enumProperty
+    *
+    * @return Enum1 The enumProperty
+    */
+    public function getEnumProperty()
+    {
+        if (array_key_exists("enumProperty", $this->_propDict)) {
+            if (is_a($this->_propDict["enumProperty"], "Beta\Microsoft\Graph\Model\Enum1")) {
+                return $this->_propDict["enumProperty"];
+            } else {
+                $this->_propDict["enumProperty"] = new Enum1($this->_propDict["enumProperty"]);
+                return $this->_propDict["enumProperty"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the enumProperty
+    *
+    * @param Enum1 $val The value to assign to the enumProperty
+    *
+    * @return DerivedComplexTypeRequest The DerivedComplexTypeRequest
+    */
+    public function setEnumProperty($val)
+    {
+        $this->_propDict["enumProperty"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EmptyBaseComplexTypeRequest.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EmptyBaseComplexTypeRequest.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* EmptyBaseComplexTypeRequest File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,9 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
 /**
-* FeedbackTokenSet class
+* EmptyBaseComplexTypeRequest class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +21,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class EmptyBaseComplexTypeRequest extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EmptyComplexType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EmptyComplexType.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* EmptyComplexType File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,9 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
 /**
-* FeedbackTokenSet class
+* EmptyComplexType class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +21,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class EmptyComplexType extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Endpoint.php
@@ -1,0 +1,54 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Endpoint File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* Endpoint class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Endpoint extends Entity
+{
+    /**
+    * Gets the property1
+    *
+    * @return int The property1
+    */
+    public function getProperty1()
+    {
+        if (array_key_exists("property1", $this->_propDict)) {
+            return $this->_propDict["property1"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the property1
+    *
+    * @param int $val The property1
+    *
+    * @return Endpoint
+    */
+    public function setProperty1($val)
+    {
+        $this->_propDict["property1"] = intval($val);
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -1,0 +1,123 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Entity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* Entity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Entity implements \JsonSerializable
+{
+    /**
+    * The array of properties available
+    * to the model
+    *
+    * @var array(string => string)
+    */
+    protected $_propDict;
+    
+    /**
+    * Construct a new Entity
+    *
+    * @param array $propDict A list of properties to set
+    */
+    function __construct($propDict = array())
+    {
+		$this->_propDict = $propDict;
+    }
+
+    /**
+    * Gets the property dictionary of the Entity
+    *
+    * @return array The list of properties
+    */
+    public function getProperties()
+    {
+        return $this->_propDict;
+    }
+    
+    /**
+    * Gets the id
+    *
+    * @return string The id
+    */
+    public function getId()
+    {
+        if (array_key_exists("id", $this->_propDict)) {
+            return $this->_propDict["id"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the id
+    *
+    * @param string $val The id
+    *
+    * @return Entity
+    */
+    public function setId($val)
+    {
+        $this->_propDict["id"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the ODataType
+    *
+    * @return string The ODataType
+    */
+    public function getODataType()
+    {
+        return $this->_propDict["@odata.type"];
+    }
+    
+    /**
+    * Sets the ODataType
+    *
+    * @param string The ODataType
+    *
+    * @return Entity
+    */
+    public function setODataType($val)
+    {
+        $this->_propDict["@odata.type"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Serializes the object by property array
+	* Manually serialize DateTime into RFC3339 format
+    *
+    * @return array The list of properties
+    */
+    public function jsonSerialize()
+    {
+        $serializableProperties = $this->getProperties();
+        foreach ($serializableProperties as $property => $val) {
+            if (is_a($val, "\DateTime")) {
+                $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
+            } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
+                $serializableProperties[$property] = $val->value();
+            }
+        }
+        return $serializableProperties;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EntityType2.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EntityType2.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* EntityType2 File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* EntityType2 class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class EntityType2 extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EntityType3.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/EntityType3.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* EntityType3 File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* EntityType3 class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class EntityType3 extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Enum1.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Enum1.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* Enum1 File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,12 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
+use Microsoft\Graph\Core\Enum;
+
 /**
-* FeedbackTokenSet class
+* Enum1 class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +24,11 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class Enum1 extends Enum
 {
+    /**
+    * The Enum Enum1
+    */
+    const VALUE0 = "value0";
+    const VALUE1 = "value1";
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Identity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Identity.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Identity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+/**
+* Identity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Identity extends Entity
+{
+    /**
+    * Gets the displayName
+    *
+    * @return string The displayName
+    */
+    public function getDisplayName()
+    {
+        if (array_key_exists("displayName", $this->_propDict)) {
+            return $this->_propDict["displayName"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the displayName
+    *
+    * @param string $val The value of the displayName
+    *
+    * @return Identity
+    */
+    public function setDisplayName($val)
+    {
+        $this->_propDict["displayName"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the id
+    *
+    * @return string The id
+    */
+    public function getId()
+    {
+        if (array_key_exists("id", $this->_propDict)) {
+            return $this->_propDict["id"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the id
+    *
+    * @param string $val The value of the id
+    *
+    * @return Identity
+    */
+    public function setId($val)
+    {
+        $this->_propDict["id"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/IdentitySet.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/IdentitySet.php
@@ -1,0 +1,119 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* IdentitySet File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+/**
+* IdentitySet class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class IdentitySet extends Entity
+{
+
+    /**
+    * Gets the application
+    *
+    * @return Identity The application
+    */
+    public function getApplication()
+    {
+        if (array_key_exists("application", $this->_propDict)) {
+            if (is_a($this->_propDict["application"], "Beta\Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["application"];
+            } else {
+                $this->_propDict["application"] = new Identity($this->_propDict["application"]);
+                return $this->_propDict["application"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the application
+    *
+    * @param Identity $val The value to assign to the application
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setApplication($val)
+    {
+        $this->_propDict["application"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the device
+    *
+    * @return Identity The device
+    */
+    public function getDevice()
+    {
+        if (array_key_exists("device", $this->_propDict)) {
+            if (is_a($this->_propDict["device"], "Beta\Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["device"];
+            } else {
+                $this->_propDict["device"] = new Identity($this->_propDict["device"]);
+                return $this->_propDict["device"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the device
+    *
+    * @param Identity $val The value to assign to the device
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setDevice($val)
+    {
+        $this->_propDict["device"] = $val;
+         return $this;
+    }
+
+    /**
+    * Gets the user
+    *
+    * @return Identity The user
+    */
+    public function getUser()
+    {
+        if (array_key_exists("user", $this->_propDict)) {
+            if (is_a($this->_propDict["user"], "Beta\Microsoft\Graph\Model\Identity")) {
+                return $this->_propDict["user"];
+            } else {
+                $this->_propDict["user"] = new Identity($this->_propDict["user"]);
+                return $this->_propDict["user"];
+            }
+        }
+        return null;
+    }
+
+    /**
+    * Sets the user
+    *
+    * @param Identity $val The value to assign to the user
+    *
+    * @return IdentitySet The IdentitySet
+    */
+    public function setUser($val)
+    {
+        $this->_propDict["user"] = $val;
+         return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
@@ -1,0 +1,64 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* OnenotePage File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* OnenotePage class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class OnenotePage extends Entity
+{
+    /**
+    * Gets the content
+    * The OneNotePage content.
+///
+/// Test token string
+    *
+    * @return \GuzzleHttp\Psr7\Stream The content
+    */
+    public function getContent()
+    {
+        if (array_key_exists("content", $this->_propDict)) {
+            if (is_a($this->_propDict["content"], "\GuzzleHttp\Psr7\Stream")) {
+                return $this->_propDict["content"];
+            } else {
+                $this->_propDict["content"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["content"]);
+                return $this->_propDict["content"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the content
+    * The OneNotePage content.
+///
+/// Test token string
+    *
+    * @param \GuzzleHttp\Psr7\Stream $val The content
+    *
+    * @return OnenotePage
+    */
+    public function setContent($val)
+    {
+        $this->_propDict["content"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/PlannerGroup.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/PlannerGroup.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* PlannerGroup File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* PlannerGroup class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class PlannerGroup extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Recipient.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Recipient.php
@@ -1,0 +1,78 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Recipient File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+/**
+* Recipient class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Recipient extends Entity
+{
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the name
+    *
+    * @param string $val The value of the name
+    *
+    * @return Recipient
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    /**
+    * Gets the email
+    *
+    * @return string The email
+    */
+    public function getEmail()
+    {
+        if (array_key_exists("email", $this->_propDict)) {
+            return $this->_propDict["email"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the email
+    *
+    * @param string $val The value of the email
+    *
+    * @return Recipient
+    */
+    public function setEmail($val)
+    {
+        $this->_propDict["email"] = $val;
+        return $this;
+    }
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/ResponseObject.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/ResponseObject.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* ResponseObject File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,9 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
 /**
-* FeedbackTokenSet class
+* ResponseObject class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +21,6 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class ResponseObject extends Entity
 {
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Schedule.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Schedule.php
@@ -1,0 +1,110 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* Schedule File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* Schedule class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class Schedule extends Entity
+{
+    /**
+    * Gets the enabled
+    *
+    * @return bool The enabled
+    */
+    public function getEnabled()
+    {
+        if (array_key_exists("enabled", $this->_propDict)) {
+            return $this->_propDict["enabled"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the enabled
+    *
+    * @param bool $val The enabled
+    *
+    * @return Schedule
+    */
+    public function setEnabled($val)
+    {
+        $this->_propDict["enabled"] = boolval($val);
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the timesOff
+     *
+     * @return array The timesOff
+     */
+    public function getTimesOff()
+    {
+        if (array_key_exists("timesOff", $this->_propDict)) {
+           return $this->_propDict["timesOff"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the timesOff
+    *
+    * @param TimeOff $val The timesOff
+    *
+    * @return Schedule
+    */
+    public function setTimesOff($val)
+    {
+		$this->_propDict["timesOff"] = $val;
+        return $this;
+    }
+    
+
+     /** 
+     * Gets the timeOffRequests
+     *
+     * @return array The timeOffRequests
+     */
+    public function getTimeOffRequests()
+    {
+        if (array_key_exists("timeOffRequests", $this->_propDict)) {
+           return $this->_propDict["timeOffRequests"];
+        } else {
+            return null;
+        }
+    }
+    
+    /** 
+    * Sets the timeOffRequests
+    *
+    * @param TimeOffRequest $val The timeOffRequests
+    *
+    * @return Schedule
+    */
+    public function setTimeOffRequests($val)
+    {
+		$this->_propDict["timeOffRequests"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity1.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity1 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* SingletonEntity1 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity1 extends Entity
+{
+    /**
+    * Gets the testSingleNav
+    *
+    * @return TestType The testSingleNav
+    */
+    public function getTestSingleNav()
+    {
+        if (array_key_exists("testSingleNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav"], "Beta\Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testSingleNav"];
+            } else {
+                $this->_propDict["testSingleNav"] = new TestType($this->_propDict["testSingleNav"]);
+                return $this->_propDict["testSingleNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav
+    *
+    * @param TestType $val The testSingleNav
+    *
+    * @return SingletonEntity1
+    */
+    public function setTestSingleNav($val)
+    {
+        $this->_propDict["testSingleNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity2.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity2.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* SingletonEntity2 File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* SingletonEntity2 class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class SingletonEntity2 extends Entity
+{
+    /**
+    * Gets the testSingleNav2
+    *
+    * @return EntityType3 The testSingleNav2
+    */
+    public function getTestSingleNav2()
+    {
+        if (array_key_exists("testSingleNav2", $this->_propDict)) {
+            if (is_a($this->_propDict["testSingleNav2"], "Beta\Microsoft\Graph\Model\EntityType3")) {
+                return $this->_propDict["testSingleNav2"];
+            } else {
+                $this->_propDict["testSingleNav2"] = new EntityType3($this->_propDict["testSingleNav2"]);
+                return $this->_propDict["testSingleNav2"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testSingleNav2
+    *
+    * @param EntityType3 $val The testSingleNav2
+    *
+    * @return SingletonEntity2
+    */
+    public function setTestSingleNav2($val)
+    {
+        $this->_propDict["testSingleNav2"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestEntity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestEntity.php
@@ -1,0 +1,120 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TestEntity File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* TestEntity class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TestEntity extends Entity
+{
+    /**
+    * Gets the testNav
+    *
+    * @return TestType The testNav
+    */
+    public function getTestNav()
+    {
+        if (array_key_exists("testNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testNav"], "Beta\Microsoft\Graph\Model\TestType")) {
+                return $this->_propDict["testNav"];
+            } else {
+                $this->_propDict["testNav"] = new TestType($this->_propDict["testNav"]);
+                return $this->_propDict["testNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testNav
+    *
+    * @param TestType $val The testNav
+    *
+    * @return TestEntity
+    */
+    public function setTestNav($val)
+    {
+        $this->_propDict["testNav"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the testInvalidNav
+    *
+    * @return EntityType2 The testInvalidNav
+    */
+    public function getTestInvalidNav()
+    {
+        if (array_key_exists("testInvalidNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testInvalidNav"], "Beta\Microsoft\Graph\Model\EntityType2")) {
+                return $this->_propDict["testInvalidNav"];
+            } else {
+                $this->_propDict["testInvalidNav"] = new EntityType2($this->_propDict["testInvalidNav"]);
+                return $this->_propDict["testInvalidNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testInvalidNav
+    *
+    * @param EntityType2 $val The testInvalidNav
+    *
+    * @return TestEntity
+    */
+    public function setTestInvalidNav($val)
+    {
+        $this->_propDict["testInvalidNav"] = $val;
+        return $this;
+    }
+    
+    /**
+    * Gets the testExplicitNav
+    *
+    * @return EntityType3 The testExplicitNav
+    */
+    public function getTestExplicitNav()
+    {
+        if (array_key_exists("testExplicitNav", $this->_propDict)) {
+            if (is_a($this->_propDict["testExplicitNav"], "Beta\Microsoft\Graph\Model\EntityType3")) {
+                return $this->_propDict["testExplicitNav"];
+            } else {
+                $this->_propDict["testExplicitNav"] = new EntityType3($this->_propDict["testExplicitNav"]);
+                return $this->_propDict["testExplicitNav"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the testExplicitNav
+    *
+    * @param EntityType3 $val The testExplicitNav
+    *
+    * @return TestEntity
+    */
+    public function setTestExplicitNav($val)
+    {
+        $this->_propDict["testExplicitNav"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
@@ -1,0 +1,58 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* TestType File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\Model;
+
+/**
+* TestType class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright © Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class TestType extends Entity
+{
+    /**
+    * Gets the propertyAlpha
+    *
+    * @return DerivedComplexTypeRequest The propertyAlpha
+    */
+    public function getPropertyAlpha()
+    {
+        if (array_key_exists("propertyAlpha", $this->_propDict)) {
+            if (is_a($this->_propDict["propertyAlpha"], "Beta\Microsoft\Graph\Model\DerivedComplexTypeRequest")) {
+                return $this->_propDict["propertyAlpha"];
+            } else {
+                $this->_propDict["propertyAlpha"] = new DerivedComplexTypeRequest($this->_propDict["propertyAlpha"]);
+                return $this->_propDict["propertyAlpha"];
+            }
+        }
+        return null;
+    }
+    
+    /**
+    * Sets the propertyAlpha
+    *
+    * @param DerivedComplexTypeRequest $val The propertyAlpha
+    *
+    * @return TestType
+    */
+    public function setPropertyAlpha($val)
+    {
+        $this->_propDict["propertyAlpha"] = $val;
+        return $this;
+    }
+    
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOff.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOff.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* TimeOff File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* TimeOff class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,33 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class TimeOff extends Entity
 {
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the name
+    *
+    * @param string $val The name
+    *
+    * @return TimeOff
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOffRequest.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOffRequest.php
@@ -2,7 +2,7 @@
 /**
 * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 * 
-* FeedbackTokenSet File
+* TimeOffRequest File
 * PHP version 7
 *
 * @category  Library
@@ -11,9 +11,10 @@
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-namespace Microsoft\Graph\CallRecords\Model;
+namespace Beta\Microsoft\Graph\Model;
+
 /**
-* FeedbackTokenSet class
+* TimeOffRequest class
 *
 * @category  Model
 * @package   Microsoft.Graph
@@ -21,6 +22,33 @@ namespace Microsoft\Graph\CallRecords\Model;
 * @license   https://opensource.org/licenses/MIT MIT License
 * @link      https://graph.microsoft.com
 */
-class FeedbackTokenSet extends \Microsoft\Graph\Model\Entity
+class TimeOffRequest extends Entity
 {
+    /**
+    * Gets the name
+    *
+    * @return string The name
+    */
+    public function getName()
+    {
+        if (array_key_exists("name", $this->_propDict)) {
+            return $this->_propDict["name"];
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+    * Sets the name
+    *
+    * @param string $val The name
+    *
+    * @return TimeOffRequest
+    */
+    public function setName($val)
+    {
+        $this->_propDict["name"] = $val;
+        return $this;
+    }
+    
 }

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -62,7 +62,7 @@
     <Content Include="TestDataJava\**\*.java">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestDataPHP\**\*.php">
+    <Content Include="TestDataPHP*\**\*.php">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestDataTypeScript\**\*.ts">

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PHPMultipleNamespacesTests.cs" />
     <Compile Include="TypeScriptMultipeNamespacesTests.cs" />
     <Compile Include="JavaMultipleNamespacesTests.cs" />
     <Compile Include="CSharpMultipleNamespacesTests.cs" />
@@ -59,6 +60,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestDataJava\**\*.java">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestDataPHP\**\*.php">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestDataTypeScript\**\*.ts">


### PR DESCRIPTION
- Similar to other languages
  - used fully qualified name for cross namespace references
  - used plain type name for same namespace references.
- Updated hard coded Entity references to take multiple namespace scenarios into account
- Updated beta generation logic to take in a `php.namespacePrefix` input instead of a full `php.namespace`. When prefix is `Beta`, types under `microsoft.graph.callRecords` namespace end up in `\Beta\Microsoft\Graph\CallRecords\Model\` namespace.
  - This allows types from Beta and V1 to live together in the same project
- Updated output folder structure to reflect namespaces as well. For example
  - `CallRecord.php` in V1 goes into `com/Microsoft/Graph/CallRecords/Model/` folder
  - `CallRecord.php` in Beta goes into `com/Beta/Microsoft/Graph/CallRecords/Model/` folder
- Added tests for both V1 and Beta generation
- Fixed a bug where `is_a` wasn't leveraging "entity name sanitization". It was referring to a nonexistent `List` type, even though as part of the generation, the name is sanitized to `GraphList`.
- Regression testing:
  - V1 and Beta generations with single namespaces are an exact match except for the `is_a` bug fix in [Drive.php#L255](https://github.com/microsoftgraph/msgraph-sdk-php/blob/dev/src/Model/Drive.php#L255) and [SharedDriveItem.php#L132](https://github.com/microsoftgraph/msgraph-sdk-php/blob/dev/src/Model/SharedDriveItem.php#L132).
- I was tempted to refactor out the common logic between complex and entity types, but for the sake of having a clean diff to highlight the actual namespace change, I will give that a try in a future PR.

[AB#5034](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/5034)
[AB#5035](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/5035)