### PR TITLE
Fix linting errors in TypeScript namespace generation

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -23,12 +23,9 @@ export as namespace microsoftgraph;
 export type NullableOption<T> = T | null;
 
 <#=typeScriptNamespaces.MainNamespace.ToString()#>
-
 <#
 foreach (var subNamespace in typeScriptNamespaces.SubNamespaces)
 {
-#>
-<#=subNamespace.Value.ToString()#>
-<#
+#><#=subNamespace.Value.ToString()#><#
 }
 #>

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
@@ -111,16 +111,17 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         /// <param name="enumType">enum</param>
         private void AddEnum(OdcmEnum enumType)
         {
+            var export = IsMainNamespace ? "export " : string.Empty;
             var enumTypeName = enumType.Name.UpperCaseFirstChar();
             var enumValues = enumType.GetEnumValues();
-            var exportTypeLength = "export type".Length + enumTypeName.Length + enumValues.Length + 3;
+            var exportTypeLength = (export + "type").Length + enumTypeName.Length + enumValues.Length + 3;
             if (exportTypeLength < MaxLineLength)
             {
-                sb.AppendLine($"{NamespaceIndent}export type {enumTypeName} = {enumValues};");
+                sb.AppendLine($"{NamespaceIndent}{export}type {enumTypeName} = {enumValues};");
             }
             else
             {
-                sb.AppendLine($"{NamespaceIndent}export type {enumTypeName} =");
+                sb.AppendLine($"{NamespaceIndent}{export}type {enumTypeName} =");
                 var enums = enumValues.Split('|');
                 sb.Append($"{NamespaceIndent}{TabSpace}| ");
                 sb.Append(string.Join(Environment.NewLine + NamespaceIndent + TabSpace + "| ", enums.Select(@enum => @enum.Trim())));
@@ -141,6 +142,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         /// <param name="class">entity or complex type</param>
         private void AddEntityOrComplexType(OdcmClass @class)
         {
+            var export = IsMainNamespace ? "export " : string.Empty;
             var propCount = @class.Properties.Count;
             var entityTypeName = @class.Name.UpperCaseFirstChar();
             if (propCount == 0 && entityTypeName[0] == 'I')
@@ -159,7 +161,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
             var extendsStatement = @class.Base == null
                 ? string.Empty
                 : $" extends {GetFullyQualifiedTypeScriptTypeName(@class.Base.GetTypeString(), @class.Base.Namespace.GetNamespaceName())}";
-            var exportInterfaceLine = NamespaceIndent + "export interface " + entityTypeName + extendsStatement + " {";
+            var exportInterfaceLine = NamespaceIndent + $"{export}interface " + entityTypeName + extendsStatement + " {";
             if (propCount == 0)
             {
                 sb.AppendLine(exportInterfaceLine + "}");

--- a/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -90,23 +90,22 @@ export interface IdentitySet {
     user?: NullableOption<Identity>;
 }
 
-
 export namespace CallRecords {
-    export type CallType = "unknown" | "groupCall";
-    export type ClientPlatform = "unknown" | "windows";
-    export type FailureStage = "unknown" | "callSetup";
-    export type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
-    export type NetworkConnectionType = "unknown" | "wired";
-    export type ProductFamily = "unknown" | "teams";
-    export type ServiceRole = "unknown" | "customBot";
-    export type UserFeedbackRating = "notRated" | "bad";
-    export type WifiBand = "unknown" | "frequency24GHz";
-    export type WifiRadioType = "unknown" | "wifi80211a";
-    export type Modality = "audio" | "video";
-    export interface SingletonEntity1 extends microsoftgraph.Entity {
+    type CallType = "unknown" | "groupCall";
+    type ClientPlatform = "unknown" | "windows";
+    type FailureStage = "unknown" | "callSetup";
+    type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
+    type NetworkConnectionType = "unknown" | "wired";
+    type ProductFamily = "unknown" | "teams";
+    type ServiceRole = "unknown" | "customBot";
+    type UserFeedbackRating = "notRated" | "bad";
+    type WifiBand = "unknown" | "frequency24GHz";
+    type WifiRadioType = "unknown" | "wifi80211a";
+    type Modality = "audio" | "video";
+    interface SingletonEntity1 extends microsoftgraph.Entity {
         testSingleNav?: NullableOption<microsoftgraph.TestType>;
     }
-    export interface CallRecord extends microsoftgraph.Entity {
+    interface CallRecord extends microsoftgraph.Entity {
         version?: number;
         type?: CallType;
         modalities?: Modality[];
@@ -119,7 +118,7 @@ export namespace CallRecords {
         sessions?: NullableOption<Session[]>;
         recipients?: NullableOption<microsoftgraph.EntityType2[]>;
     }
-    export interface Session extends microsoftgraph.Entity {
+    interface Session extends microsoftgraph.Entity {
         modalities?: Modality[];
         startDateTime?: string;
         endDateTime?: string;
@@ -128,7 +127,7 @@ export namespace CallRecords {
         failureInfo?: NullableOption<FailureInfo>;
         segments?: NullableOption<Segment[]>;
     }
-    export interface Segment extends microsoftgraph.Entity {
+    interface Segment extends microsoftgraph.Entity {
         startDateTime?: string;
         endDateTime?: string;
         caller?: NullableOption<Endpoint>;
@@ -141,29 +140,29 @@ export namespace CallRecords {
         photo?: NullableOption<Photo>;
     }
 // tslint:disable-next-line: no-empty-interface
-    export interface Option extends microsoftgraph.Entity {}
-    export interface Photo extends microsoftgraph.Entity {
+    interface Option extends microsoftgraph.Entity {}
+    interface Photo extends microsoftgraph.Entity {
         failureInfo?: NullableOption<FailureInfo>;
         option?: NullableOption<Option>;
     }
-    export interface Endpoint {
+    interface Endpoint {
         userAgent?: NullableOption<UserAgent>;
     }
-    export interface UserAgent {
+    interface UserAgent {
         headerValue?: NullableOption<string>;
         applicationVersion?: NullableOption<string>;
     }
-    export interface FailureInfo {
+    interface FailureInfo {
         stage?: FailureStage;
         reason?: NullableOption<string>;
     }
-    export interface Media {
+    interface Media {
         label?: NullableOption<string>;
         callerNetwork?: NullableOption<NetworkInfo>;
         callerDevice?: NullableOption<DeviceInfo>;
         streams?: NullableOption<MediaStream[]>;
     }
-    export interface NetworkInfo {
+    interface NetworkInfo {
         connectionType?: NetworkConnectionType;
         wifiBand?: WifiBand;
         basicServiceSetIdentifier?: NullableOption<string>;
@@ -171,12 +170,12 @@ export namespace CallRecords {
         wifiSignalStrength?: NullableOption<number>;
         bandwidthLowEventRatio?: NullableOption<number>;
     }
-    export interface DeviceInfo {
+    interface DeviceInfo {
         captureDeviceName?: NullableOption<string>;
         sentSignalLevel?: NullableOption<number>;
         speakerGlitchRate?: NullableOption<number>;
     }
-    export interface MediaStream {
+    interface MediaStream {
         streamId?: NullableOption<string>;
         startDateTime?: NullableOption<string>;
         streamDirection?: MediaStreamDirection;
@@ -185,25 +184,24 @@ export namespace CallRecords {
         lowVideoProcessingCapabilityRatio?: NullableOption<number>;
         averageAudioNetworkJitter?: NullableOption<string>;
     }
-    export interface ParticipantEndpoint extends Endpoint {
+    interface ParticipantEndpoint extends Endpoint {
         identity?: NullableOption<microsoftgraph.IdentitySet>;
         feedback?: NullableOption<UserFeedback>;
     }
-    export interface UserFeedback {
+    interface UserFeedback {
         text?: NullableOption<string>;
         rating?: UserFeedbackRating;
         tokens?: NullableOption<FeedbackTokenSet>;
     }
 // tslint:disable-next-line: no-empty-interface
-    export interface FeedbackTokenSet {}
+    interface FeedbackTokenSet {}
 // tslint:disable-next-line: no-empty-interface
-    export interface ServiceEndpoint extends Endpoint {}
-    export interface ClientUserAgent extends UserAgent {
+    interface ServiceEndpoint extends Endpoint {}
+    interface ClientUserAgent extends UserAgent {
         platform?: ClientPlatform;
         productFamily?: ProductFamily;
     }
-    export interface ServiceUserAgent extends UserAgent {
+    interface ServiceUserAgent extends UserAgent {
         role?: ServiceRole;
     }
 }
-


### PR DESCRIPTION
## Summary

This is fixing the issues found by `dtslint`. (thanks @nikithauc).
1. Double empty lines are removed.
2. `export` in subnamespace types are removed as they are not needed.

## Generated code differences

Code diff can be seen in the test changes.

## Command line arguments to run these changes

`.\Typewriter.exe -v Info -m 'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml' -o .\TypeScriptLintFixesV1\ -g Files -l TypeScript`

`.\Typewriter.exe -v Info -m 'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml' -o .\TypeScriptLintFixesBeta\ -g Files -l TypeScript`

## Links to issues or work items this PR addresses
[AB#5029](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/5029)