### PR TITLE
- fixes a bug where url options would be inserted twice for collection POST requests

### DIFF
--- a/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
@@ -42,7 +42,7 @@ import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.TypeName()#>;
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         final ReferenceRequestBody body = new ReferenceRequestBody(getBaseRequest().getClient().getServiceRoot() + "/<#=prop#>/<#=implicitNavigationProperty#>" + new<#=c.TypeName()#>.id);
         new <#=c.TypeWithReferencesRequestBuilder()#>(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(new<#=c.TypeName()#>, body, callback);
     }
 
@@ -50,7 +50,7 @@ import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.TypeName()#>;
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         final ReferenceRequestBody body = new ReferenceRequestBody(getBaseRequest().getClient().getServiceRoot() + "/<#=prop#>/<#=implicitNavigationProperty#>" + new<#=c.TypeName()#>.id);
         return new <#=c.TypeWithReferencesRequestBuilder()#>(requestUrl,getBaseRequest().getClient(), /* Options */ null)
-                .buildRequest(getBaseRequest().getOptions())
+                .buildRequest(getBaseRequest().getHeaders())
                 .post(new<#=c.TypeName()#>, body);
     }
 <#     } 

--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
@@ -53,14 +53,14 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
     public void post(final <#=c.TypeName()#> new<#=c.TypeName()#>, final ICallback<<#=c.TypeName()#>> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new <#=c.TypeRequestBuilder()#>(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(new<#=c.TypeName()#>, callback);
     }
 
     public <#=c.TypeName()#> post(final <#=c.TypeName()#> new<#=c.TypeName()#>) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new <#=c.TypeRequestBuilder()#>(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(new<#=c.TypeName()#>);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
@@ -62,14 +62,14 @@ public class CallCollectionRequest extends BaseCollectionRequest<CallCollectionR
     public void post(final Call newCall, final ICallback<Call> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new CallRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newCall, callback);
     }
 
     public Call post(final Call newCall) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new CallRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newCall);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
@@ -62,14 +62,14 @@ public class EntityType2CollectionRequest extends BaseCollectionRequest<EntityTy
     public void post(final EntityType2 newEntityType2, final ICallback<EntityType2> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new EntityType2RequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newEntityType2, callback);
     }
 
     public EntityType2 post(final EntityType2 newEntityType2) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new EntityType2RequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newEntityType2);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
@@ -42,7 +42,7 @@ public class EntityType3CollectionReferenceRequest extends BaseCollectionRequest
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         final ReferenceRequestBody body = new ReferenceRequestBody(getBaseRequest().getClient().getServiceRoot() + "/testTypes/" + newEntityType3.id);
         new EntityType3WithReferenceRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newEntityType3, body, callback);
     }
 
@@ -50,7 +50,7 @@ public class EntityType3CollectionReferenceRequest extends BaseCollectionRequest
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         final ReferenceRequestBody body = new ReferenceRequestBody(getBaseRequest().getClient().getServiceRoot() + "/testTypes/" + newEntityType3.id);
         return new EntityType3WithReferenceRequestBuilder(requestUrl,getBaseRequest().getClient(), /* Options */ null)
-                .buildRequest(getBaseRequest().getOptions())
+                .buildRequest(getBaseRequest().getHeaders())
                 .post(newEntityType3, body);
     }
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
@@ -63,14 +63,14 @@ public class EntityType3CollectionRequest extends BaseCollectionRequest<EntityTy
     public void post(final EntityType3 newEntityType3, final ICallback<EntityType3> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new EntityType3RequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newEntityType3, callback);
     }
 
     public EntityType3 post(final EntityType3 newEntityType3) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new EntityType3RequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newEntityType3);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
@@ -62,14 +62,14 @@ public class TimeOffCollectionRequest extends BaseCollectionRequest<TimeOffColle
     public void post(final TimeOff newTimeOff, final ICallback<TimeOff> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new TimeOffRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newTimeOff, callback);
     }
 
     public TimeOff post(final TimeOff newTimeOff) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new TimeOffRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newTimeOff);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
@@ -63,14 +63,14 @@ public class TimeOffRequestCollectionRequest extends BaseCollectionRequest<TimeO
     public void post(final TimeOffRequest newTimeOffRequest, final ICallback<TimeOffRequest> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new TimeOffRequestRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newTimeOffRequest, callback);
     }
 
     public TimeOffRequest post(final TimeOffRequest newTimeOffRequest) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new TimeOffRequestRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newTimeOffRequest);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
@@ -62,14 +62,14 @@ public class CallRecordCollectionRequest extends BaseCollectionRequest<CallRecor
     public void post(final CallRecord newCallRecord, final ICallback<CallRecord> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new CallRecordRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newCallRecord, callback);
     }
 
     public CallRecord post(final CallRecord newCallRecord) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new CallRecordRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newCallRecord);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
@@ -64,14 +64,14 @@ public class SegmentCollectionRequest extends BaseCollectionRequest<SegmentColle
     public void post(final Segment newSegment, final ICallback<Segment> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new SegmentRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newSegment, callback);
     }
 
     public Segment post(final Segment newSegment) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new SegmentRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newSegment);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
@@ -62,14 +62,14 @@ public class SessionCollectionRequest extends BaseCollectionRequest<SessionColle
     public void post(final Session newSession, final ICallback<Session> callback) {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         new SessionRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newSession, callback);
     }
 
     public Session post(final Session newSession) throws ClientException {
         final String requestUrl = getBaseRequest().getRequestUrl().toString();
         return new SessionRequestBuilder(requestUrl, getBaseRequest().getClient(), /* Options */ null)
-            .buildRequest(getBaseRequest().getOptions())
+            .buildRequest(getBaseRequest().getHeaders())
             .post(newSession);
     }
 


### PR DESCRIPTION
## Summary

Because getRequestUrl already inserts the options (functions and query), providing the options again in build request was inserting those twice, causing the request to fail.

## Generated code differences

https://github.com/microsoftgraph/msgraph-sdk-java/pull/445

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses