### PR TITLE
- fixes an issue where the dependabot reference didn't update the assembly path following upgrade

### DIFF
--- a/src/GraphODataTemplateWriter/GraphODataTemplateWriter.csproj
+++ b/src/GraphODataTemplateWriter/GraphODataTemplateWriter.csproj
@@ -37,7 +37,7 @@
       <HintPath>..\..\packages\Inflector.1.0.0.0\lib\net45\Inflector.dll</HintPath>
     </Reference>
     <Reference Include="Mono.TextTemplating">
-      <HintPath>..\..\packages\Mono.TextTemplating.2.0.5\lib\Mono.TextTemplating.dll</HintPath>
+      <HintPath>..\..\packages\Mono.TextTemplating.2.0.5\lib\net45\Mono.TextTemplating.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NLog.4.7.5\lib\net45\NLog.dll</HintPath>


### PR DESCRIPTION
MonTextTemplate ships multiple tarets with version 2.0.5 which changes the path of the DLL.
During the last update, dependabot didn't update the path causing a broken hint path.
This fixes the reference path, until we move to dotnet core and package references.