### PR TITLE
Fix OData methods with OData primitive return type

### DIFF
--- a/Templates/CSharp/Base/SharedCSharp.template.tt
+++ b/Templates/CSharp/Base/SharedCSharp.template.tt
@@ -314,4 +314,34 @@ public string GetRequestMethodWithOptionsHeader()
         /// <returns>The built request.</returns>";
 }
 
+// -------------------------------------------------------------
+// Methods used in MethodRequest.cs.tt and IMethodRequest.cs.tt for OData actions and functions.
+// -------------------------------------------------------------
+
+/// <summary>
+/// Used in MethodRequest.cs.tt and IMethodRequest.cs.tt to get the ODataMethod*Response type
+/// defined in Microsoft.Graph.Core. Updates to supported OData primitives for OData methods
+/// needs to occur in MethodRequest.cs.tt, IMethodRequest.cs.tt, Microsoft.Graph.Core, and here.
+/// </summary>
+/// <param name="type"></param>
+/// <returns></returns>
+public string GetMethodRequestPrimitiveReturnTypeString(string type)
+{
+    switch (type.ToLowerInvariant())
+    {
+        case "string":
+            return "ODataMethodStringResponse";
+        case "int32":
+            return "ODataMethodIntResponse";
+        case "boolean":
+        case "bool":
+            return "ODataMethodBooleanResponse";
+        case "int64":
+            return "ODataMethodLongResponse";
+        default:
+            return type;
+    }
+}
+
+
 #>

--- a/Templates/CSharp/Requests/IMethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/IMethodRequest.cs.tt
@@ -27,8 +27,8 @@ if (returnEntityType != null)
     // GetMethodRequestPrimitiveReturnTypeString() in SharedCSharp.
     var tempReturnType = GetMethodRequestPrimitiveReturnTypeString(returnEntityType);
 
-    // These magic strings represent types in M.G.C. If the return
-    // type is a primitive, then make it nullable.
+    // These magic strings represent types in Microsoft.Graph.Core.
+    // If the return type is a primitive, then make it nullable.
     if (tempReturnType == "ODataMethodIntResponse" ||
         tempReturnType == "ODataMethodBooleanResponse" ||
         tempReturnType == "ODataMethodLongResponse")

--- a/Templates/CSharp/Requests/IMethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/IMethodRequest.cs.tt
@@ -18,8 +18,27 @@ var requestType = entityName + methodName + "Request";
 
 var returnEntityType = method.ReturnType == null ? null : method.ReturnType.GetTypeString(@namespace);
 var returnEntityParameter = string.Empty;
-if (returnEntityType != null) {returnEntityParameter = returnEntityType.ToLower();}
+if (returnEntityType != null) 
+{
+    returnEntityParameter = returnEntityType.ToLower();
+
+    // Updates to supported OData primitives need to occur here,
+    // IMethodRequest.cs.tt, Microsoft.Graph.Core, and in
+    // GetMethodRequestPrimitiveReturnTypeString() in SharedCSharp.
+    var tempReturnType = GetMethodRequestPrimitiveReturnTypeString(returnEntityType);
+
+    // These magic strings represent types in M.G.C. If the return
+    // type is a primitive, then make it nullable.
+    if (tempReturnType == "ODataMethodIntResponse" ||
+        tempReturnType == "ODataMethodBooleanResponse" ||
+        tempReturnType == "ODataMethodLongResponse")
+    {
+        returnEntityType = returnEntityType + "?";
+    }
+}
 var returnTypeObject = method.ReturnType == null ? null : method.ReturnType.AsOdcmClass();
+
+
 
 var isCollection = method.IsCollection;
 
@@ -27,9 +46,13 @@ var sendAsyncReturnType = isCollection
     ? "I" + entityName + methodName + "CollectionPage"
     : returnEntityType;
 
+
+
 var methodReturnType = sendAsyncReturnType == null
     ? "System.Threading.Tasks.Task"
     : "System.Threading.Tasks.Task<" + sendAsyncReturnType + ">";
+
+
 
 bool hasParameters = method.Parameters != null && method.Parameters.Any();
 bool includeRequestBody = hasParameters && isAction;

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -223,18 +223,21 @@ namespace <#=@namespace#>
             return this.SendStreamRequestAsync(null, cancellationToken, httpCompletionOption);
 <#
     }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && !isPrimitiveReturnType)
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType))
     {
+        if (isPrimitiveReturnType)
+        {
+#>
+            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
+            return response.Value;            
+<#
+        }
+        else
+        {
 #>
             return this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
 <#
-    }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && isPrimitiveReturnType)
-    {
-#>
-            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
-            return response.Value;
-<#
+        }
     }
     else
     {
@@ -330,18 +333,21 @@ namespace <#=@namespace#>
             return this.SendStreamRequestAsync(null, cancellationToken, httpCompletionOption);
 <#
     }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && !isPrimitiveReturnType)
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType))
     {
+        if (isPrimitiveReturnType)
+        {
+#>
+            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
+            return response.Value;            
+<#
+        }
+        else
+        {
 #>
             return this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
 <#
-    }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && isPrimitiveReturnType)
-    {
-#>
-            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
-            return response.Value;
-<#
+        }
     }
     else
     {

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -16,28 +16,75 @@ var entityName = method.Class.Name.ToCheckedCase();
 var isFunction = method.IsFunction;
 var isAction = !isFunction;
 var isComposable = method.IsComposable;
+var isCollection = method.IsCollection;
 
 var methodName = method.Name.Substring(method.Name.IndexOf('.') + 1).ToCheckedCase();
 var requestType = entityName + methodName + "Request";
 
+var returnEntityParameter = string.Empty;
+
+// Represents the return of the SendAsync call within a public GetSync() or PostAsync() call.
+var sendAsyncReturnType = string.Empty;
+
+// Indicates whether the OData method returns an OData primitive (non-collection).
+// Collections of OData primitives is already supported.
+var isPrimitiveReturnType = false;
+
+// Represents the return type of a GetAsync() or PostAsync() call.
 var returnEntityType = method.ReturnType == null ? null : method.ReturnType.GetTypeString(@namespace);
 
-var returnEntityParameter = string.Empty;
-if (returnEntityType != null) {returnEntityParameter = returnEntityType.ToLower();}
+// Set the SendAsync return type and determine whether we are working with an OData primitive.
+if (returnEntityType != null) 
+{
+    returnEntityParameter = returnEntityType.ToLower();
+    if (isCollection)
+    {
+        sendAsyncReturnType = "I" + entityName + methodName + "CollectionPage";
+    }
+    else
+    {
+        // Updates to supported OData primitives need to occur here,
+        // IMethodRequest.cs.tt, Microsoft.Graph.Core, and in
+        // GetMethodRequestPrimitiveReturnTypeString() in SharedCSharp.
+        sendAsyncReturnType = GetMethodRequestPrimitiveReturnTypeString(returnEntityType);
 
-var isCollection = method.IsCollection;
+        // These magic strings represent types in M.G.C.
+        if (sendAsyncReturnType == "ODataMethodStringResponse" ||
+            sendAsyncReturnType == "ODataMethodIntResponse" ||
+            sendAsyncReturnType == "ODataMethodBooleanResponse" ||
+            sendAsyncReturnType == "ODataMethodLongResponse")
+        {
+            isPrimitiveReturnType = true;
+        }
+    }
+}
+else
+{
+    sendAsyncReturnType = returnEntityType;
+}
 
-var sendAsyncReturnType = isCollection
-    ? "I" + entityName + methodName + "CollectionPage"
-    : returnEntityType;
-
-var methodReturnType = sendAsyncReturnType == null
-    ? "System.Threading.Tasks.Task"
-    : "System.Threading.Tasks.Task<" + sendAsyncReturnType + ">";
+// Set the return type of the public GetSync() or PostAsync() call.
+var methodReturnType = string.Empty;
+if (sendAsyncReturnType == null)
+{
+    methodReturnType = "System.Threading.Tasks.Task";
+}
+else
+{
+    if (isCollection)
+    {
+        var collectionPage = "I" + entityName + methodName + "CollectionPage";
+        methodReturnType = "System.Threading.Tasks.Task<" + collectionPage + ">";
+    }
+    else
+    {
+        methodReturnType = "System.Threading.Tasks.Task<" + returnEntityType + ">";
+    }
+}
 
 string methodOverloadReturnType = methodReturnType;
 
-if (isCollection)
+if (isCollection || isPrimitiveReturnType)
 {
     methodReturnType = string.Concat("async ", methodReturnType);
 }
@@ -176,10 +223,17 @@ namespace <#=@namespace#>
             return this.SendStreamRequestAsync(null, cancellationToken, httpCompletionOption);
 <#
     }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType))
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && !isPrimitiveReturnType)
     {
 #>
             return this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
+<#
+    }
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && isPrimitiveReturnType)
+    {
+#>
+            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
+            return response.Value;
 <#
     }
     else
@@ -276,10 +330,17 @@ namespace <#=@namespace#>
             return this.SendStreamRequestAsync(null, cancellationToken, httpCompletionOption);
 <#
     }
-    else if (!string.IsNullOrEmpty(sendAsyncReturnType))
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && !isPrimitiveReturnType)
     {
 #>
             return this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
+<#
+    }
+    else if (!string.IsNullOrEmpty(sendAsyncReturnType) && isPrimitiveReturnType)
+    {
+#>
+            var response = await this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
+            return response.Value;
 <#
     }
     else

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -77,8 +77,12 @@ else
         methodReturnType = "System.Threading.Tasks.Task<" + collectionPage + ">";
     }
     else
-    {
-        methodReturnType = "System.Threading.Tasks.Task<" + returnEntityType + ">";
+    {   
+        var returnParameter = sendAsyncReturnType == "ODataMethodIntResponse" ||
+                              sendAsyncReturnType == "ODataMethodBooleanResponse" ||
+                              sendAsyncReturnType == "ODataMethodLongResponse" ? returnEntityType + "?"
+                              : returnEntityType;
+        methodReturnType = "System.Threading.Tasks.Task<" + returnParameter + ">";
     }
 }
 

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -229,7 +229,7 @@ namespace <#=@namespace#>
         {
 #>
             var response = await this.SendAsync<<#=sendAsyncReturnType#>>(<#=methodParameter#>, cancellationToken);
-            return response.Value;            
+            return response.Value;
 <#
         }
         else
@@ -339,7 +339,7 @@ namespace <#=@namespace#>
         {
 #>
             var response = await this.SendAsync<<#=sendAsyncReturnType#>>(null, cancellationToken);
-            return response.Value;            
+            return response.Value;
 <#
         }
         else

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -675,7 +675,7 @@ namespace Typewriter.Test
 
             Generator.GenerateFiles(testMetadata, optionsCSharp);
 
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithInt64Request.cs");
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType3ActionMethodWithInt64Request.cs");
             Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
 
             IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -557,7 +557,11 @@ namespace Typewriter.Test
         }
 
         [Test, RunInApplicationDomain]
-        public void It_creates_function_request_with_OData_string_return_type()
+        [TestCase("TestType2FunctionMethodWithStringRequest.cs", "var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);")]
+        [TestCase("TestType2FunctionMethodWithBooleanRequest.cs", "var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);")]
+        [TestCase("TestType2FunctionMethodWithInt32Request.cs", "var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);")]
+        [TestCase("TestType3ActionMethodWithInt64Request.cs", "var response = await this.SendAsync<ODataMethodLongResponse>(null, cancellationToken);")]
+        public void It_creates_method_request_with_OData_return_type(string outputFileName, string testParameter)
         {
             const string outputDirectory = "output";
 
@@ -570,118 +574,11 @@ namespace Typewriter.Test
 
             Generator.GenerateFiles(testMetadata, optionsCSharp);
 
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithStringRequest.cs");
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\" + outputFileName);
             Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
 
             IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
             bool hasTestParameter = false;
-            string testParameter = "var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);";
-
-
-            foreach (var line in lines)
-            {
-                // We only need to check once.
-                if (line.Contains(testParameter))
-                {
-                    hasTestParameter = true;
-                    break;
-                }
-            }
-
-            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
-        }
-
-        [Test, RunInApplicationDomain]
-        public void It_creates_function_request_with_OData_boolean_return_type()
-        {
-            const string outputDirectory = "output";
-
-            Options optionsCSharp = new Options()
-            {
-                Output = outputDirectory,
-                Language = "CSharp",
-                GenerationMode = GenerationMode.Files
-            };
-
-            Generator.GenerateFiles(testMetadata, optionsCSharp);
-
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithBooleanRequest.cs");
-            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
-
-            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
-            bool hasTestParameter = false;
-            string testParameter = "var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);";
-
-
-            foreach (var line in lines)
-            {
-                // We only need to check once.
-                if (line.Contains(testParameter))
-                {
-                    hasTestParameter = true;
-                    break;
-                }
-            }
-
-            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
-        }
-
-        [Test, RunInApplicationDomain]
-        public void It_creates_function_request_with_OData_int32_return_type()
-        {
-            const string outputDirectory = "output";
-
-            Options optionsCSharp = new Options()
-            {
-                Output = outputDirectory,
-                Language = "CSharp",
-                GenerationMode = GenerationMode.Files
-            };
-
-            Generator.GenerateFiles(testMetadata, optionsCSharp);
-
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithInt32Request.cs");
-            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
-
-            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
-            bool hasTestParameter = false;
-            string testParameter = "var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);";
-
-
-            foreach (var line in lines)
-            {
-                // We only need to check once.
-                if (line.Contains(testParameter))
-                {
-                    hasTestParameter = true;
-                    break;
-                }
-            }
-
-            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
-        }
-
-        [Test, RunInApplicationDomain]
-        public void It_creates_action_request_with_OData_int64_return_type()
-        {
-            const string outputDirectory = "output";
-
-            Options optionsCSharp = new Options()
-            {
-                Output = outputDirectory,
-                Language = "CSharp",
-                GenerationMode = GenerationMode.Files
-            };
-
-            Generator.GenerateFiles(testMetadata, optionsCSharp);
-
-            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType3ActionMethodWithInt64Request.cs");
-            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
-
-            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
-            bool hasTestParameter = false;
-            string testParameter = "var response = await this.SendAsync<ODataMethodLongResponse>(null, cancellationToken);";
-
 
             foreach (var line in lines)
             {

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -555,5 +555,145 @@ namespace Typewriter.Test
             Assert.IsTrue(hasContainsTargetBeenSet, $"The expected ContainsTarget attribute wasn't set in the transformed cleaned metadata.");
             Assert.IsFalse(hasCapabilityAnnotations, $"The expected capability annotations weren't removed in the transformed cleaned metadata.");
         }
+
+        [Test, RunInApplicationDomain]
+        public void It_creates_function_request_with_OData_string_return_type()
+        {
+            const string outputDirectory = "output";
+
+            Options optionsCSharp = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, optionsCSharp);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithStringRequest.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestParameter = false;
+            string testParameter = "var response = await this.SendAsync<ODataMethodStringResponse>(null, cancellationToken);";
+
+
+            foreach (var line in lines)
+            {
+                // We only need to check once.
+                if (line.Contains(testParameter))
+                {
+                    hasTestParameter = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
+        }
+
+        [Test, RunInApplicationDomain]
+        public void It_creates_function_request_with_OData_boolean_return_type()
+        {
+            const string outputDirectory = "output";
+
+            Options optionsCSharp = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, optionsCSharp);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithBooleanRequest.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestParameter = false;
+            string testParameter = "var response = await this.SendAsync<ODataMethodBooleanResponse>(null, cancellationToken);";
+
+
+            foreach (var line in lines)
+            {
+                // We only need to check once.
+                if (line.Contains(testParameter))
+                {
+                    hasTestParameter = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
+        }
+
+        [Test, RunInApplicationDomain]
+        public void It_creates_function_request_with_OData_int32_return_type()
+        {
+            const string outputDirectory = "output";
+
+            Options optionsCSharp = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, optionsCSharp);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithInt32Request.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestParameter = false;
+            string testParameter = "var response = await this.SendAsync<ODataMethodIntResponse>(null, cancellationToken);";
+
+
+            foreach (var line in lines)
+            {
+                // We only need to check once.
+                if (line.Contains(testParameter))
+                {
+                    hasTestParameter = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
+        }
+
+        [Test, RunInApplicationDomain]
+        public void It_creates_action_request_with_OData_int64_return_type()
+        {
+            const string outputDirectory = "output";
+
+            Options optionsCSharp = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, optionsCSharp);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @"\Requests\TestType2FunctionMethodWithInt64Request.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestParameter = false;
+            string testParameter = "var response = await this.SendAsync<ODataMethodLongResponse>(null, cancellationToken);";
+
+
+            foreach (var line in lines)
+            {
+                // We only need to check once.
+                if (line.Contains(testParameter))
+                {
+                    hasTestParameter = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(hasTestParameter, $"The expected test token string, '{testParameter}', was not set in the generated test file. We didn't properly generate the SendAsync method.");
+        }
     }
 }

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -105,7 +105,7 @@
         <Parameter Name="bindparameter" Type="microsoft.graph.testType2" />
         <ReturnType Type="Edm.Int32" Nullable="false" />
       </Function>
-      <Action Name="FunctionMethodWithInt64" IsBound="true">
+      <Action Name="ActionMethodWithInt64" IsBound="true">
         <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
         <ReturnType Type="Edm.Int64" Nullable="false" />
       </Action>

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -92,6 +92,23 @@
         <Parameter Name="Comment" Type="Edm.String" Unicode="false" />
         <Parameter Name="TestProperty" Type="Edm.String" Nullable="true"/>
       </Action>
+      
+      <Function Name="FunctionMethodWithString" IsBound="true">
+        <Parameter Name="bindparameter" Type="microsoft.graph.testType2" />
+        <ReturnType Type="Edm.String" Unicode="false" />
+      </Function>
+      <Function Name="FunctionMethodWithBoolean" IsBound="true">
+        <Parameter Name="bindparameter" Type="microsoft.graph.testType2" />
+        <ReturnType Type="Edm.Boolean" Nullable="false" />
+      </Function>
+      <Function Name="FunctionMethodWithInt32" IsBound="true">
+        <Parameter Name="bindparameter" Type="microsoft.graph.testType2" />
+        <ReturnType Type="Edm.Int32" Nullable="false" />
+      </Function>
+      <Action Name="FunctionMethodWithInt64" IsBound="true">
+        <Parameter Name="bindingParameter" Type="microsoft.graph.testType3" />
+        <ReturnType Type="Edm.Int64" Nullable="false" />
+      </Action>
 
       <EntityContainer Name="GraphService">
         <Singleton Name="testSingleton" Type="microsoft.graph.testSingleton"/>


### PR DESCRIPTION
## Summary

ODate primitives method return types are returned in an object.
We weren't handling the object which resulted in serialization
exceptions.

	modified:   Templates/CSharp/Base/SharedCSharp.template.tt
	modified:   Templates/CSharp/Requests/MethodRequest.cs.tt

## Generated code differences

https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/160
https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/800

## Command line arguments to run these changes

```pwsh
# Run against the current typewriter dev branch 
-v Info -m https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml -o dotnetbeta_old -l CSharp -g Files -e beta

# Run against this typewriter branch 
-v Info -m https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml -o dotnetbeta_new -l CSharp -g Files -e beta
```

## Links to issues or work items this PR addresses

The generated changes are supported by these changes: https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/135