### PR TITLE
- adds missing fluent method for odata filter

### DIFF
--- a/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
@@ -68,6 +68,19 @@ import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.TypeName()#>;
     }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeCollectionReferenceRequest()#> filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeCollectionReferenceRequest()#>)this;
+    }
+
+<# } #>
 <# if (c.GetFeatures().CanSelect) { #>
     /**
      * Sets the select clause for the request

--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
@@ -77,6 +77,19 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
     }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeCollectionRequest()#> filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeCollectionRequest()#>)this;
+    }
+
+<# } #>
 <# if (c.GetFeatures().CanSelect) { #>
     /**
      * Sets the select clause for the request

--- a/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequest.java.tt
@@ -51,6 +51,13 @@ import <#=importNamespace#>.concurrency.IExecutors;
     }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    public <#=c.ITypeCollectionRequest()#> filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeCollectionRequest()#>)this;
+    }
+
+<# } #>
 <# if (c.GetFeatures().CanSelect) { #>
     public <#=c.ITypeCollectionRequest()#> select(final String value) {
         addQueryOption(new com.microsoft.graph.options.QueryOption("$select", value));

--- a/Templates/Java/requests_extensions/BaseEntityReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityReferenceRequest.java.tt
@@ -58,6 +58,18 @@ import <#=importNamespace#>.core.IBaseClient;
         return (<#=c.TypeReferenceRequest()#>)this;
     }
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeReferenceRequest()#> filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeReferenceRequest()#>)this;
+    }
+<# } #>
 <# if (c.GetFeatures().CanUpdate) { #>
     /**
      * Puts the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
@@ -99,6 +99,19 @@ import <#=importNamespace#>.http.HttpMethod;
      }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public <#=c.ITypeRequest()#> filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (<#=c.TypeRequest()#>)this;
+     }
+
+<# } #>
 <# if (c.AsOdcmProperty() != null && c.AsOdcmProperty().IsCollection && c.GetFeatures().CanUseTop) { #>
 
     /**

--- a/Templates/Java/requests_extensions/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityWithReferenceRequest.java.tt
@@ -88,4 +88,16 @@ import <#=importNamespace#>.serializer.IJsonBackedObject;
         return (<#=c.TypeWithReferencesRequest()#>)this;
     }
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeWithReferencesRequest()#> filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeWithReferencesRequest()#>)this;
+    }
+<# } #>
 }

--- a/Templates/Java/requests_extensions/BaseMethodBodyRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodBodyRequest.java.tt
@@ -106,4 +106,17 @@ import <#=importNamespace#>.http.HttpMethod;
     }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=iTypeRequest#> filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=typeRequest#>)this;
+    }
+
+<# } #>
 }

--- a/Templates/Java/requests_extensions/BaseMethodCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionRequest.java.tt
@@ -144,4 +144,17 @@ import <#=importNamespace#>.concurrency.IExecutors;
     }
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeCollectionRequest()#> filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.ITypeCollectionRequest()#>)this;
+    }
+
+<# } #>
 }

--- a/Templates/Java/requests_extensions/BaseMethodRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodRequest.java.tt
@@ -82,6 +82,22 @@ if (c.AsOdcmMethod().IsAction()) {
 <#
         }
 
+                if (c.GetFeatures().CanFilter) {
+#>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeRequest()#> filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeRequest()#>)this;
+    }
+
+<#
+        }
+
         if (c.AsOdcmProperty() != null && c.AsOdcmProperty().IsCollection && c.GetFeatures().CanUseTop) {
 #>
 
@@ -227,7 +243,21 @@ if (c.AsOdcmMethod().IsAction()) {
 
 <#
         }
+        if (c.GetFeatures().CanFilter) {
+#>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public <#=c.ITypeRequest()#> filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (<#=c.TypeRequest()#>)this;
+    }
 
+<#
+        }
         if (c.AsOdcmProperty() != null && c.AsOdcmProperty().IsCollection && c.GetFeatures().CanUseTop) {
 #>
 

--- a/Templates/Java/requests_extensions/IBaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/IBaseEntityCollectionRequest.java.tt
@@ -29,6 +29,16 @@ import <#=importNamespace#>.http.IBaseCollectionPage;
     <#=c.ITypeCollectionRequest()#> expand(final String value);
 
 <# } #>
+<# if (c.GetFeatures().CanFilter) { #>
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    <#=c.ITypeCollectionRequest()#> filter(final String value);
+
+<# } #>
 <# if (c.GetFeatures().CanSelect) { #>
     /**
      * Sets the select clause for the request

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallCollectionRequest.java
@@ -85,6 +85,17 @@ public class CallCollectionRequest extends BaseCollectionRequest<CallCollectionR
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ICallCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (CallCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallReferenceRequest.java
@@ -64,6 +64,16 @@ public class CallReferenceRequest extends BaseRequest implements ICallReferenceR
         return (CallReferenceRequest)this;
     }
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ICallReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (CallReferenceRequest)this;
+    }
+    /**
      * Puts the Call
      *
      * @param srcCall the Call reference to PUT

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallRequest.java
@@ -154,5 +154,16 @@ public class CallRequest extends BaseRequest implements ICallRequest {
          return (CallRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ICallRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (CallRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CallWithReferenceRequest.java
@@ -93,4 +93,14 @@ public class CallWithReferenceRequest extends BaseRequest implements ICallWithRe
         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$expand", value));
         return (CallWithReferenceRequest)this;
     }
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ICallWithReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (CallWithReferenceRequest)this;
+    }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CloudCommunicationsRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/CloudCommunicationsRequest.java
@@ -162,5 +162,16 @@ public class CloudCommunicationsRequest extends BaseRequest implements ICloudCom
          return (CloudCommunicationsRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ICloudCommunicationsRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (CloudCommunicationsRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EndpointRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EndpointRequest.java
@@ -154,5 +154,16 @@ public class EndpointRequest extends BaseRequest implements IEndpointRequest {
          return (EndpointRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IEndpointRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (EndpointRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityRequest.java
@@ -69,5 +69,16 @@ public class EntityRequest extends BaseRequest implements IEntityRequest {
          return (EntityRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IEntityRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (EntityRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2CollectionRequest.java
@@ -85,6 +85,17 @@ public class EntityType2CollectionRequest extends BaseCollectionRequest<EntityTy
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType2CollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType2CollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2ReferenceRequest.java
@@ -64,6 +64,16 @@ public class EntityType2ReferenceRequest extends BaseRequest implements IEntityT
         return (EntityType2ReferenceRequest)this;
     }
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType2ReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType2ReferenceRequest)this;
+    }
+    /**
      * Puts the EntityType2
      *
      * @param srcEntityType2 the EntityType2 reference to PUT

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2Request.java
@@ -154,5 +154,16 @@ public class EntityType2Request extends BaseRequest implements IEntityType2Reque
          return (EntityType2Request)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IEntityType2Request filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (EntityType2Request)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType2WithReferenceRequest.java
@@ -93,4 +93,14 @@ public class EntityType2WithReferenceRequest extends BaseRequest implements IEnt
         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$expand", value));
         return (EntityType2WithReferenceRequest)this;
     }
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType2WithReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType2WithReferenceRequest)this;
+    }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
@@ -65,6 +65,17 @@ public class EntityType3CollectionReferenceRequest extends BaseCollectionRequest
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType3CollectionReferenceRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3CollectionReferenceRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
@@ -86,6 +86,17 @@ public class EntityType3CollectionRequest extends BaseCollectionRequest<EntityTy
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType3CollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3CollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
@@ -61,6 +61,11 @@ public class EntityType3CollectionWithReferencesRequest extends BaseCollectionRe
         return (EntityType3CollectionWithReferencesRequest)this;
     }
 
+    public IEntityType3CollectionWithReferencesRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3CollectionWithReferencesRequest)this;
+    }
+
     public IEntityType3CollectionWithReferencesRequest select(final String value) {
         addQueryOption(new com.microsoft.graph.options.QueryOption("$select", value));
         return (EntityType3CollectionWithReferencesRequest)this;

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
@@ -77,4 +77,15 @@ public class EntityType3ForwardRequest extends BaseRequest implements IEntityTyp
         return (EntityType3ForwardRequest)this;
     }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType3ForwardRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3ForwardRequest)this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
@@ -66,6 +66,16 @@ public class EntityType3ReferenceRequest extends BaseRequest implements IEntityT
         return (EntityType3ReferenceRequest)this;
     }
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType3ReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3ReferenceRequest)this;
+    }
+    /**
      * Puts the EntityType3
      *
      * @param srcEntityType3 the EntityType3 reference to PUT

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
@@ -156,5 +156,16 @@ public class EntityType3Request extends BaseRequest implements IEntityType3Reque
          return (EntityType3Request)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IEntityType3Request filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (EntityType3Request)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
@@ -95,4 +95,14 @@ public class EntityType3WithReferenceRequest extends BaseRequest implements IEnt
         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$expand", value));
         return (EntityType3WithReferenceRequest)this;
     }
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IEntityType3WithReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (EntityType3WithReferenceRequest)this;
+    }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ICallCollectionRequest.java
@@ -38,6 +38,14 @@ public interface ICallCollectionRequest {
     ICallCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ICallCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType2CollectionRequest.java
@@ -38,6 +38,14 @@ public interface IEntityType2CollectionRequest {
     IEntityType2CollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    IEntityType2CollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/IEntityType3CollectionRequest.java
@@ -39,6 +39,14 @@ public interface IEntityType3CollectionRequest {
     IEntityType3CollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    IEntityType3CollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffCollectionRequest.java
@@ -38,6 +38,14 @@ public interface ITimeOffCollectionRequest {
     ITimeOffCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ITimeOffCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ITimeOffRequestCollectionRequest.java
@@ -39,6 +39,14 @@ public interface ITimeOffRequestCollectionRequest {
     ITimeOffRequestCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ITimeOffRequestCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageForwardRequest.java
@@ -77,4 +77,15 @@ public class OnenotePageForwardRequest extends BaseRequest implements IOnenotePa
         return (OnenotePageForwardRequest)this;
     }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public IOnenotePageForwardRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (OnenotePageForwardRequest)this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/OnenotePageRequest.java
@@ -155,5 +155,16 @@ public class OnenotePageRequest extends BaseRequest implements IOnenotePageReque
          return (OnenotePageRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IOnenotePageRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (OnenotePageRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/PlannerGroupRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/PlannerGroupRequest.java
@@ -154,5 +154,16 @@ public class PlannerGroupRequest extends BaseRequest implements IPlannerGroupReq
          return (PlannerGroupRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IPlannerGroupRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (PlannerGroupRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ScheduleRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/ScheduleRequest.java
@@ -162,5 +162,16 @@ public class ScheduleRequest extends BaseRequest implements IScheduleRequest {
          return (ScheduleRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IScheduleRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (ScheduleRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity1Request.java
@@ -156,5 +156,16 @@ public class SingletonEntity1Request extends BaseRequest implements ISingletonEn
          return (SingletonEntity1Request)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ISingletonEntity1Request filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (SingletonEntity1Request)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/SingletonEntity2Request.java
@@ -156,5 +156,16 @@ public class SingletonEntity2Request extends BaseRequest implements ISingletonEn
          return (SingletonEntity2Request)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ISingletonEntity2Request filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (SingletonEntity2Request)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestEntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestEntityRequest.java
@@ -160,5 +160,16 @@ public class TestEntityRequest extends BaseRequest implements ITestEntityRequest
          return (TestEntityRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ITestEntityRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (TestEntityRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
@@ -110,4 +110,15 @@ public class TestTypeQueryCollectionRequest extends BaseCollectionRequest<TestTy
         return (ITestTypeQueryCollectionRequest)this;
     }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ITestTypeQueryCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (ITestTypeQueryCollectionRequest)this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeReferenceRequest.java
@@ -66,6 +66,16 @@ public class TestTypeReferenceRequest extends BaseRequest implements ITestTypeRe
         return (TestTypeReferenceRequest)this;
     }
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ITestTypeReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (TestTypeReferenceRequest)this;
+    }
+    /**
      * Puts the TestType
      *
      * @param srcTestType the TestType reference to PUT

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequest.java
@@ -156,5 +156,16 @@ public class TestTypeRequest extends BaseRequest implements ITestTypeRequest {
          return (TestTypeRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ITestTypeRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (TestTypeRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeWithReferenceRequest.java
@@ -95,4 +95,14 @@ public class TestTypeWithReferenceRequest extends BaseRequest implements ITestTy
         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$expand", value));
         return (TestTypeWithReferenceRequest)this;
     }
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ITestTypeWithReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (TestTypeWithReferenceRequest)this;
+    }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffCollectionRequest.java
@@ -85,6 +85,17 @@ public class TimeOffCollectionRequest extends BaseCollectionRequest<TimeOffColle
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ITimeOffCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (TimeOffCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequest.java
@@ -154,5 +154,16 @@ public class TimeOffRequest extends BaseRequest implements ITimeOffRequest {
          return (TimeOffRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ITimeOffRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (TimeOffRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestCollectionRequest.java
@@ -86,6 +86,17 @@ public class TimeOffRequestCollectionRequest extends BaseCollectionRequest<TimeO
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ITimeOffRequestCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (TimeOffRequestCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TimeOffRequestRequest.java
@@ -154,5 +154,16 @@ public class TimeOffRequestRequest extends BaseRequest implements ITimeOffReques
          return (TimeOffRequestRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ITimeOffRequestRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (TimeOffRequestRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordCollectionRequest.java
@@ -85,6 +85,17 @@ public class CallRecordCollectionRequest extends BaseCollectionRequest<CallRecor
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ICallRecordCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (CallRecordCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/CallRecordRequest.java
@@ -162,5 +162,16 @@ public class CallRecordRequest extends BaseRequest implements ICallRecordRequest
          return (CallRecordRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ICallRecordRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (CallRecordRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ICallRecordCollectionRequest.java
@@ -38,6 +38,14 @@ public interface ICallRecordCollectionRequest {
     ICallRecordCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ICallRecordCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISegmentCollectionRequest.java
@@ -40,6 +40,14 @@ public interface ISegmentCollectionRequest {
     ISegmentCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ISegmentCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/ISessionCollectionRequest.java
@@ -38,6 +38,14 @@ public interface ISessionCollectionRequest {
     ISessionCollectionRequest expand(final String value);
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    ISessionCollectionRequest filter(final String value);
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/OptionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/OptionRequest.java
@@ -154,5 +154,16 @@ public class OptionRequest extends BaseRequest implements IOptionRequest {
          return (OptionRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IOptionRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (OptionRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/PhotoRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/PhotoRequest.java
@@ -154,5 +154,16 @@ public class PhotoRequest extends BaseRequest implements IPhotoRequest {
          return (PhotoRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public IPhotoRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (PhotoRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentCollectionRequest.java
@@ -87,6 +87,17 @@ public class SegmentCollectionRequest extends BaseCollectionRequest<SegmentColle
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISegmentCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (SegmentCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentForwardRequest.java
@@ -77,4 +77,15 @@ public class SegmentForwardRequest extends BaseRequest implements ISegmentForwar
         return (SegmentForwardRequest)this;
     }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISegmentForwardRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (SegmentForwardRequest)this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentRequest.java
@@ -167,5 +167,16 @@ public class SegmentRequest extends BaseRequest implements ISegmentRequest {
          return (SegmentRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ISegmentRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (SegmentRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentTestActionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SegmentTestActionCollectionRequest.java
@@ -110,4 +110,15 @@ public class SegmentTestActionCollectionRequest extends BaseCollectionRequest<Se
         return (ISegmentTestActionCollectionRequest)this;
     }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISegmentTestActionCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (ISegmentTestActionCollectionRequest)this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionCollectionRequest.java
@@ -85,6 +85,17 @@ public class SessionCollectionRequest extends BaseCollectionRequest<SessionColle
     }
 
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISessionCollectionRequest filter(final String value) {
+        addQueryOption(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (SessionCollectionRequest)this;
+    }
+
+    /**
      * Sets the select clause for the request
      *
      * @param value the select clause

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionReferenceRequest.java
@@ -68,6 +68,16 @@ public class SessionReferenceRequest extends BaseRequest implements ISessionRefe
         return (SessionReferenceRequest)this;
     }
     /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISessionReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (SessionReferenceRequest)this;
+    }
+    /**
      * Puts the Session
      *
      * @param srcSession the Session reference to PUT

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionRequest.java
@@ -158,5 +158,16 @@ public class SessionRequest extends BaseRequest implements ISessionRequest {
          return (SessionRequest)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ISessionRequest filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (SessionRequest)this;
+     }
+
 }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SessionWithReferenceRequest.java
@@ -97,4 +97,14 @@ public class SessionWithReferenceRequest extends BaseRequest implements ISession
         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$expand", value));
         return (SessionWithReferenceRequest)this;
     }
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+    public ISessionWithReferenceRequest filter(final String value) {
+        getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+        return (SessionWithReferenceRequest)this;
+    }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/extensions/SingletonEntity1Request.java
@@ -156,5 +156,16 @@ public class SingletonEntity1Request extends BaseRequest implements ISingletonEn
          return (SingletonEntity1Request)this;
      }
 
+    /**
+     * Sets the filter clause for the request
+     *
+     * @param value the filter clause
+     * @return the updated request
+     */
+     public ISingletonEntity1Request filter(final String value) {
+         getQueryOptions().add(new com.microsoft.graph.options.QueryOption("$filter", value));
+         return (SingletonEntity1Request)this;
+     }
+
 }
 


### PR DESCRIPTION
## Summary

java collection were missing filter to add the query string parameter in a fluent way. This aims to fix it.

## Generated code differences

https://github.com/microsoftgraph/msgraph-sdk-java/pull/461

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses