### PR TITLE
- adds missing put methods for java sdk

### DIFF
--- a/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
@@ -50,6 +50,7 @@ import <#=importNamespace#>.http.HttpMethod;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else if (!c.AsOdcmClass().Derived.Any() && c.AsOdcmClass().Base != null)
     { #>
@@ -57,6 +58,7 @@ import <#=importNamespace#>.http.HttpMethod;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else if (c.AsOdcmClass().Base == null)
     { #>
@@ -64,6 +66,7 @@ import <#=importNamespace#>.http.HttpMethod;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else
     {
@@ -214,6 +217,34 @@ import <#=importNamespace#>.http.HttpMethod;
      */
     public {0} post(final {0} new{0}) throws ClientException {{
         return send(HttpMethod.POST, new{0});
+    }}
+";
+        return string.Format(formatString, odcmObject.TypeName());
+    }
+
+    public string putMethods(OdcmObject c)
+    {
+        var odcmObject = c.AsOdcmClass();
+        var formatString =
+@"    /**
+     * Creates a {0} with a new object
+     *
+     * @param new{0} the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final {0} new{0}, final ICallback<{0}> callback) {{
+        send(HttpMethod.PUT, callback, new{0});
+    }}
+
+    /**
+     * Creates a {0} with a new object
+     *
+     * @param new{0} the object to create/update
+     * @return the created {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public {0} put(final {0} new{0}) throws ClientException {{
+        return send(HttpMethod.PUT, new{0});
     }}
 ";
         return string.Format(formatString, odcmObject.TypeName());

--- a/Templates/Java/requests_extensions/IBaseEntityRequest.java.tt
+++ b/Templates/Java/requests_extensions/IBaseEntityRequest.java.tt
@@ -22,6 +22,7 @@ import <#=importNamespace#>.http.IHttpRequest;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else if (!c.AsOdcmClass().Derived.Any() && c.AsOdcmClass().Base != null)
     { #>
@@ -29,6 +30,7 @@ import <#=importNamespace#>.http.IHttpRequest;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else if (c.AsOdcmClass().Base == null)
     { #>
@@ -36,6 +38,7 @@ import <#=importNamespace#>.http.IHttpRequest;
 <#=deleteMethods(c)#>
 <#=patchMethods(c)#>
 <#=postMethods(c)#>
+<#=putMethods(c)#>
 <#  }
     else
     {
@@ -162,6 +165,30 @@ import <#=importNamespace#>.http.IHttpRequest;
      * @throws ClientException this exception occurs if the request was unable to complete for any reason
      */
     {0} post(final {0} new{0}) throws ClientException;
+";
+        return string.Format(formatString, odcmObject.TypeName());
+    }
+
+        public string putMethods(OdcmObject c)
+    {
+        var odcmObject = c.AsOdcmClass();
+        var formatString =
+@"    /**
+     * Posts a {0} with a new object
+     *
+     * @param new{0} the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final {0} new{0}, final ICallback<{0}> callback);
+
+    /**
+     * Posts a {0} with a new object
+     *
+     * @param new{0} the object to create/update
+     * @return the created {0}
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    {0} put(final {0} new{0}) throws ClientException;
 ";
         return string.Format(formatString, odcmObject.TypeName());
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallRequest.java
@@ -112,6 +112,27 @@ public class CallRequest extends BaseRequest implements ICallRequest {
     }
 
     /**
+     * Creates a Call with a new object
+     *
+     * @param newCall the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Call newCall, final ICallback<Call> callback) {
+        send(HttpMethod.PUT, callback, newCall);
+    }
+
+    /**
+     * Creates a Call with a new object
+     *
+     * @param newCall the object to create/update
+     * @return the created Call
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Call put(final Call newCall) throws ClientException {
+        return send(HttpMethod.PUT, newCall);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CloudCommunicationsRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CloudCommunicationsRequest.java
@@ -120,6 +120,27 @@ public class CloudCommunicationsRequest extends BaseRequest implements ICloudCom
     }
 
     /**
+     * Creates a CloudCommunications with a new object
+     *
+     * @param newCloudCommunications the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final CloudCommunications newCloudCommunications, final ICallback<CloudCommunications> callback) {
+        send(HttpMethod.PUT, callback, newCloudCommunications);
+    }
+
+    /**
+     * Creates a CloudCommunications with a new object
+     *
+     * @param newCloudCommunications the object to create/update
+     * @return the created CloudCommunications
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public CloudCommunications put(final CloudCommunications newCloudCommunications) throws ClientException {
+        return send(HttpMethod.PUT, newCloudCommunications);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EndpointRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EndpointRequest.java
@@ -112,6 +112,27 @@ public class EndpointRequest extends BaseRequest implements IEndpointRequest {
     }
 
     /**
+     * Creates a Endpoint with a new object
+     *
+     * @param newEndpoint the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Endpoint newEndpoint, final ICallback<Endpoint> callback) {
+        send(HttpMethod.PUT, callback, newEndpoint);
+    }
+
+    /**
+     * Creates a Endpoint with a new object
+     *
+     * @param newEndpoint the object to create/update
+     * @return the created Endpoint
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Endpoint put(final Endpoint newEndpoint) throws ClientException {
+        return send(HttpMethod.PUT, newEndpoint);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2Request.java
@@ -112,6 +112,27 @@ public class EntityType2Request extends BaseRequest implements IEntityType2Reque
     }
 
     /**
+     * Creates a EntityType2 with a new object
+     *
+     * @param newEntityType2 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final EntityType2 newEntityType2, final ICallback<EntityType2> callback) {
+        send(HttpMethod.PUT, callback, newEntityType2);
+    }
+
+    /**
+     * Creates a EntityType2 with a new object
+     *
+     * @param newEntityType2 the object to create/update
+     * @return the created EntityType2
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public EntityType2 put(final EntityType2 newEntityType2) throws ClientException {
+        return send(HttpMethod.PUT, newEntityType2);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
@@ -114,6 +114,27 @@ public class EntityType3Request extends BaseRequest implements IEntityType3Reque
     }
 
     /**
+     * Creates a EntityType3 with a new object
+     *
+     * @param newEntityType3 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final EntityType3 newEntityType3, final ICallback<EntityType3> callback) {
+        send(HttpMethod.PUT, callback, newEntityType3);
+    }
+
+    /**
+     * Creates a EntityType3 with a new object
+     *
+     * @param newEntityType3 the object to create/update
+     * @return the created EntityType3
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public EntityType3 put(final EntityType3 newEntityType3) throws ClientException {
+        return send(HttpMethod.PUT, newEntityType3);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallRequest.java
@@ -80,6 +80,23 @@ public interface ICallRequest extends IHttpRequest {
     Call post(final Call newCall) throws ClientException;
 
     /**
+     * Posts a Call with a new object
+     *
+     * @param newCall the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Call newCall, final ICallback<Call> callback);
+
+    /**
+     * Posts a Call with a new object
+     *
+     * @param newCall the object to create/update
+     * @return the created Call
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Call put(final Call newCall) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICloudCommunicationsRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICloudCommunicationsRequest.java
@@ -80,6 +80,23 @@ public interface ICloudCommunicationsRequest extends IHttpRequest {
     CloudCommunications post(final CloudCommunications newCloudCommunications) throws ClientException;
 
     /**
+     * Posts a CloudCommunications with a new object
+     *
+     * @param newCloudCommunications the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final CloudCommunications newCloudCommunications, final ICallback<CloudCommunications> callback);
+
+    /**
+     * Posts a CloudCommunications with a new object
+     *
+     * @param newCloudCommunications the object to create/update
+     * @return the created CloudCommunications
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    CloudCommunications put(final CloudCommunications newCloudCommunications) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEndpointRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEndpointRequest.java
@@ -80,6 +80,23 @@ public interface IEndpointRequest extends IHttpRequest {
     Endpoint post(final Endpoint newEndpoint) throws ClientException;
 
     /**
+     * Posts a Endpoint with a new object
+     *
+     * @param newEndpoint the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Endpoint newEndpoint, final ICallback<Endpoint> callback);
+
+    /**
+     * Posts a Endpoint with a new object
+     *
+     * @param newEndpoint the object to create/update
+     * @return the created Endpoint
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Endpoint put(final Endpoint newEndpoint) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2Request.java
@@ -80,6 +80,23 @@ public interface IEntityType2Request extends IHttpRequest {
     EntityType2 post(final EntityType2 newEntityType2) throws ClientException;
 
     /**
+     * Posts a EntityType2 with a new object
+     *
+     * @param newEntityType2 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final EntityType2 newEntityType2, final ICallback<EntityType2> callback);
+
+    /**
+     * Posts a EntityType2 with a new object
+     *
+     * @param newEntityType2 the object to create/update
+     * @return the created EntityType2
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    EntityType2 put(final EntityType2 newEntityType2) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3Request.java
@@ -80,6 +80,23 @@ public interface IEntityType3Request extends IHttpRequest {
     EntityType3 post(final EntityType3 newEntityType3) throws ClientException;
 
     /**
+     * Posts a EntityType3 with a new object
+     *
+     * @param newEntityType3 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final EntityType3 newEntityType3, final ICallback<EntityType3> callback);
+
+    /**
+     * Posts a EntityType3 with a new object
+     *
+     * @param newEntityType3 the object to create/update
+     * @return the created EntityType3
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    EntityType3 put(final EntityType3 newEntityType3) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IOnenotePageRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IOnenotePageRequest.java
@@ -80,6 +80,23 @@ public interface IOnenotePageRequest extends IHttpRequest {
     OnenotePage post(final byte[] newOnenotePage) throws ClientException;
 
     /**
+     * Posts a OnenotePage with a new object
+     *
+     * @param newOnenotePage the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final OnenotePage newOnenotePage, final ICallback<OnenotePage> callback);
+
+    /**
+     * Posts a OnenotePage with a new object
+     *
+     * @param newOnenotePage the object to create/update
+     * @return the created OnenotePage
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    OnenotePage put(final OnenotePage newOnenotePage) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IPlannerGroupRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IPlannerGroupRequest.java
@@ -80,6 +80,23 @@ public interface IPlannerGroupRequest extends IHttpRequest {
     PlannerGroup post(final PlannerGroup newPlannerGroup) throws ClientException;
 
     /**
+     * Posts a PlannerGroup with a new object
+     *
+     * @param newPlannerGroup the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final PlannerGroup newPlannerGroup, final ICallback<PlannerGroup> callback);
+
+    /**
+     * Posts a PlannerGroup with a new object
+     *
+     * @param newPlannerGroup the object to create/update
+     * @return the created PlannerGroup
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    PlannerGroup put(final PlannerGroup newPlannerGroup) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IScheduleRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IScheduleRequest.java
@@ -80,6 +80,23 @@ public interface IScheduleRequest extends IHttpRequest {
     Schedule post(final Schedule newSchedule) throws ClientException;
 
     /**
+     * Posts a Schedule with a new object
+     *
+     * @param newSchedule the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Schedule newSchedule, final ICallback<Schedule> callback);
+
+    /**
+     * Posts a Schedule with a new object
+     *
+     * @param newSchedule the object to create/update
+     * @return the created Schedule
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Schedule put(final Schedule newSchedule) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ISingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ISingletonEntity1Request.java
@@ -80,6 +80,23 @@ public interface ISingletonEntity1Request extends IHttpRequest {
     SingletonEntity1 post(final SingletonEntity1 newSingletonEntity1) throws ClientException;
 
     /**
+     * Posts a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final SingletonEntity1 newSingletonEntity1, final ICallback<SingletonEntity1> callback);
+
+    /**
+     * Posts a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @return the created SingletonEntity1
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    SingletonEntity1 put(final SingletonEntity1 newSingletonEntity1) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ISingletonEntity2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ISingletonEntity2Request.java
@@ -80,6 +80,23 @@ public interface ISingletonEntity2Request extends IHttpRequest {
     SingletonEntity2 post(final SingletonEntity2 newSingletonEntity2) throws ClientException;
 
     /**
+     * Posts a SingletonEntity2 with a new object
+     *
+     * @param newSingletonEntity2 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final SingletonEntity2 newSingletonEntity2, final ICallback<SingletonEntity2> callback);
+
+    /**
+     * Posts a SingletonEntity2 with a new object
+     *
+     * @param newSingletonEntity2 the object to create/update
+     * @return the created SingletonEntity2
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    SingletonEntity2 put(final SingletonEntity2 newSingletonEntity2) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITestEntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITestEntityRequest.java
@@ -80,6 +80,23 @@ public interface ITestEntityRequest extends IHttpRequest {
     TestEntity post(final TestEntity newTestEntity) throws ClientException;
 
     /**
+     * Posts a TestEntity with a new object
+     *
+     * @param newTestEntity the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final TestEntity newTestEntity, final ICallback<TestEntity> callback);
+
+    /**
+     * Posts a TestEntity with a new object
+     *
+     * @param newTestEntity the object to create/update
+     * @return the created TestEntity
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    TestEntity put(final TestEntity newTestEntity) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITestTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITestTypeRequest.java
@@ -80,6 +80,23 @@ public interface ITestTypeRequest extends IHttpRequest {
     TestType post(final TestType newTestType) throws ClientException;
 
     /**
+     * Posts a TestType with a new object
+     *
+     * @param newTestType the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final TestType newTestType, final ICallback<TestType> callback);
+
+    /**
+     * Posts a TestType with a new object
+     *
+     * @param newTestType the object to create/update
+     * @return the created TestType
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    TestType put(final TestType newTestType) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequest.java
@@ -80,6 +80,23 @@ public interface ITimeOffRequest extends IHttpRequest {
     TimeOff post(final TimeOff newTimeOff) throws ClientException;
 
     /**
+     * Posts a TimeOff with a new object
+     *
+     * @param newTimeOff the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final TimeOff newTimeOff, final ICallback<TimeOff> callback);
+
+    /**
+     * Posts a TimeOff with a new object
+     *
+     * @param newTimeOff the object to create/update
+     * @return the created TimeOff
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    TimeOff put(final TimeOff newTimeOff) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestRequest.java
@@ -80,6 +80,23 @@ public interface ITimeOffRequestRequest extends IHttpRequest {
     TimeOffRequest post(final TimeOffRequest newTimeOffRequest) throws ClientException;
 
     /**
+     * Posts a TimeOffRequest with a new object
+     *
+     * @param newTimeOffRequest the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final TimeOffRequest newTimeOffRequest, final ICallback<TimeOffRequest> callback);
+
+    /**
+     * Posts a TimeOffRequest with a new object
+     *
+     * @param newTimeOffRequest the object to create/update
+     * @return the created TimeOffRequest
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    TimeOffRequest put(final TimeOffRequest newTimeOffRequest) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageRequest.java
@@ -113,6 +113,27 @@ public class OnenotePageRequest extends BaseRequest implements IOnenotePageReque
     }
 
     /**
+     * Creates a OnenotePage with a new object
+     *
+     * @param newOnenotePage the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final OnenotePage newOnenotePage, final ICallback<OnenotePage> callback) {
+        send(HttpMethod.PUT, callback, newOnenotePage);
+    }
+
+    /**
+     * Creates a OnenotePage with a new object
+     *
+     * @param newOnenotePage the object to create/update
+     * @return the created OnenotePage
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public OnenotePage put(final OnenotePage newOnenotePage) throws ClientException {
+        return send(HttpMethod.PUT, newOnenotePage);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/PlannerGroupRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/PlannerGroupRequest.java
@@ -112,6 +112,27 @@ public class PlannerGroupRequest extends BaseRequest implements IPlannerGroupReq
     }
 
     /**
+     * Creates a PlannerGroup with a new object
+     *
+     * @param newPlannerGroup the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final PlannerGroup newPlannerGroup, final ICallback<PlannerGroup> callback) {
+        send(HttpMethod.PUT, callback, newPlannerGroup);
+    }
+
+    /**
+     * Creates a PlannerGroup with a new object
+     *
+     * @param newPlannerGroup the object to create/update
+     * @return the created PlannerGroup
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public PlannerGroup put(final PlannerGroup newPlannerGroup) throws ClientException {
+        return send(HttpMethod.PUT, newPlannerGroup);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ScheduleRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ScheduleRequest.java
@@ -120,6 +120,27 @@ public class ScheduleRequest extends BaseRequest implements IScheduleRequest {
     }
 
     /**
+     * Creates a Schedule with a new object
+     *
+     * @param newSchedule the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Schedule newSchedule, final ICallback<Schedule> callback) {
+        send(HttpMethod.PUT, callback, newSchedule);
+    }
+
+    /**
+     * Creates a Schedule with a new object
+     *
+     * @param newSchedule the object to create/update
+     * @return the created Schedule
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Schedule put(final Schedule newSchedule) throws ClientException {
+        return send(HttpMethod.PUT, newSchedule);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity1Request.java
@@ -114,6 +114,27 @@ public class SingletonEntity1Request extends BaseRequest implements ISingletonEn
     }
 
     /**
+     * Creates a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final SingletonEntity1 newSingletonEntity1, final ICallback<SingletonEntity1> callback) {
+        send(HttpMethod.PUT, callback, newSingletonEntity1);
+    }
+
+    /**
+     * Creates a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @return the created SingletonEntity1
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public SingletonEntity1 put(final SingletonEntity1 newSingletonEntity1) throws ClientException {
+        return send(HttpMethod.PUT, newSingletonEntity1);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity2Request.java
@@ -114,6 +114,27 @@ public class SingletonEntity2Request extends BaseRequest implements ISingletonEn
     }
 
     /**
+     * Creates a SingletonEntity2 with a new object
+     *
+     * @param newSingletonEntity2 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final SingletonEntity2 newSingletonEntity2, final ICallback<SingletonEntity2> callback) {
+        send(HttpMethod.PUT, callback, newSingletonEntity2);
+    }
+
+    /**
+     * Creates a SingletonEntity2 with a new object
+     *
+     * @param newSingletonEntity2 the object to create/update
+     * @return the created SingletonEntity2
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public SingletonEntity2 put(final SingletonEntity2 newSingletonEntity2) throws ClientException {
+        return send(HttpMethod.PUT, newSingletonEntity2);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestEntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestEntityRequest.java
@@ -118,6 +118,27 @@ public class TestEntityRequest extends BaseRequest implements ITestEntityRequest
     }
 
     /**
+     * Creates a TestEntity with a new object
+     *
+     * @param newTestEntity the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final TestEntity newTestEntity, final ICallback<TestEntity> callback) {
+        send(HttpMethod.PUT, callback, newTestEntity);
+    }
+
+    /**
+     * Creates a TestEntity with a new object
+     *
+     * @param newTestEntity the object to create/update
+     * @return the created TestEntity
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public TestEntity put(final TestEntity newTestEntity) throws ClientException {
+        return send(HttpMethod.PUT, newTestEntity);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequest.java
@@ -114,6 +114,27 @@ public class TestTypeRequest extends BaseRequest implements ITestTypeRequest {
     }
 
     /**
+     * Creates a TestType with a new object
+     *
+     * @param newTestType the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final TestType newTestType, final ICallback<TestType> callback) {
+        send(HttpMethod.PUT, callback, newTestType);
+    }
+
+    /**
+     * Creates a TestType with a new object
+     *
+     * @param newTestType the object to create/update
+     * @return the created TestType
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public TestType put(final TestType newTestType) throws ClientException {
+        return send(HttpMethod.PUT, newTestType);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequest.java
@@ -112,6 +112,27 @@ public class TimeOffRequest extends BaseRequest implements ITimeOffRequest {
     }
 
     /**
+     * Creates a TimeOff with a new object
+     *
+     * @param newTimeOff the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final TimeOff newTimeOff, final ICallback<TimeOff> callback) {
+        send(HttpMethod.PUT, callback, newTimeOff);
+    }
+
+    /**
+     * Creates a TimeOff with a new object
+     *
+     * @param newTimeOff the object to create/update
+     * @return the created TimeOff
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public TimeOff put(final TimeOff newTimeOff) throws ClientException {
+        return send(HttpMethod.PUT, newTimeOff);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestRequest.java
@@ -112,6 +112,27 @@ public class TimeOffRequestRequest extends BaseRequest implements ITimeOffReques
     }
 
     /**
+     * Creates a TimeOffRequest with a new object
+     *
+     * @param newTimeOffRequest the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final TimeOffRequest newTimeOffRequest, final ICallback<TimeOffRequest> callback) {
+        send(HttpMethod.PUT, callback, newTimeOffRequest);
+    }
+
+    /**
+     * Creates a TimeOffRequest with a new object
+     *
+     * @param newTimeOffRequest the object to create/update
+     * @return the created TimeOffRequest
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public TimeOffRequest put(final TimeOffRequest newTimeOffRequest) throws ClientException {
+        return send(HttpMethod.PUT, newTimeOffRequest);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordRequest.java
@@ -120,6 +120,27 @@ public class CallRecordRequest extends BaseRequest implements ICallRecordRequest
     }
 
     /**
+     * Creates a CallRecord with a new object
+     *
+     * @param newCallRecord the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final CallRecord newCallRecord, final ICallback<CallRecord> callback) {
+        send(HttpMethod.PUT, callback, newCallRecord);
+    }
+
+    /**
+     * Creates a CallRecord with a new object
+     *
+     * @param newCallRecord the object to create/update
+     * @return the created CallRecord
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public CallRecord put(final CallRecord newCallRecord) throws ClientException {
+        return send(HttpMethod.PUT, newCallRecord);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordRequest.java
@@ -80,6 +80,23 @@ public interface ICallRecordRequest extends IHttpRequest {
     CallRecord post(final CallRecord newCallRecord) throws ClientException;
 
     /**
+     * Posts a CallRecord with a new object
+     *
+     * @param newCallRecord the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final CallRecord newCallRecord, final ICallback<CallRecord> callback);
+
+    /**
+     * Posts a CallRecord with a new object
+     *
+     * @param newCallRecord the object to create/update
+     * @return the created CallRecord
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    CallRecord put(final CallRecord newCallRecord) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/IOptionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/IOptionRequest.java
@@ -80,6 +80,23 @@ public interface IOptionRequest extends IHttpRequest {
     Option post(final Option newOption) throws ClientException;
 
     /**
+     * Posts a Option with a new object
+     *
+     * @param newOption the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Option newOption, final ICallback<Option> callback);
+
+    /**
+     * Posts a Option with a new object
+     *
+     * @param newOption the object to create/update
+     * @return the created Option
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Option put(final Option newOption) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/IPhotoRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/IPhotoRequest.java
@@ -80,6 +80,23 @@ public interface IPhotoRequest extends IHttpRequest {
     Photo post(final Photo newPhoto) throws ClientException;
 
     /**
+     * Posts a Photo with a new object
+     *
+     * @param newPhoto the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Photo newPhoto, final ICallback<Photo> callback);
+
+    /**
+     * Posts a Photo with a new object
+     *
+     * @param newPhoto the object to create/update
+     * @return the created Photo
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Photo put(final Photo newPhoto) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentRequest.java
@@ -80,6 +80,23 @@ public interface ISegmentRequest extends IHttpRequest {
     Segment post(final Segment newSegment) throws ClientException;
 
     /**
+     * Posts a Segment with a new object
+     *
+     * @param newSegment the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Segment newSegment, final ICallback<Segment> callback);
+
+    /**
+     * Posts a Segment with a new object
+     *
+     * @param newSegment the object to create/update
+     * @return the created Segment
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Segment put(final Segment newSegment) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionRequest.java
@@ -80,6 +80,23 @@ public interface ISessionRequest extends IHttpRequest {
     Session post(final Session newSession) throws ClientException;
 
     /**
+     * Posts a Session with a new object
+     *
+     * @param newSession the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final Session newSession, final ICallback<Session> callback);
+
+    /**
+     * Posts a Session with a new object
+     *
+     * @param newSession the object to create/update
+     * @return the created Session
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    Session put(final Session newSession) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISingletonEntity1Request.java
@@ -80,6 +80,23 @@ public interface ISingletonEntity1Request extends IHttpRequest {
     SingletonEntity1 post(final SingletonEntity1 newSingletonEntity1) throws ClientException;
 
     /**
+     * Posts a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    void put(final SingletonEntity1 newSingletonEntity1, final ICallback<SingletonEntity1> callback);
+
+    /**
+     * Posts a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @return the created SingletonEntity1
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    SingletonEntity1 put(final SingletonEntity1 newSingletonEntity1) throws ClientException;
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/OptionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/OptionRequest.java
@@ -112,6 +112,27 @@ public class OptionRequest extends BaseRequest implements IOptionRequest {
     }
 
     /**
+     * Creates a Option with a new object
+     *
+     * @param newOption the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Option newOption, final ICallback<Option> callback) {
+        send(HttpMethod.PUT, callback, newOption);
+    }
+
+    /**
+     * Creates a Option with a new object
+     *
+     * @param newOption the object to create/update
+     * @return the created Option
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Option put(final Option newOption) throws ClientException {
+        return send(HttpMethod.PUT, newOption);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/PhotoRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/PhotoRequest.java
@@ -112,6 +112,27 @@ public class PhotoRequest extends BaseRequest implements IPhotoRequest {
     }
 
     /**
+     * Creates a Photo with a new object
+     *
+     * @param newPhoto the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Photo newPhoto, final ICallback<Photo> callback) {
+        send(HttpMethod.PUT, callback, newPhoto);
+    }
+
+    /**
+     * Creates a Photo with a new object
+     *
+     * @param newPhoto the object to create/update
+     * @return the created Photo
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Photo put(final Photo newPhoto) throws ClientException {
+        return send(HttpMethod.PUT, newPhoto);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentRequest.java
@@ -125,6 +125,27 @@ public class SegmentRequest extends BaseRequest implements ISegmentRequest {
     }
 
     /**
+     * Creates a Segment with a new object
+     *
+     * @param newSegment the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Segment newSegment, final ICallback<Segment> callback) {
+        send(HttpMethod.PUT, callback, newSegment);
+    }
+
+    /**
+     * Creates a Segment with a new object
+     *
+     * @param newSegment the object to create/update
+     * @return the created Segment
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Segment put(final Segment newSegment) throws ClientException {
+        return send(HttpMethod.PUT, newSegment);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionRequest.java
@@ -116,6 +116,27 @@ public class SessionRequest extends BaseRequest implements ISessionRequest {
     }
 
     /**
+     * Creates a Session with a new object
+     *
+     * @param newSession the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final Session newSession, final ICallback<Session> callback) {
+        send(HttpMethod.PUT, callback, newSession);
+    }
+
+    /**
+     * Creates a Session with a new object
+     *
+     * @param newSession the object to create/update
+     * @return the created Session
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public Session put(final Session newSession) throws ClientException {
+        return send(HttpMethod.PUT, newSession);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SingletonEntity1Request.java
@@ -114,6 +114,27 @@ public class SingletonEntity1Request extends BaseRequest implements ISingletonEn
     }
 
     /**
+     * Creates a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @param callback the callback to be called after success or failure
+     */
+    public void put(final SingletonEntity1 newSingletonEntity1, final ICallback<SingletonEntity1> callback) {
+        send(HttpMethod.PUT, callback, newSingletonEntity1);
+    }
+
+    /**
+     * Creates a SingletonEntity1 with a new object
+     *
+     * @param newSingletonEntity1 the object to create/update
+     * @return the created SingletonEntity1
+     * @throws ClientException this exception occurs if the request was unable to complete for any reason
+     */
+    public SingletonEntity1 put(final SingletonEntity1 newSingletonEntity1) throws ClientException {
+        return send(HttpMethod.PUT, newSingletonEntity1);
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause


### PR DESCRIPTION
## Summary

the java SDK was missing put methods for entity requests. This PR fixes it.

## Generated code differences

https://github.com/microsoftgraph/msgraph-sdk-java/pull/446

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses