### PR TITLE
Add endpoint for runs of typewriter when adding docs

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -151,8 +151,6 @@ stages:
         docsDirectory: $(docsDirectoryBeta)
         repoName: "msgraph-beta-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileBeta)
-    - pwsh: |
-        Write-Host "Success!"
 
 - stage: stage_csharp_v1
   dependsOn:

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -1,15 +1,15 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # contains an end to end validation pipeline using C# compilation tests for staging beta metadata
 
-# capture-metadata.yml will result in the capture and cleaning of the metadata 
+# capture-metadata.yml will result in the capture and cleaning of the metadata
 # with the artifacts posted to GitHub.
 
 parameters:
 - name: 'endpoint'
-  type: string 
+  type: string
   default: "v1.0"
 - name: 'inputMetadata'
-  type: string 
+  type: string
   default: $(rawMetadataFileV1)
 - name: 'outputPath'
   type: string
@@ -23,7 +23,7 @@ parameters:
 - name: 'cleanMetadataFile'
   type: string
   default: $(cleanMetadataFileV1)
-  
+
 steps:
 
 # We only need the scripts
@@ -62,6 +62,7 @@ steps:
     DocsDirectory: ${{ parameters.docsDirectory }}
     GenerationMode: 'TransformWithDocs'
     Transform: $(transformScript)
+    endpointVersion: ${{ parameters.endpoint }}
   displayName: 'run Typewriter to clean ${{ parameters.endpoint }} metadata'
 
 # Use the clean metadata from the last step to generate DotNet files.

--- a/scripts/run-typewriter-clean-metadata.ps1
+++ b/scripts/run-typewriter-clean-metadata.ps1
@@ -1,8 +1,10 @@
 # Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
+# This script runs typewriter which results in: 1) metadata processed through an xslt and 2) documentation added as annotations in the metadata
+
 Push-Location -Path $env:TypewriterDirectory
 
 # Note: We were only inserting the v1.0 docs. This change will make us insert beta docs into beta code files.
-& $env:TypewriterExecutable -v Info -m $env:InputMetadataFile -o $env:OutputPath -g $env:GenerationMode -t $env:Transform -d $env:DocsDirectory
+& $env:TypewriterExecutable -v Info -m $env:InputMetadataFile -o $env:OutputPath -g $env:GenerationMode -t $env:Transform -d $env:DocsDirectory -e $env:endpointVersion
 
 Pop-Location


### PR DESCRIPTION
This change is needed so that we can support adding documentation to the beta clean metadata.

https://github.com/microsoftgraph/msgraph-metadata/pull/46