### PR TITLE
- replaces inflector by its dotnet standard verssion

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 {
@@ -10,6 +10,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
     using NLog;
     using System.Linq;
     using System.Runtime.CompilerServices;
+    using System.Globalization;
+    using Inflector;
 
     public static class TypeHelperCSharp
     {
@@ -298,10 +300,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
         {
             return !SimpleTypes.Contains(t);
         }
-
+        private static readonly Inflector inflector = new Inflector(CultureInfo.GetCultureInfo("en-US"));
         public static string GetNamespaceName(this OdcmNamespace namespaceObject)
         {
-            return Inflector.Inflector.Titleize(namespaceObject.Name).Replace(" ", "");
+            return inflector.Titleize(namespaceObject.Name).Replace(" ", "");
         }
 
         public static string GetToLowerFirstCharName(this OdcmProperty property)

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
 {
@@ -188,7 +188,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
 
             pieces.AddRange(@namespace.Split('.').ToList());
 
-            var pascalCasePieces = pieces.Select(piece => piece.Pascalize());
+            var pascalCasePieces = pieces.Select(piece => piece.ToPascalize());
             return string.Join("\\", pascalCasePieces);
         }
 

--- a/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/StringExtensions.cs
@@ -1,9 +1,10 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 namespace Microsoft.Graph.ODataTemplateWriter.Extensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Text.RegularExpressions;
 
     public static class StringExtensions
@@ -52,24 +53,25 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             return Regex.Replace(toSpaces, "[ -~]", " ");
         }
 
+        private static readonly Inflector.Inflector inflector = new Inflector.Inflector(CultureInfo.GetCultureInfo("en-US"));
         public static string ToSingularize(this string input) 
         {
-            return Inflector.Inflector.Singularize(input);
+            return inflector.Singularize(input);
         }
 
         public static string ToCamelize (this string input)
         {
-            return Inflector.Inflector.Camelize(input);
+            return inflector.Camelize(input);
         }
 
         public static string ToPascalize(this string input)
         {
-            return Inflector.Inflector.Pascalize(input);
+            return inflector.Pascalize(input);
         }
 
         public static string ToUnderscore(this string input)
         {
-            return Inflector.Inflector.Underscore(input);
+            return inflector.Underscore(input);
         }
 
         /// <summary>

--- a/src/GraphODataTemplateWriter/GraphODataTemplateWriter.csproj
+++ b/src/GraphODataTemplateWriter/GraphODataTemplateWriter.csproj
@@ -49,9 +49,7 @@
     <ProjectReference Include="..\..\submodules\vipr\src\Readers\Vipr.Reader.OData.v4\Vipr.Reader.OData.v4.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Inflector">
-      <Version>1.0.0</Version>
-    </PackageReference>
+    <PackageReference Include="Inflector.NetStandard" Version="1.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Mono.TextTemplating">


### PR DESCRIPTION
inflector hasn't been upgraded to dotnet standard. However the community put together a fork on dotnet standard that's more popular than the original thing.