### PR TITLE
Nikithauc/typescript beta mainnamespace

### DIFF
--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -18,7 +18,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export as namespace microsoftgraph;
+export as namespace <#=typeScriptNamespaces.MainNamespace.GetMainNameSpace()#>;
 
 export type NullableOption<T> = T | null;
 

--- a/Templates/TypeScript/src/entity_types.ts.tt
+++ b/Templates/TypeScript/src/entity_types.ts.tt
@@ -18,7 +18,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export as namespace <#=typeScriptNamespaces.MainNamespace.GetMainNameSpace()#>;
+export as namespace <#=typeScriptNamespaces.MainNamespace.GetMainNamespace()#>;
 
 export type NullableOption<T> = T | null;
 

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         /// Returns the main or top level namespace
         /// </summary>
         /// <returns></returns>
-        public string GetMainNameSpace() {
+        public string GetMainNameSpace()
+        {
             return TypeScriptMainNamespaceName;
         }
 

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp;
+using Microsoft.Graph.ODataTemplateWriter.Settings;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,8 +36,16 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         // constants
         private const int MaxLineLength = 120;
         private const string MainNamespaceName = "Microsoft.Graph";
-        private const string TypeScriptMainNamespaceName = "microsoftgraph";
+        private string TypeScriptMainNamespaceName = "microsoftgraph" + (ConfigurationService.Settings.Properties != null && ConfigurationService.Settings.Properties.ContainsKey("typescript.namespacePostfix") ? ConfigurationService.Settings.Properties["typescript.namespacePostfix"] : string.Empty);
         private const string TabSpace = "    ";
+
+        /// <summary>
+        /// Returns the main or top level namespace
+        /// </summary>
+        /// <returns></returns>
+        public string GetMainNameSpace() {
+            return TypeScriptMainNamespaceName;
+        }
 
         /// <summary>
         /// Groups entity, complex and enum types to be printed

--- a/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/TypeScript/TypeScriptNamespace.cs
@@ -36,16 +36,16 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
         // constants
         private const int MaxLineLength = 120;
         private const string MainNamespaceName = "Microsoft.Graph";
-        private string TypeScriptMainNamespaceName = "microsoftgraph" + (ConfigurationService.Settings.Properties != null && ConfigurationService.Settings.Properties.ContainsKey("typescript.namespacePostfix") ? ConfigurationService.Settings.Properties["typescript.namespacePostfix"] : string.Empty);
+        private const string TypeScriptMainNamespaceNamePrefix = "microsoftgraph";
         private const string TabSpace = "    ";
 
         /// <summary>
         /// Returns the main or top level namespace
         /// </summary>
         /// <returns></returns>
-        public string GetMainNameSpace()
+        public string GetMainNamespace()
         {
-            return TypeScriptMainNamespaceName;
+            return TypeScriptMainNamespaceNamePrefix + (ConfigurationService.Settings.Properties != null && ConfigurationService.Settings.Properties.ContainsKey("typescript.namespacePostfix") ? ConfigurationService.Settings.Properties["typescript.namespacePostfix"] : string.Empty);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.TypeScript
 
             if (@namespace == MainNamespaceName) // types in main namespace e.g. microsoftgraph.Entity
             {
-                return TypeScriptMainNamespaceName + "." + type;
+                return GetMainNamespace() + "." + type;
             }
 
             // names in subnamespaces e.g. microsoftgraph.CallRecords.CallRecord

--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -31,7 +31,7 @@ namespace Typewriter.Test
         // and generation process creates a single file with nested namespaces
         private const string MetadataWithSubNamespacesFile = "MetadataWithSubNamespaces.xml";
 
-        public static void Run(TestLanguage language, bool isPhpBeta = false)
+        public static void Run(TestLanguage language, bool isBeta = false)
         {
             string getMetadataFile(TestLanguage testLanguage)
             {
@@ -54,7 +54,7 @@ namespace Typewriter.Test
 
             // Arrange
             var languageStr = language.ToString();
-            var directoryPostfix = isPhpBeta ? "PHPBeta" : languageStr;
+            var directoryPostfix = languageStr + (isBeta ? "Beta" : string.Empty);
             var outputDirectoryName = OutputDirectoryPrefix + directoryPostfix;
             var testDataDirectoryName = TestDataDirectoryPrefix + directoryPostfix;
 
@@ -74,9 +74,17 @@ namespace Typewriter.Test
             if (language == TestLanguage.Java)
                 options.EndpointVersion = "v1.0"; // fixes java generation test as the endpoint contains the version and the default options are not applied in this testing mode
 
-            if (isPhpBeta)
+            if (isBeta)
             {
-                options.Properties = new List<string> { "php.namespacePrefix:Beta" };
+                if (TestLanguage.PHP == language) 
+                {
+                    options.Properties = new List<string> { "php.namespacePrefix:Beta" };
+                }
+
+                if (TestLanguage.TypeScript == language)
+                {
+                    options.Properties = new List<string> { "typescript.namespacePostfix:beta" };
+                }
             }
 
             // Act

--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -76,7 +76,7 @@ namespace Typewriter.Test
 
             if (isBeta)
             {
-                if (TestLanguage.PHP == language) 
+                if (TestLanguage.PHP == language)
                 {
                     options.Properties = new List<string> { "php.namespacePrefix:Beta" };
                 }

--- a/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
+++ b/test/Typewriter.Test/PHPMultipleNamespacesTests.cs
@@ -14,7 +14,7 @@ namespace Typewriter.Test
         [Test, RunInApplicationDomain]
         public void TestBeta()
         {
-            MultipleNamespacesTestRunner.Run(TestLanguage.PHP, isPhpBeta: true);
+            MultipleNamespacesTestRunner.Run(TestLanguage.PHP, isBeta: true);
         }
     }
 }

--- a/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -1,0 +1,207 @@
+// Project: https://github.com/microsoftgraph/msgraph-typescript-typings
+// Definitions by: Microsoft Graph Team <https://github.com/microsoftgraph>
+//                 Michael Mainer <https://github.com/MIchaelMainer>
+//                 Peter Ombwa <https://github.com/peombwa>
+//                 Mustafa Zengin <https://github.com/zengin>
+//                 DeVere Dyett <https://github.com/ddyett>
+//                 Nikitha Udaykumar Chettiar <https://github.com/nikithauc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export as namespace microsoftgraphbeta;
+
+export type NullableOption<T> = T | null;
+
+export type Enum1 = "value0" | "value1";
+export interface Entity {
+    id?: string;
+}
+export interface TestType extends Entity {
+    propertyAlpha?: NullableOption<DerivedComplexTypeRequest>;
+}
+// tslint:disable-next-line: no-empty-interface
+export interface EntityType2 extends Entity {}
+// tslint:disable-next-line: no-empty-interface
+export interface EntityType3 extends Entity {}
+export interface TestEntity extends Entity {
+    testNav?: NullableOption<TestType>;
+    testInvalidNav?: NullableOption<EntityType2>;
+    testExplicitNav?: NullableOption<EntityType3>;
+}
+export interface Endpoint extends Entity {
+    property1?: NullableOption<number>;
+}
+export interface SingletonEntity1 extends Entity {
+    testSingleNav?: NullableOption<TestType>;
+}
+export interface SingletonEntity2 extends Entity {
+    testSingleNav2?: NullableOption<EntityType3>;
+}
+export interface TimeOffRequest extends Entity {
+    name?: NullableOption<string>;
+}
+export interface TimeOff extends Entity {
+    name?: NullableOption<string>;
+}
+export interface Schedule extends Entity {
+    enabled?: NullableOption<boolean>;
+    timesOff?: NullableOption<TimeOff[]>;
+    timeOffRequests?: NullableOption<TimeOffRequest[]>;
+}
+export interface Call extends Entity {
+    subject?: NullableOption<string>;
+}
+export interface CloudCommunications extends Entity {
+    calls?: NullableOption<Call[]>;
+    callRecords?: NullableOption<CallRecords.CallRecord[]>;
+}
+export interface OnenotePage extends Entity {
+    // The OneNotePage content.
+///
+/// Test token string
+    content?: NullableOption<any>;
+}
+// tslint:disable-next-line: no-empty-interface
+export interface PlannerGroup extends Entity {}
+// tslint:disable-next-line: no-empty-interface
+export interface EmptyBaseComplexTypeRequest {}
+export interface DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest {
+    property1?: NullableOption<string>;
+    property2?: NullableOption<string>;
+    enumProperty?: NullableOption<Enum1>;
+}
+// tslint:disable-next-line: no-empty-interface
+export interface ResponseObject {}
+export interface Recipient {
+    name?: NullableOption<string>;
+    email?: NullableOption<string>;
+}
+// tslint:disable-next-line: no-empty-interface
+export interface EmptyComplexType {}
+// tslint:disable-next-line: interface-name
+export interface Identity {
+    displayName?: NullableOption<string>;
+    id?: NullableOption<string>;
+}
+// tslint:disable-next-line: interface-name
+export interface IdentitySet {
+    application?: NullableOption<Identity>;
+    device?: NullableOption<Identity>;
+    user?: NullableOption<Identity>;
+}
+
+export namespace CallRecords {
+    type CallType = "unknown" | "groupCall";
+    type ClientPlatform = "unknown" | "windows";
+    type FailureStage = "unknown" | "callSetup";
+    type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
+    type NetworkConnectionType = "unknown" | "wired";
+    type ProductFamily = "unknown" | "teams";
+    type ServiceRole = "unknown" | "customBot";
+    type UserFeedbackRating = "notRated" | "bad";
+    type WifiBand = "unknown" | "frequency24GHz";
+    type WifiRadioType = "unknown" | "wifi80211a";
+    type Modality = "audio" | "video";
+    interface SingletonEntity1 extends microsoftgraphbeta.Entity {
+        testSingleNav?: NullableOption<microsoftgraphbeta.TestType>;
+    }
+    interface CallRecord extends microsoftgraphbeta.Entity {
+        version?: number;
+        type?: CallType;
+        modalities?: Modality[];
+        lastModifiedDateTime?: string;
+        startDateTime?: string;
+        endDateTime?: string;
+        organizer?: NullableOption<microsoftgraphbeta.IdentitySet>;
+        participants?: NullableOption<microsoftgraphbeta.IdentitySet[]>;
+        joinWebUrl?: NullableOption<string>;
+        sessions?: NullableOption<Session[]>;
+        recipients?: NullableOption<microsoftgraphbeta.EntityType2[]>;
+    }
+    interface Session extends microsoftgraphbeta.Entity {
+        modalities?: Modality[];
+        startDateTime?: string;
+        endDateTime?: string;
+        caller?: NullableOption<Endpoint>;
+        callee?: NullableOption<Endpoint>;
+        failureInfo?: NullableOption<FailureInfo>;
+        segments?: NullableOption<Segment[]>;
+    }
+    interface Segment extends microsoftgraphbeta.Entity {
+        startDateTime?: string;
+        endDateTime?: string;
+        caller?: NullableOption<Endpoint>;
+        callee?: NullableOption<Endpoint>;
+        failureInfo?: NullableOption<FailureInfo>;
+        media?: NullableOption<Media[]>;
+        refTypes?: NullableOption<microsoftgraphbeta.EntityType3[]>;
+        refType?: NullableOption<microsoftgraphbeta.Call>;
+        sessionRef?: NullableOption<Session>;
+        photo?: NullableOption<Photo>;
+    }
+// tslint:disable-next-line: no-empty-interface
+    interface Option extends microsoftgraphbeta.Entity {}
+    interface Photo extends microsoftgraphbeta.Entity {
+        failureInfo?: NullableOption<FailureInfo>;
+        option?: NullableOption<Option>;
+    }
+    interface Endpoint {
+        userAgent?: NullableOption<UserAgent>;
+    }
+    interface UserAgent {
+        headerValue?: NullableOption<string>;
+        applicationVersion?: NullableOption<string>;
+    }
+    interface FailureInfo {
+        stage?: FailureStage;
+        reason?: NullableOption<string>;
+    }
+    interface Media {
+        label?: NullableOption<string>;
+        callerNetwork?: NullableOption<NetworkInfo>;
+        callerDevice?: NullableOption<DeviceInfo>;
+        streams?: NullableOption<MediaStream[]>;
+    }
+    interface NetworkInfo {
+        connectionType?: NetworkConnectionType;
+        wifiBand?: WifiBand;
+        basicServiceSetIdentifier?: NullableOption<string>;
+        wifiRadioType?: WifiRadioType;
+        wifiSignalStrength?: NullableOption<number>;
+        bandwidthLowEventRatio?: NullableOption<number>;
+    }
+    interface DeviceInfo {
+        captureDeviceName?: NullableOption<string>;
+        sentSignalLevel?: NullableOption<number>;
+        speakerGlitchRate?: NullableOption<number>;
+    }
+    interface MediaStream {
+        streamId?: NullableOption<string>;
+        startDateTime?: NullableOption<string>;
+        streamDirection?: MediaStreamDirection;
+        packetUtilization?: NullableOption<number>;
+        wasMediaBypassed?: NullableOption<boolean>;
+        lowVideoProcessingCapabilityRatio?: NullableOption<number>;
+        averageAudioNetworkJitter?: NullableOption<string>;
+    }
+    interface ParticipantEndpoint extends Endpoint {
+        identity?: NullableOption<microsoftgraphbeta.IdentitySet>;
+        feedback?: NullableOption<UserFeedback>;
+    }
+    interface UserFeedback {
+        text?: NullableOption<string>;
+        rating?: UserFeedbackRating;
+        tokens?: NullableOption<FeedbackTokenSet>;
+    }
+// tslint:disable-next-line: no-empty-interface
+    interface FeedbackTokenSet {}
+// tslint:disable-next-line: no-empty-interface
+    interface ServiceEndpoint extends Endpoint {}
+    interface ClientUserAgent extends UserAgent {
+        platform?: ClientPlatform;
+        productFamily?: ProductFamily;
+    }
+    interface ServiceUserAgent extends UserAgent {
+        role?: ServiceRole;
+    }
+}

--- a/test/Typewriter.Test/TypeScriptMultipeNamespacesTests.cs
+++ b/test/Typewriter.Test/TypeScriptMultipeNamespacesTests.cs
@@ -5,10 +5,16 @@ namespace Typewriter.Test
     [TestFixture]
     public class TypeScriptMultipeNamespacesTests
     {
-        [Test]
+        [Test, RunInApplicationDomain]
         public void Test()
         {
             MultipleNamespacesTestRunner.Run(TestLanguage.TypeScript);
+        }
+
+        [Test, RunInApplicationDomain]
+        public void TestBeta()
+        {
+            MultipleNamespacesTestRunner.Run(TestLanguage.TypeScript, isBeta: true);
         }
     }
 }

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -73,7 +73,7 @@
     <Content Include="TestDataPHP*\**\*.php">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestDataTypeScript\**\*.ts">
+    <Content Include="TestDataTypeScript*\**\*.ts">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Metadata\MetadataMultipleNamespaces.xml">


### PR DESCRIPTION
For beta version, the typescript typings top-level namespace is 'microsoftgraphbeta'. The existing code has main namespaces always set to 'microsoftgraph'. This PR brings in the following changes-
1. For the main namespace to be generated as 'microsoftgraphbeta' when generating beta version, we will be passing "typescript.namespacePostfix:beta" as a property '-p typescript.namespacePostfix:beta'. 
2. During the generation of the typescript main namespace, the code will if the property 'typescript.namespacePostfix' exists and if present, will append the value to "microsoftgraph".