### PR TITLE
Supports missing request body parameter

### DIFF
--- a/Templates/CSharp/Model/MethodRequestBody.cs.tt
+++ b/Templates/CSharp/Model/MethodRequestBody.cs.tt
@@ -31,13 +31,6 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     public partial class <#=requestBody#>
     {
     <#
-
-    //HashSet<OdcmParameter> uniqueParameters = new HashSet<OdcmParameter>();
-
-    //var methods = method.WithDistinctOverloads();
-//
-    //var distinctParameters = method.WithDistinctParameters();
-
     foreach (var param in method.WithDistinctParameters())
     {
         var paramTypeString = param.Type.GetTypeString(method.Namespace.GetNamespaceName());

--- a/Templates/CSharp/Model/MethodRequestBody.cs.tt
+++ b/Templates/CSharp/Model/MethodRequestBody.cs.tt
@@ -31,7 +31,14 @@ namespace <#=method.Namespace.GetNamespaceName()#>
     public partial class <#=requestBody#>
     {
     <#
-    foreach (var param in method.Parameters)
+
+    //HashSet<OdcmParameter> uniqueParameters = new HashSet<OdcmParameter>();
+
+    //var methods = method.WithDistinctOverloads();
+//
+    //var distinctParameters = method.WithDistinctParameters();
+
+    foreach (var param in method.WithDistinctParameters())
     {
         var paramTypeString = param.Type.GetTypeString(method.Namespace.GetNamespaceName());
         

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -500,11 +500,30 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             return methods.Distinct(methodComparer).ToList();
         }
 
+        private static readonly OdcmParameterEqualityComparer paramComparer = new OdcmParameterEqualityComparer();
+        /// <summary>
+        /// Deduplicates the parameter list for an overloaded method. 
+        /// </summary>
+        /// <param name="odcmMethod">Method with potential overloads and duplicate parameters across overloads.</param>
+        /// <returns>A deduplicated list of OdcmParameter.</returns>
+        public static List<OdcmParameter> WithDistinctParameters(this OdcmMethod odcmMethod)
+        {
+            var distinctMethods = odcmMethod.WithDistinctOverloads();
+
+            var parameters = new List<OdcmParameter>();
+
+            foreach (var method in distinctMethods)
+            {
+                parameters.AddRange(method.Parameters);
+            }
+
+            return parameters.Distinct(paramComparer).ToList();
+        }
+
         /// Returns a List containing the supplied class' methods plus their overloads
         public static IEnumerable<OdcmMethod> MethodsAndOverloads(this OdcmClass odcmClass)
         {
             return odcmClass.Methods.SelectMany(x => x.WithOverloads());
         }
     }
-
 }


### PR DESCRIPTION
CSDL reordering triggered this regression. Discovered that reordered overloaded action, evaluateDynamicMembership was missing a property. We were only capturing parameters for the first overload. We need to capture all of the parameters which this commit fixes.

![image](https://user-images.githubusercontent.com/8527305/92298953-15ecc400-ef03-11ea-898f-d37a9b836c1e.png)
