### PR TITLE
- adds missing skip and skipToken methods for collection requests

### DIFF
--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
@@ -103,6 +103,29 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
     }
 
 <# } #>
+<# if (c.GetFeatures().CanSkip) { #>
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public <#=c.ITypeCollectionRequest()#> skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (<#=c.TypeCollectionRequest()#>)this;
+    }
+
+<# } #>
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public <#=c.ITypeCollectionRequest()#> skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (<#=c.ITypeCollectionRequest()#>)this;
+    }
     public <#=c.ITypeCollectionPage()#> buildFromResponse(final <#=c.BaseTypeCollectionResponse()#> response) {
         final <#=c.ITypeCollectionRequestBuilder()#> builder;
         if (response.nextLink != null) {

--- a/Templates/Java/requests_extensions/IBaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/IBaseEntityCollectionRequest.java.tt
@@ -49,5 +49,23 @@ import <#=importNamespace#>.http.IBaseCollectionPage;
     <#=c.ITypeCollectionRequest()#> top(final int value);
 
 <# } #>
+<# if (c.GetFeatures().CanSkip) { #>
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    <#=c.ITypeCollectionRequest()#> skip(final int value);
+
+<# } #>
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	<#=c.ITypeCollectionRequest()#> skipToken(String skipToken);
 }
 <#=PostProcess(c.ITypeCollectionRequest())#>

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
@@ -106,6 +106,27 @@ public class CallCollectionRequest extends BaseCollectionRequest<CallCollectionR
         return (CallCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ICallCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (CallCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ICallCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ICallCollectionRequest)this;
+    }
     public ICallCollectionPage buildFromResponse(final CallCollectionResponse response) {
         final ICallCollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
@@ -106,6 +106,27 @@ public class EntityType2CollectionRequest extends BaseCollectionRequest<EntityTy
         return (EntityType2CollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public IEntityType2CollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (EntityType2CollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public IEntityType2CollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (IEntityType2CollectionRequest)this;
+    }
     public IEntityType2CollectionPage buildFromResponse(final EntityType2CollectionResponse response) {
         final IEntityType2CollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
@@ -107,6 +107,27 @@ public class EntityType3CollectionRequest extends BaseCollectionRequest<EntityTy
         return (EntityType3CollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public IEntityType3CollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (EntityType3CollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public IEntityType3CollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (IEntityType3CollectionRequest)this;
+    }
     public IEntityType3CollectionPage buildFromResponse(final EntityType3CollectionResponse response) {
         final IEntityType3CollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallCollectionRequest.java
@@ -53,4 +53,20 @@ public interface ICallCollectionRequest {
      */
     ICallCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ICallCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ICallCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2CollectionRequest.java
@@ -53,4 +53,20 @@ public interface IEntityType2CollectionRequest {
      */
     IEntityType2CollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    IEntityType2CollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	IEntityType2CollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3CollectionRequest.java
@@ -54,4 +54,20 @@ public interface IEntityType3CollectionRequest {
      */
     IEntityType3CollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    IEntityType3CollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	IEntityType3CollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffCollectionRequest.java
@@ -53,4 +53,20 @@ public interface ITimeOffCollectionRequest {
      */
     ITimeOffCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ITimeOffCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ITimeOffCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestCollectionRequest.java
@@ -54,4 +54,20 @@ public interface ITimeOffRequestCollectionRequest {
      */
     ITimeOffRequestCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ITimeOffRequestCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ITimeOffRequestCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
@@ -106,6 +106,27 @@ public class TimeOffCollectionRequest extends BaseCollectionRequest<TimeOffColle
         return (TimeOffCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ITimeOffCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (TimeOffCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ITimeOffCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ITimeOffCollectionRequest)this;
+    }
     public ITimeOffCollectionPage buildFromResponse(final TimeOffCollectionResponse response) {
         final ITimeOffCollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
@@ -107,6 +107,27 @@ public class TimeOffRequestCollectionRequest extends BaseCollectionRequest<TimeO
         return (TimeOffRequestCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ITimeOffRequestCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (TimeOffRequestCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ITimeOffRequestCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ITimeOffRequestCollectionRequest)this;
+    }
     public ITimeOffRequestCollectionPage buildFromResponse(final TimeOffRequestCollectionResponse response) {
         final ITimeOffRequestCollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
@@ -106,6 +106,27 @@ public class CallRecordCollectionRequest extends BaseCollectionRequest<CallRecor
         return (CallRecordCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ICallRecordCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (CallRecordCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ICallRecordCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ICallRecordCollectionRequest)this;
+    }
     public ICallRecordCollectionPage buildFromResponse(final CallRecordCollectionResponse response) {
         final ICallRecordCollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordCollectionRequest.java
@@ -53,4 +53,20 @@ public interface ICallRecordCollectionRequest {
      */
     ICallRecordCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ICallRecordCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ICallRecordCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentCollectionRequest.java
@@ -55,4 +55,20 @@ public interface ISegmentCollectionRequest {
      */
     ISegmentCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ISegmentCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ISegmentCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionCollectionRequest.java
@@ -53,4 +53,20 @@ public interface ISessionCollectionRequest {
      */
     ISessionCollectionRequest top(final int value);
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    ISessionCollectionRequest skip(final int value);
+
+    /**
+	 * Sets the skip token value for the request
+	 * 
+	 * @param skipToken value for pagination
+     *
+	 * @return the updated request
+	 */
+	ISessionCollectionRequest skipToken(String skipToken);
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
@@ -108,6 +108,27 @@ public class SegmentCollectionRequest extends BaseCollectionRequest<SegmentColle
         return (SegmentCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ISegmentCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (SegmentCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ISegmentCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ISegmentCollectionRequest)this;
+    }
     public ISegmentCollectionPage buildFromResponse(final SegmentCollectionResponse response) {
         final ISegmentCollectionRequestBuilder builder;
         if (response.nextLink != null) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
@@ -106,6 +106,27 @@ public class SessionCollectionRequest extends BaseCollectionRequest<SessionColle
         return (SessionCollectionRequest)this;
     }
 
+    /**
+     * Sets the skip value for the request
+     *
+     * @param value of the number of items to skip
+     * @return the updated request
+     */
+    public ISessionCollectionRequest skip(final int value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$skip", value + ""));
+        return (SessionCollectionRequest)this;
+    }
+
+
+    /**
+     * Add Skip token for pagination
+     * @param skipToken - Token for pagination
+     * @return the updated request
+     */
+    public ISessionCollectionRequest skipToken(final String skipToken) {
+    	addQueryOption(new QueryOption("$skiptoken", skipToken));
+        return (ISessionCollectionRequest)this;
+    }
     public ISessionCollectionPage buildFromResponse(final SessionCollectionResponse response) {
         final ISessionCollectionRequestBuilder builder;
         if (response.nextLink != null) {


### PR DESCRIPTION
## Summary

entity collection requests in java were missing extension methods to allow consumers to provide the skip and skipToken arguments.

## Generated code differences

https://github.com/microsoftgraph/msgraph-sdk-java/pull/443

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses