### PR TITLE
adds support for deprecation annotations in java

### DIFF
--- a/Templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/CSharp/Model/ComplexType.cs.tt
@@ -21,12 +21,12 @@ if (typeDeclaration.EndsWith("Request"))
     typeDeclaration = String.Concat(typeDeclaration, "Object");
 }
 
-// Capture the cstor type declaration as the typedeclaration may get appended with a base type. 
+// Capture the cstor type declaration as the typedeclaration may get appended with a base type.
 string cstorTypeDeclaration = typeDeclaration;
 
 if (complex.Base != null)
 {
-    // Disambiguate the base type declaration for the same reason we did this 
+    // Disambiguate the base type declaration for the same reason we did this
 	// for typeDeclaration.
 	var baseTypeDeclaration = complex.Base.GetTypeString(complex.Namespace.GetNamespaceName());
 
@@ -43,7 +43,7 @@ var classType = complex.IsAbstract ? "abstract partial class" : "partial class";
 
 var attributeStringBuilder = new StringBuilder();
 
-if (complex.Deprecation != null)
+if (complex.IsDeprecated)
 {
    attributeStringBuilder.Append(complex.GetDeprecationString());
    attributeStringBuilder.Append(Environment.NewLine);
@@ -100,7 +100,7 @@ if (!complex.IsAbstract)
 
             var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Newtonsoft.Json.Required.Default)]", property.Name);
 
-            if (property.Deprecation != null)
+            if (property.IsDeprecated)
             {
                 attributeDefinition = property.GetDeprecationString() + Environment.NewLine + "        " + attributeDefinition;
             }
@@ -138,7 +138,7 @@ if (!complex.IsAbstract)
         }
 
     // Only include AdditionalData in the base classes.
-    // Adding odata.type to all complex types with no base class. 
+    // Adding odata.type to all complex types with no base class.
     if (complex.Base == null)
     {
     #>

--- a/Templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/CSharp/Model/EntityType.cs.tt
@@ -39,7 +39,7 @@ if (entity.Base != null)
 
 var attributeStringBuilder = new StringBuilder();
 
-if (entity.Deprecation != null)
+if (entity.IsDeprecated)
 {
    attributeStringBuilder.Append(entity.GetDeprecationString());
    attributeStringBuilder.Append(Environment.NewLine);
@@ -106,7 +106,7 @@ namespace <#=@namespace#>
                     ? propertyTypeString
                     : propertyTypeString + "?";
 
-            // We want to disambiguate structural property return types in case there is a naming 
+            // We want to disambiguate structural property return types in case there is a naming
             // collision with a request builder, like what we had for the Search entity, and the SearchRequest
             // complex type.
             if (propertyType.EndsWith("Request") && property.IsNavigation() == false)
@@ -119,7 +119,7 @@ namespace <#=@namespace#>
 
             var attributeDefinition = string.Format("[JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = \"{0}\", Required = Newtonsoft.Json.Required.Default)]", property.Name);
 
-            if (property.Deprecation != null)
+            if (property.IsDeprecated)
             {
                 attributeDefinition = property.GetDeprecationString() + Environment.NewLine + "        " + attributeDefinition;
             }

--- a/Templates/CSharp/Model/EnumType.cs.tt
+++ b/Templates/CSharp/Model/EnumType.cs.tt
@@ -18,7 +18,7 @@ namespace <#=enumT.Namespace.GetNamespaceName()#>
     /// <summary>
     /// The enum <#=enumName#>.
     /// </summary>
-<# if (enumT.Deprecation != null) { #>
+<# if (enumT.IsDeprecated) { #>
     <#=enumT.GetDeprecationString()#>
 <# } #>
     [JsonConverter(typeof(<#=enumConverterTypeName#>))]
@@ -39,7 +39,7 @@ namespace <#=enumT.Namespace.GetNamespaceName()#>
         /// <summary>
         /// <#=emumMember.Name.ToUpperFirstChar().SplitCamelCase()#>
         /// </summary>
-<# if (emumMember.Deprecation != null) { #>
+<# if (emumMember.IsDeprecated) { #>
         <#=emumMember.GetDeprecationString()#>
 <# } #>
         <#=emumMember.Name.ToCheckedCase().GetSanitizedPropertyName()#> = <#=emumMember.Value#>,

--- a/Templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/CSharp/Requests/EntityClient.cs.tt
@@ -69,7 +69,7 @@ namespace <#=@namespace#>
         /// <summary>
         /// Gets the <#=propName#> request builder.
         /// </summary>
-<# if (prop.Deprecation != null) { #>
+<# if (prop.IsDeprecated) { #>
         <#=prop.GetDeprecationString()#>
 <# } #>
         public I<#=collectionRequestBuilder#> <#=sanitizedPropName#>
@@ -90,7 +90,7 @@ namespace <#=@namespace#>
         /// <summary>
         /// Gets the <#=propName#> request builder.
         /// </summary>
-<# if (prop.Deprecation != null) { #>
+<# if (prop.IsDeprecated) { #>
         <#=prop.GetDeprecationString()#>
 <# } #>
         public <#=iRequestBuilder#> <#=sanitizedPropName#>

--- a/Templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/CSharp/Requests/MethodRequest.cs.tt
@@ -34,7 +34,7 @@ var isPrimitiveReturnType = false;
 var returnEntityType = method.ReturnType == null ? null : method.ReturnType.GetTypeString(@namespace);
 
 // Set the SendAsync return type and determine whether we are working with an OData primitive.
-if (returnEntityType != null) 
+if (returnEntityType != null)
 {
     returnEntityParameter = returnEntityType.ToLower();
     if (isCollection)
@@ -77,7 +77,7 @@ else
         methodReturnType = "System.Threading.Tasks.Task<" + collectionPage + ">";
     }
     else
-    {   
+    {
         var returnParameter = sendAsyncReturnType == "ODataMethodIntResponse" ||
                               sendAsyncReturnType == "ODataMethodBooleanResponse" ||
                               sendAsyncReturnType == "ODataMethodLongResponse" ? returnEntityType + "?"
@@ -112,7 +112,7 @@ namespace <#=@namespace#>
     /// <summary>
     /// The type <#=requestType#>.
     /// </summary>
-<# if (method.Deprecation != null) { #>
+<# if (method.IsDeprecated) { #>
     <#=method.GetDeprecationString()#>
 <# } #>
     public partial class <#=requestType#> : <#=baseRequestTypeName#>, I<#=requestType#>
@@ -148,7 +148,7 @@ namespace <#=@namespace#>
 <#
     }
 #>
-<# 
+<#
     if(isAction) // POST
     {
 #>
@@ -259,7 +259,7 @@ namespace <#=@namespace#>
 
 #>
 
-<# 
+<#
     if(method.IsFunction) // GET for a OData function.
     {
 #>
@@ -367,7 +367,7 @@ namespace <#=@namespace#>
 <#  } // End GET
  #>
 
-<# 
+<#
     if(method.IsFunction && method.IsComposable) // PATCH for a OData function.
     {
 #>
@@ -396,7 +396,7 @@ namespace <#=@namespace#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
+        public <#=methodReturnType#> PatchAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>,
 <#
     if (returnsStream)
     {
@@ -465,10 +465,10 @@ namespace <#=@namespace#>
 <#
     }
 #>
-        }        
+        }
 <#  } // End PATCH for a OData function.
 #>
-<# 
+<#
     if(method.IsFunction && method.IsComposable) // PUT for a OData function.
     {
 #>
@@ -497,7 +497,7 @@ namespace <#=@namespace#>
     }
 #>
         /// <returns>The task to await for async call.</returns>
-        public <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>, 
+        public <#=methodReturnType#> PutAsync(<#=returnEntityType#> <#=returnEntityParameter.GetSanitizedParameterName()#>,
 <#
     if (returnsStream)
     {
@@ -566,7 +566,7 @@ namespace <#=@namespace#>
 <#
     }
 #>
-        }        
+        }
 <#  } // End PUT for a OData function.
 #>
 <#

--- a/Templates/Java/models_extensions/BaseEntity.java.tt
+++ b/Templates/Java/models_extensions/BaseEntity.java.tt
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import java.util.HashMap;
 <# } #>
 
-<#=TypeHelperJava.CreateClassDef(c.TypeName(), c.BaseClassName(), "IJsonBackedObject")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeName(), c.BaseClassName(), "IJsonBackedObject", c.Deprecation?.Description)#>
 
 <#
     if(((OdcmClass)c).Base == null){

--- a/Templates/Java/models_extensions/BaseMethodParameterSet.java.tt
+++ b/Templates/Java/models_extensions/BaseMethodParameterSet.java.tt
@@ -16,7 +16,7 @@ import <#=importNamespace#>.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeParameterSet())#>
+<#=TypeHelperJava.CreateClassDef(c.TypeParameterSet(), null, null, c.Deprecation?.Description)#>
 <# var parameters = c.AsOdcmMethod().WithOverloads().WithDistinctParameters(); #>
 <#=TypeHelperJava.CreateParameterDef(parameters)#>
     /**
@@ -49,14 +49,26 @@ var parameterName = parameter.ParamName().SanitizePropertyName(parameter).ToLowe
 <# foreach(var parameter in parameters) { #>
         /**
          * The <#=parameter.ParamName().SanitizePropertyName(parameter).ToLowerFirstChar()#> parameter value
+<# if(parameter.IsDeprecated) {#>
+         * @deprecated <#= parameter?.Deprecation?.Description #>
+<# } #>
          */
+<# if(parameter.IsDeprecated) {#>
+        @Deprecated
+<# } #>
         @Nullable
         protected <#=parameter.ParamType()#> <#=parameter.ParamName().SanitizePropertyName(parameter).ToLowerFirstChar()#>;
         /**
          * Sets the <#=parameter.ParamName().SanitizePropertyName(parameter).ToUpperFirstChar()#>
          * @param val the value to set it to
          * @return the current builder object
+<# if(parameter.IsDeprecated) {#>
+         * @deprecated <#= parameter?.Deprecation?.Description #>
+<# } #>
          */
+<# if(parameter.IsDeprecated) {#>
+        @Deprecated
+<# } #>
         @Nonnull
         public <#=c.TypeParameterSetBuilder()#> with<#=parameter.ParamName().SanitizePropertyName(parameter).ToUpperFirstChar()#>(@Nullable final <#=parameter.ParamType()#> val) {
             this.<#=parameter.ParamName().SanitizePropertyName(parameter).ToLowerFirstChar()#> = val;

--- a/Templates/Java/models_extensions/IBaseClient.java.tt
+++ b/Templates/Java/models_extensions/IBaseClient.java.tt
@@ -20,7 +20,13 @@ foreach (var prop in model.EntityContainer.Properties)
      * Gets the collection of <#=propertyName#> objects
      *
      * @return the request builder for the collection of <#=propertyName#> objects
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     <#=prop.TypeCollectionRequestBuilder()#> <#=prop.Name#>();
 
@@ -29,7 +35,13 @@ foreach (var prop in model.EntityContainer.Properties)
      *
      * @param id the id of the <#=propertyName#> to retrieve
      * @return the request builder for the <#=propertyName#> object
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     <#=prop.TypeRequestBuilder()#> <#=prop.Name#>(@Nonnull final String id);
 <#
@@ -42,7 +54,13 @@ foreach (var prop in model.EntityContainer.Properties)
      * Gets the <#=c.TypeRequestBuilder()#>
      *
      * @return the <#=prop.Projection.Type.GetTypeString()#>
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     <#=prop.TypeRequestBuilder()#> <#=prop.Name#>();
 <#

--- a/Templates/Java/models_extensions/IBaseClient.java.tt
+++ b/Templates/Java/models_extensions/IBaseClient.java.tt
@@ -7,7 +7,7 @@
 <# var importNamespace = host.CurrentModel.GetNamespace().AddPrefix(); #>
 import <#=importNamespace#>.core.IBaseClient;
 
-<#=TypeHelperJava.CreateInterfaceDef(c.IBaseClientType(host), "IBaseClient")#>
+<#=TypeHelperJava.CreateInterfaceDef(c.IBaseClientType(host), "IBaseClient", null)#>
 <#
 foreach (var prop in model.EntityContainer.Properties)
 {

--- a/Templates/Java/models_generated/Enum.java.tt
+++ b/Templates/Java/models_generated/Enum.java.tt
@@ -7,7 +7,13 @@
 
 /**
  * The Enum <#=c.Name.ToUpperFirstChar().SplitCamelCase()#>.
+<# if(c.IsDeprecated) {#>
+ * @deprecated <#= c?.Deprecation?.Description #>
+<# } #>
 */
+<# if(c.IsDeprecated) {#>
+@Deprecated
+<# } #>
 public enum <#= c.Name.ToUpperFirstChar()#>
 {
 <#
@@ -16,7 +22,13 @@ public enum <#= c.Name.ToUpperFirstChar()#>
 #>
     /**
     * <#= value.Name.SplitCamelCase()#>
+<# if(value.IsDeprecated) {#>
+    * @deprecated <#= value.Deprecation?.Description #>
+<# } #>
     */
+<# if(value.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     <#= value.Name.ToUnderscore().ToUpper() #>,
 <#
     }

--- a/Templates/Java/requests_extensions/BaseClient.java.tt
+++ b/Templates/Java/requests_extensions/BaseClient.java.tt
@@ -8,7 +8,7 @@
 import <#=importNamespace#>.models.extensions.<#=c.IBaseClientType(host)#>;
 import <#=importNamespace#>.core.BaseClient;
 
-<#=TypeHelperJava.CreateClassDef(c.BaseClientType(host), "BaseClient", c.IBaseClientType(host))#>
+<#=TypeHelperJava.CreateClassDef(c.BaseClientType(host), "BaseClient", c.IBaseClientType(host), c.Deprecation?.Description)#>
 
     /**
      * The default endpoint for the Microsoft Graph Service

--- a/Templates/Java/requests_extensions/BaseClient.java.tt
+++ b/Templates/Java/requests_extensions/BaseClient.java.tt
@@ -45,7 +45,13 @@ foreach (var prop in model.EntityContainer.Properties)
      * Gets the collection of <#=propertyName#> objects
      *
      * @return the request builder for the collection of <#=propertyName#> objects
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=prop.TypeCollectionRequestBuilder()#> <#=prop.Name#>() {
         return new <#=prop.TypeCollectionRequestBuilder()#>(getServiceRoot() + "/<#=prop.Name#>", this, null);
@@ -56,7 +62,13 @@ foreach (var prop in model.EntityContainer.Properties)
      *
      * @param id the id of the <#=propertyName#> to retrieve
      * @return the request builder for the <#=propertyName#> object
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=prop.TypeRequestBuilder()#> <#=prop.Name#>(@Nonnull final String id) {
         return new <#=prop.TypeRequestBuilder()#>(getServiceRoot() + "/<#=prop.Name#>/" + id, this, null);
@@ -71,7 +83,13 @@ foreach (var prop in model.EntityContainer.Properties)
      * Gets the <#=c.TypeRequestBuilder()#>
      *
      * @return the <#=prop.Projection.Type.GetTypeString()#>
+<# if(prop.IsDeprecated) {#>
+     * @deprecated <#= prop?.Deprecation?.Description #>
+<# } #>
      */
+<# if(prop.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=prop.TypeRequestBuilder()#> <#=prop.Name#>() {
         return new <#=prop.TypeRequestBuilder()#>(getServiceRoot() + "/<#=prop.Name#>", this, null);

--- a/Templates/Java/requests_extensions/BaseEntityCollectionPage.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionPage.java.tt
@@ -12,7 +12,7 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
 <# var importNamespace = host.CurrentModel.GetNamespace().AddPrefix(); #>
 import <#=importNamespace#>.http.BaseCollectionPage;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionPage(), "BaseCollectionPage<"+ c.TypeName() + ", "+c.TypeCollectionRequestBuilder()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionPage(), "BaseCollectionPage<"+ c.TypeName() + ", "+c.TypeCollectionRequestBuilder()+">", null, c.Deprecation?.Description)#>
 
     /**
      * A collection page for <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequest.java.tt
@@ -20,7 +20,7 @@ import <#=importNamespace#>.http.BaseCollectionWithReferencesRequest;
 import <#=importNamespace#>.http.BaseCollectionWithReferencesRequestBuilder;
 import <#=importNamespace#>.http.ReferenceRequestBody;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionReferenceRequest(), "BaseCollectionWithReferencesRequest<" + c.TypeName() + ", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionWithReferencesRequest()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionReferenceRequest(), "BaseCollectionWithReferencesRequest<" + c.TypeName() + ", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionWithReferencesRequest()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.TypeName()#>
@@ -39,7 +39,7 @@ import <#=importNamespace#>.http.ReferenceRequestBody;
 
 			//Append the singleton's navigation type to the @odata.id if relevant
 			var implicitNavigationProperty = string.Empty;
-			if (navigationProperty.GetType() == typeof(OdcmSingleton)) 
+			if (navigationProperty.GetType() == typeof(OdcmSingleton))
 				implicitNavigationProperty = c.AsOdcmProperty().Name + "/";
 
             String prop = c.AsOdcmProperty().GetServiceCollectionNavigationPropertyForPropertyType(((CustomT4Host)Host).CurrentModel).Name;
@@ -70,7 +70,7 @@ import <#=importNamespace#>.http.ReferenceRequestBody;
                 .buildRequest(getBaseRequest().getHeaders())
                 .post(new<#=c.TypeName()#>, body);
     }
-<#     } 
+<#     }
 #>
 <# if (c.GetFeatures().CanExpand) { #>
     /**

--- a/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionReferenceRequestBuilder.java.tt
@@ -10,7 +10,7 @@
 import <#=importNamespace#>.http.BaseCollectionReferenceRequestBuilder;
 import <#=importNamespace#>.core.IBaseClient;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionReferenceRequestBuilder(), "BaseCollectionReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionReferenceRequest()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionReferenceRequestBuilder(), "BaseCollectionReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionReferenceRequest()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequest.java.tt
@@ -16,7 +16,7 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
 import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCollectionRequestBuilder()#>;
 import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCollectionRequest()#>;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequest(), "BaseEntityCollectionRequest<"+c.TypeName()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequest(), "BaseEntityCollectionRequest<"+c.TypeName()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequestBuilder.java.tt
@@ -83,7 +83,13 @@ if (currentTypeProjection != null) {
 <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
 <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeCollectionRequestBuilder()#> <#=method.MethodName().ToLowerFirstChar()#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeCollectionRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);
@@ -98,7 +104,13 @@ if (currentTypeProjection != null) {
 <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
 <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeRequestBuilder()#> <#=method.MethodName().ToLowerFirstChar()#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);

--- a/Templates/Java/requests_extensions/BaseEntityCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionRequestBuilder.java.tt
@@ -40,7 +40,7 @@ foreach (var method in currentTypeProjection.MethodsAndOverloads().Where(x => x.
 #>
 import <#=method#>;
 <# } #>
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequestBuilder(), "BaseCollectionRequestBuilder<"+c.TypeName()+", "+c.TypeRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+", "+c.TypeCollectionRequest()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequestBuilder(), "BaseCollectionRequestBuilder<"+c.TypeName()+", "+c.TypeRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+", "+c.TypeCollectionRequest()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.ClassTypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionResponse.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionResponse.java.tt
@@ -8,6 +8,6 @@
 <# var importNamespace = host.CurrentModel.GetNamespace().AddPrefix(); #>
 import <#=importNamespace#>.http.BaseCollectionResponse;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionResponse(), "BaseCollectionResponse<"+c.TypeName()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionResponse(), "BaseCollectionResponse<"+c.TypeName()+">", null, c.Deprecation?.Description)#>
 
 }

--- a/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesPage.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesPage.java.tt
@@ -17,7 +17,7 @@ import com.google.gson.annotations.Expose;
 <# var importNamespace = host.CurrentModel.GetNamespace().AddPrefix(); #>
 import <#=importNamespace#>.http.BaseCollectionPage;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesPage(), "BaseCollectionPage<" + c.TypeName()+", "+c.TypeCollectionWithReferencesRequestBuilder()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesPage(), "BaseCollectionPage<" + c.TypeName()+", "+c.TypeCollectionWithReferencesRequestBuilder()+">", null, c.Deprecation?.Description)#>
 
     /**
      * A collection page for <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequest.java.tt
@@ -21,7 +21,7 @@ import <#=importNamespace#>.http.BaseCollectionWithReferencesRequest;
 import <#=importNamespace#>.http.BaseCollectionWithReferencesRequestBuilder;
 import <#=importNamespace#>.concurrency.IExecutors;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesRequest(), "BaseCollectionWithReferencesRequest<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionRequest()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesRequest(), "BaseCollectionWithReferencesRequest<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionRequest()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
@@ -11,7 +11,7 @@ import <#=importNamespace#>.http.BaseCollectionWithReferencesRequestBuilder;
 import <#=importNamespace#>.core.IBaseClient;
 <# var mainNamespace = host.CurrentNamespace(); #>
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesRequestBuilder(), "BaseCollectionWithReferencesRequestBuilder<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionReferenceRequest()+", "+c.TypeCollectionReferenceRequestBuilder()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionWithReferencesRequestBuilder(), "BaseCollectionWithReferencesRequestBuilder<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+", "+c.TypeWithReferencesRequestBuilder()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionWithReferencesPage()+", "+c.TypeCollectionReferenceRequest()+", "+c.TypeCollectionReferenceRequestBuilder()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for this collection of <#=c.ClassTypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityReferenceRequest.java.tt
@@ -14,7 +14,7 @@ import <#=importNamespace#>.core.IBaseClient;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonObject;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeReferenceRequest(), "BaseReferenceRequest<"+c.TypeName()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeReferenceRequest(), "BaseReferenceRequest<"+c.TypeName()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityReferenceRequestBuilder.java.tt
@@ -11,7 +11,7 @@
 import <#=importNamespace#>.http.BaseReferenceRequestBuilder;
 import <#=importNamespace#>.core.IBaseClient;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeReferenceRequestBuilder(), "BaseReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeReferenceRequest()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeReferenceRequestBuilder(), "BaseReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeReferenceRequest()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityRequest.java.tt
@@ -10,7 +10,7 @@ import <#=importNamespace#>.core.IBaseClient;
 import <#=importNamespace#>.http.BaseRequest;
 import <#=importNamespace#>.http.HttpMethod;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeRequest(), "BaseRequest<"+c.TypeName()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeRequest(), "BaseRequest<"+c.TypeName()+">", null, c.Deprecation?.Description)#>
 	<# if (c.AsOdcmClass() != null && c.AsOdcmClass().Derived.Any()) { #>
 
     /**

--- a/Templates/Java/requests_extensions/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityRequestBuilder.java.tt
@@ -180,7 +180,13 @@ if (c.AsOdcmClass() != null)
 <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
 <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeCollectionRequestBuilder()#> <#=sanitizedMethod#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeCollectionRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);
@@ -193,7 +199,13 @@ if (c.AsOdcmClass() != null)
 <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
 <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeRequestBuilder()#> <#=sanitizedMethod#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);

--- a/Templates/Java/requests_extensions/BaseEntityRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityRequestBuilder.java.tt
@@ -15,7 +15,7 @@ foreach (var method in c.AsOdcmClass().MethodsAndOverloads().Where(x => !x.IsBou
 import <#=method#>;
 <# } #>
 
-<#=TypeHelperJava.CreateClassDef(c.TypeRequestBuilder(), "BaseRequestBuilder<"+c.TypeName()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeRequestBuilder(), "BaseRequestBuilder<"+c.TypeName()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityStreamRequestBuilder.java.tt
@@ -136,7 +136,13 @@ if (c.AsOdcmClass() != null)
      <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
      <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeCollectionRequestBuilder()#> <#=method.MethodName().ToLowerFirstChar()#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeCollectionRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);
@@ -150,7 +156,13 @@ if (c.AsOdcmClass() != null)
      <#if(method.MethodHasParameters()) { #>
      * @param parameters the parameters for the service method
      <# } #>
+<# if(method.IsDeprecated) {#>
+     * @deprecated <#= method?.Deprecation?.Description #>
+<# } #>
      */
+<# if(method.IsDeprecated) {#>
+    @Deprecated
+<# } #>
     @Nonnull
     public <#=method.TypeRequestBuilder()#> <#=method.MethodName().ToLowerFirstChar()#>(<#if(method.MethodHasParameters()) { #>@Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         return new <#=method.TypeRequestBuilder()#>(getRequestUrlWithAdditionalSegment("<#=method.MethodFullName()#>"), getClient(), null<#if(method.MethodHasParameters()) { #>, parameters<# } #>);

--- a/Templates/Java/requests_extensions/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityStreamRequestBuilder.java.tt
@@ -16,7 +16,7 @@ foreach (var method in c.AsOdcmClass().MethodsAndOverloads().Where(x => !x.IsBou
 import <#=method#>;
 <# } #>
 
-<#=TypeHelperJava.CreateClassDef(c.TypeStreamRequestBuilder(), "BaseRequestBuilder<InputStream>")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeStreamRequestBuilder(), "BaseRequestBuilder<InputStream>", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityWithReferenceRequest.java.tt
@@ -13,7 +13,7 @@ import <#=importNamespace#>.http.HttpMethod;
 import <#=importNamespace#>.core.IBaseClient;
 import <#=importNamespace#>.serializer.IJsonBackedObject;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeWithReferencesRequest(), "BaseWithReferenceRequest<"+c.ClassTypeName()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeWithReferencesRequest(), "BaseWithReferenceRequest<"+c.ClassTypeName()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseEntityWithReferenceRequestBuilder.java.tt
@@ -10,7 +10,7 @@
 import <#=importNamespace#>.http.BaseWithReferenceRequestBuilder;
 import <#=importNamespace#>.core.IBaseClient;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeWithReferencesRequestBuilder(), "BaseWithReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeWithReferencesRequestBuilder(), "BaseWithReferenceRequestBuilder<"+c.TypeName()+", "+c.TypeWithReferencesRequest()+", "+c.TypeReferenceRequestBuilder()+">", null, c.Deprecation?.Description)#>
 
     /**
      * The request builder for the <#=c.TypeName()#>

--- a/Templates/Java/requests_extensions/BaseMethodCollectionPage.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionPage.java.tt
@@ -5,11 +5,11 @@
 <#host.TemplateName = c.TypeCollectionPage();#>
 <#=writer.WriteHeader()#>
 <#=host.CreatePackageDef()#>
-<# 
-	/** 
+<#
+	/**
 	* Manual check for deltaLink
-	* This allows for a user to get the delta link URL with which 
-	* to make future delta query calls to the service. Since it is 
+	* This allows for a user to get the delta link URL with which
+	* to make future delta query calls to the service. Since it is
 	* not surfaced in the additionalDataManager, we add it manually
 	* to the object for easy access.
 	*/
@@ -30,7 +30,7 @@ import <#=importNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.Type
 import <#=importNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCollectionPage()#>;
 import <#=importNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCollectionResponse()#>;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionPage(), (deltaPage ? "DeltaCollectionPage" : "BaseCollectionPage")+"<"+ (c.AsOdcmMethod().ReturnType ?? c.AsOdcmMethod().Class).TypeName() + ", "+c.TypeCollectionRequestBuilder()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionPage(), (deltaPage ? "DeltaCollectionPage" : "BaseCollectionPage")+"<"+ (c.AsOdcmMethod().ReturnType ?? c.AsOdcmMethod().Class).TypeName() + ", "+c.TypeCollectionRequestBuilder()+">", null, c.Deprecation?.Description)#>
 
     /**
      * A collection page for <#=(c as OdcmMethod).OdcmMethodReturnType()#>.

--- a/Templates/Java/requests_extensions/BaseMethodCollectionRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionRequest.java.tt
@@ -36,7 +36,7 @@ if (c.AsOdcmMethod().IsAction()) {
 import <#=importNamespace#>.http.<#=baseType#>;
 import <#=importNamespace#>.concurrency.IExecutors;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequest(), baseType +"<" + (c as OdcmMethod).OdcmMethodReturnType()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequest(), baseType +"<" + (c as OdcmMethod).OdcmMethodReturnType()+", "+c.TypeCollectionResponse()+", "+c.TypeCollectionPage()+">", null, c.Deprecation?.Description)#>
 
 <# if (c.AsOdcmMethod().IsAction() && c.AsOdcmMethod().MethodHasParameters()) { #>
 
@@ -271,7 +271,7 @@ import <#=importNamespace#>.concurrency.IExecutors;
         addCountOption(true);
         return this;
     }
-<# } #> 
+<# } #>
 <# if (c.GetFeatures().CanUseTop) { #>
 
     /**

--- a/Templates/Java/requests_extensions/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionRequestBuilder.java.tt
@@ -21,7 +21,7 @@ import <#=importNamespace#>.core.IBaseClient;
 import <#=importNamespace#>.http.<#= (c.AsOdcmMethod().IsFunction ? "BaseFunctionCollectionRequestBuilder" : "BaseActionCollectionRequestBuilder") #>;
 
 <# bool isAction = !c.AsOdcmMethod().IsFunction; #>
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequestBuilder(), c.GetMethodCollectionRequestBuilderSuperClass())#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequestBuilder(), c.GetMethodCollectionRequestBuilderSuperClass(), null, c.Deprecation?.Description)#>
 
 <#if(c.AsOdcmMethod().MethodHasParameters() && isAction) { #>
     private <#=c.AsOdcmMethod().TypeParameterSet() #> body;

--- a/Templates/Java/requests_extensions/BaseMethodCollectionResponse.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodCollectionResponse.java.tt
@@ -15,7 +15,7 @@ import <#=importNamespace#>.serializer.ISerializer;
 <# } #>
 import <#=importNamespace#>.http.BaseCollectionResponse;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeCollectionResponse(), "BaseCollectionResponse<"+(c as OdcmMethod).OdcmMethodReturnType()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeCollectionResponse(), "BaseCollectionResponse<"+(c as OdcmMethod).OdcmMethodReturnType()+">", null, c.Deprecation?.Description)#>
 
 <# if (((c as OdcmMethod).ReturnType is OdcmPrimitiveType) || ((c as OdcmMethod).ReturnType is OdcmEnum) ) { #>
     /**

--- a/Templates/Java/requests_extensions/BaseMethodRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodRequest.java.tt
@@ -19,7 +19,7 @@ import <#=importNamespace#>.core.IBaseClient;
 import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.AsOdcmMethod().TypeParameterSet()#>;
 <# } #>
 
-<#=TypeHelperJava.CreateClassDef(c.TypeRequest(), "BaseRequest<"+c.ReturnType()+">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeRequest(), "BaseRequest<"+c.ReturnType()+">", null, c.Deprecation?.Description)#>
     /**
      * The request for this <#=c.TypeName()#>
      *

--- a/Templates/Java/requests_extensions/BaseMethodRequestBuilder.java.tt
+++ b/Templates/Java/requests_extensions/BaseMethodRequestBuilder.java.tt
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 <# bool isAction = !c.AsOdcmMethod().IsFunction; #>
-<#=TypeHelperJava.CreateClassDef(c.TypeRequestBuilder(), c.GetMethodRequestBuilderSuperClass())#>
+<#=TypeHelperJava.CreateClassDef(c.TypeRequestBuilder(), c.GetMethodRequestBuilderSuperClass(), null, c.Deprecation?.Description)#>
 
 <#if(c.AsOdcmMethod().MethodHasParameters() && isAction) { #>
     private <#=c.AsOdcmMethod().TypeParameterSet() #> body;
@@ -89,7 +89,7 @@ import javax.annotation.Nonnull;
     }#>
         return request;
     }
-<# 
+<#
 var m = c as OdcmMethod;
 if(m != null && m.IsComposable && m.ReturnType != null && m.ReturnType is OdcmClass) {
     foreach(var prop in m.ReturnType.AsOdcmClass().NavigationProperties(true))

--- a/Templates/Java/requests_extensions/BaseStreamRequest.java.tt
+++ b/Templates/Java/requests_extensions/BaseStreamRequest.java.tt
@@ -11,7 +11,7 @@ import <#=importNamespace#>.http.BaseStreamRequest;
 
 import java.io.InputStream;
 
-<#=TypeHelperJava.CreateClassDef(c.TypeStreamRequest(), "BaseStreamRequest<" + c.ClassTypeName() + ">")#>
+<#=TypeHelperJava.CreateClassDef(c.TypeStreamRequest(), "BaseStreamRequest<" + c.ClassTypeName() + ">", null, c.Deprecation?.Description)#>
 
     /**
      * The request for the <#=c.TypeName()#>

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 
         public static string GetDeprecationString(this OdcmObject instance)
         {
-            if (instance.Deprecation != null)
+            if (instance.IsDeprecated)
             {
                 return String.Format(DeprecationString, instance.Deprecation.Description);
             }

--- a/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
@@ -1071,11 +1071,11 @@ import javax.annotation.Nonnull;";
             var format =
     @"    /**
      * The {0}.
-     * {1}
+     * {1}{2}
      */
-    @SerializedName(value = ""{2}"", alternate = {{""{3}""}})
-    @Expose{4}
-    public {5} {6};
+    @SerializedName(value = ""{3}"", alternate = {{""{4}""}})
+    @Expose{5}{6}
+    public {7} {8};
 
 ";
             foreach (var p in parameters)
@@ -1084,9 +1084,11 @@ import javax.annotation.Nonnull;";
                     format,
                     p.ParamName().SplitCamelCase(),
                     ReplaceInvalidCharacters(p.LongDescription),
+                    (p.IsDeprecated ? $"\r\n     * @deprecated {p.Deprecation?.Description}" : string.Empty),
                     p.ParamName(),
                     p.ParamName().ToUpperFirstChar(),
                     (p.IsNullable() ? "\r\n\t@Nullable" : string.Empty),
+                    (p.IsDeprecated ? "\r\n@Deprecated" : string.Empty),
                     p.ParamType(),
                     p.ParamName().SanitizePropertyName(p).ToLowerFirstChar()
                 );
@@ -1200,19 +1202,19 @@ import javax.annotation.Nonnull;";
             var format =
     @"    /**
      * The {0}.
-     * {1}
-     */
-    @SerializedName(value = ""{2}"", alternate = {{""{3}""}})
-    @Expose{4}
-    public {5} {6};
+     * {1}{2}
+     */{3}
+    @SerializedName(value = ""{4}"", alternate = {{""{5}""}})
+    @Expose{6}
+    public {7} {8};
 
 ";
             var collectionFormat =
     @"    /**
      * The {0}.
-     * {1}
-     */{4}
-    public {5} {6};
+     * {1}{2}
+     */{3}{6}
+    public {7} {8};
 
 ";
 
@@ -1242,6 +1244,8 @@ import javax.annotation.Nonnull;";
                 sb.AppendFormat(propertyFormat,
                     propertyName.SplitCamelCase(),
                     GetSanitizedDescription(property),
+                    property.IsDeprecated ? $"\r\n     * @deprecated {property.Deprecation?.Description}" : string.Empty,
+                    property.IsDeprecated ? "\r\n    @Deprecated" : string.Empty,
                     property.Name,
                     propertyName,
                     (property.IsNullable() ? "\r\n\t@Nullable" : string.Empty),
@@ -1255,17 +1259,17 @@ import javax.annotation.Nonnull;";
         /// name = the name of the class
         /// extends = the class it extends
         /// implements = the interface it extends
-        public static string CreateClassDef(string name, string extends = null, string implements = null)
+        public static string CreateClassDef(string name, string extends, string implements, string deprecationDescription)
         {
-            return CreateClassOrInterface(name, true, extends, implements);
+            return CreateClassOrInterface(name, true, extends, implements, deprecationDescription);
         }
 
-        public static string CreateInterfaceDef(string name, string extends = null)
+        public static string CreateInterfaceDef(string name, string extends, string deprecationDescription)
         {
-            return CreateClassOrInterface(name, false, extends, null);
+            return CreateClassOrInterface(name, false, extends, null, deprecationDescription);
         }
 
-        public static string CreateClassOrInterface(string name, bool isClass = true, string extends = null, string implements = null)
+        public static string CreateClassOrInterface(string name, bool isClass = true, string extends = null, string implements = null, string deprecationDescription = null)
         {
             var extendsStr = string.Empty;
             if (!string.IsNullOrEmpty(extends))
@@ -1282,12 +1286,14 @@ import javax.annotation.Nonnull;";
             var format = @"
 
 /**
- * The {1} for the {0}.
- */
-public {1} {2}{3}{4} {{";
+ * The {1} for the {0}.{2}
+ */{3}
+public {1} {4}{5}{6} {{";
             string declaration = string.Format(format,
                 isClass ? name.SplitCamelCase() : name.SplitCamelCase().Remove(0, 1),
                 isClass ? "class" : "interface",
+                string.IsNullOrEmpty(deprecationDescription) ? string.Empty : $"\r\n * @deprecated {deprecationDescription}",
+                string.IsNullOrEmpty(deprecationDescription) ? string.Empty : "\r\n@Deprecated",
                 name,
                 extendsStr,
                 implementsStr);

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Graph2.CallRecords
         /// <param name="callrecord">The CallRecord object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<CallRecord> PatchAsync(CallRecord callrecord, 
+        public System.Threading.Tasks.Task<CallRecord> PatchAsync(CallRecord callrecord,
             CancellationToken cancellationToken)
         {
             this.Method = "PATCH";
             return this.SendAsync<CallRecord>(callrecord, cancellationToken);
-        }        
+        }
 
         /// <summary>
         /// Issues the PUT request.
@@ -91,12 +91,12 @@ namespace Microsoft.Graph2.CallRecords
         /// <param name="callrecord">The CallRecord object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<CallRecord> PutAsync(CallRecord callrecord, 
+        public System.Threading.Tasks.Task<CallRecord> PutAsync(CallRecord callrecord,
             CancellationToken cancellationToken)
         {
             this.Method = "PUT";
             return this.SendAsync<CallRecord>(callrecord, cancellationToken);
-        }        
+        }
 
         /// <summary>
         /// Adds the specified expand value to the request.

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/DerivedComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/DerivedComplexTypeRequest.java
@@ -22,7 +22,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Derived Complex Type Request.
+ * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
  */
+@Deprecated
 public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
 
@@ -47,7 +49,9 @@ public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest imple
     /**
      * The Enum Property.
      * 
+     * @deprecated enum1 is deprecated. Please use string.
      */
+    @Deprecated
     @SerializedName(value = "enumProperty", alternate = {"EnumProperty"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EmptyBaseComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EmptyBaseComplexTypeRequest.java
@@ -20,7 +20,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Empty Base Complex Type Request.
+ * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
  */
+@Deprecated
 public class EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
     /** the OData type of the object as returned by the service */

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EntityType3.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EntityType3.java
@@ -21,7 +21,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Entity Type3.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3 extends Entity implements IJsonBackedObject {
 
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EntityType3ForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/EntityType3ForwardParameterSet.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 
 /**
  * The class for the Entity Type3Forward Parameter Set.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardParameterSet {
     /**
      * The to Recipients.

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/IBaseGraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/IBaseGraphServiceClient.java
@@ -30,7 +30,9 @@ public interface IBaseGraphServiceClient extends IBaseClient {
      * Gets the collection of TestTypes objects
      *
      * @return the request builder for the collection of TestTypes objects
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     EntityType3CollectionRequestBuilder testTypes();
 
@@ -39,7 +41,9 @@ public interface IBaseGraphServiceClient extends IBaseClient {
      *
      * @param id the id of the TestTypes to retrieve
      * @return the request builder for the TestTypes object
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     EntityType3RequestBuilder testTypes(@Nonnull final String id);
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/ResponseObject.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/ResponseObject.java
@@ -20,7 +20,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Response Object.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class ResponseObject implements IJsonBackedObject {
 
     /** the OData type of the object as returned by the service */

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/SingletonEntity2.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/SingletonEntity2.java
@@ -29,7 +29,9 @@ public class SingletonEntity2 extends Entity implements IJsonBackedObject {
     /**
      * The Test Single Nav2.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @SerializedName(value = "testSingleNav2", alternate = {"TestSingleNav2"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestEntity.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestEntity.java
@@ -49,7 +49,9 @@ public class TestEntity extends Entity implements IJsonBackedObject {
     /**
      * The Test Explicit Nav.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @SerializedName(value = "testExplicitNav", alternate = {"TestExplicitNav"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestType.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestType.java
@@ -29,7 +29,9 @@ public class TestType extends Entity implements IJsonBackedObject {
     /**
      * The Property Alpha.
      * 
+     * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
      */
+    @Deprecated
     @SerializedName(value = "propertyAlpha", alternate = {"PropertyAlpha"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestTypeQueryParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/extensions/TestTypeQueryParameterSet.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 
 /**
  * The class for the Test Type Query Parameter Set.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryParameterSet {
     /**
      * The requests.

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/generated/Enum1.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/generated/Enum1.java
@@ -8,7 +8,9 @@ package com.microsoft.graph.models.generated;
 
 /**
  * The Enum Enum1.
+ * @deprecated enum1 is deprecated. Please use string.
 */
+@Deprecated
 public enum Enum1
 {
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/BaseGraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/BaseGraphServiceClient.java
@@ -55,7 +55,9 @@ public class BaseGraphServiceClient extends BaseClient implements IBaseGraphServ
      * Gets the collection of TestTypes objects
      *
      * @return the request builder for the collection of TestTypes objects
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3CollectionRequestBuilder testTypes() {
         return new EntityType3CollectionRequestBuilder(getServiceRoot() + "/testTypes", this, null);
@@ -66,7 +68,9 @@ public class BaseGraphServiceClient extends BaseClient implements IBaseGraphServ
      *
      * @param id the id of the TestTypes to retrieve
      * @return the request builder for the TestTypes object
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3RequestBuilder testTypes(@Nonnull final String id) {
         return new EntityType3RequestBuilder(getServiceRoot() + "/testTypes/" + id, this, null);

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionPage.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionPage.java
@@ -15,7 +15,9 @@ import com.microsoft.graph.http.BaseCollectionPage;
 
 /**
  * The class for the Entity Type3Collection Page.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionPage extends BaseCollectionPage<EntityType3, EntityType3CollectionRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
@@ -33,7 +33,9 @@ import com.microsoft.graph.http.ReferenceRequestBody;
 
 /**
  * The class for the Entity Type3Collection Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionReferenceRequest extends BaseCollectionWithReferencesRequest<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionWithReferencesRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Collection Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionReferenceRequestBuilder extends BaseCollectionReferenceRequestBuilder<EntityType3, EntityType3ReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionReferenceRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
@@ -28,7 +28,9 @@ import com.microsoft.graph.requests.extensions.EntityType3CollectionRequest;
 
 /**
  * The class for the Entity Type3Collection Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionRequest extends BaseEntityCollectionRequest<EntityType3, EntityType3CollectionResponse, EntityType3CollectionPage> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionRequestBuilder.java
@@ -27,7 +27,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Collection Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionRequestBuilder extends BaseCollectionRequestBuilder<EntityType3, EntityType3RequestBuilder, EntityType3CollectionResponse, EntityType3CollectionPage, EntityType3CollectionRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionResponse.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionResponse.java
@@ -12,7 +12,9 @@ import com.microsoft.graph.http.BaseCollectionResponse;
 
 /**
  * The class for the Entity Type3Collection Response.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionResponse extends BaseCollectionResponse<EntityType3> {
 
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesPage.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesPage.java
@@ -30,7 +30,9 @@ import com.microsoft.graph.http.BaseCollectionPage;
 
 /**
  * The class for the Entity Type3Collection With References Page.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesPage extends BaseCollectionPage<EntityType3, EntityType3CollectionWithReferencesRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
@@ -34,7 +34,9 @@ import com.microsoft.graph.concurrency.IExecutors;
 
 /**
  * The class for the Entity Type3Collection With References Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesRequest extends BaseCollectionWithReferencesRequest<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionWithReferencesRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Collection With References Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesRequestBuilder extends BaseCollectionWithReferencesRequestBuilder<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionReferenceRequest, EntityType3CollectionReferenceRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
@@ -21,7 +21,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Forward Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardRequest extends BaseRequest<Void> {
     /**
      * The request for this EntityType3Forward

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ForwardRequestBuilder.java
@@ -19,7 +19,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Entity Type3Forward Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<EntityType3> {
 
     private EntityType3ForwardParameterSet body;

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
@@ -27,7 +27,9 @@ import com.google.gson.JsonObject;
 
 /**
  * The class for the Entity Type3Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ReferenceRequest extends BaseReferenceRequest<EntityType3> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ReferenceRequestBuilder extends BaseReferenceRequestBuilder<EntityType3, EntityType3ReferenceRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3Request.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.http.HttpMethod;
 
 /**
  * The class for the Entity Type3Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3Request extends BaseRequest<EntityType3> {
 	
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3RequestBuilder.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
 
     /**
@@ -65,7 +67,9 @@ public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
      * Gets a builder to execute the method
      * @return the request builder
      * @param parameters the parameters for the service method
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3ForwardRequestBuilder forward(@Nonnull final EntityType3ForwardParameterSet parameters) {
         return new EntityType3ForwardRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.forward"), getClient(), null, parameters);

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
@@ -26,7 +26,9 @@ import com.microsoft.graph.serializer.IJsonBackedObject;
 
 /**
  * The class for the Entity Type3With Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3WithReferenceRequest extends BaseWithReferenceRequest<EntityType3> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequestBuilder.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3With Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3WithReferenceRequestBuilder extends BaseWithReferenceRequestBuilder<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionPage.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionPage.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.requests.extensions.TestTypeQueryCollectionResponse;
 
 /**
  * The class for the Test Type Query Collection Page.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionPage extends BaseCollectionPage<ResponseObject, TestTypeQueryCollectionRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
@@ -28,7 +28,9 @@ import com.microsoft.graph.concurrency.IExecutors;
 
 /**
  * The class for the Test Type Query Collection Request.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionRequest extends BaseActionCollectionRequest<ResponseObject, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage> {
 
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequestBuilder.java
@@ -27,7 +27,9 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
 
 /**
  * The class for the Test Type Query Collection Request Builder.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<ResponseObject, TestTypeQueryCollectionRequestBuilder, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage, TestTypeQueryCollectionRequest> {
 
     private TestTypeQueryParameterSet body;

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionResponse.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionResponse.java
@@ -15,7 +15,9 @@ import com.microsoft.graph.http.BaseCollectionResponse;
 
 /**
  * The class for the Test Type Query Collection Response.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionResponse extends BaseCollectionResponse<ResponseObject> {
 
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/extensions/TestTypeRequestBuilder.java
@@ -65,7 +65,9 @@ public class TestTypeRequestBuilder extends BaseRequestBuilder<TestType> {
      * Gets a builder to execute the method
      * @return the request builder collection
      * @param parameters the parameters for the service method
+     * @deprecated responseObject is deprecated. Please use something else.
      */
+    @Deprecated
     @Nonnull
     public TestTypeQueryCollectionRequestBuilder query(@Nonnull final TestTypeQueryParameterSet parameters) {
         return new TestTypeQueryCollectionRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.query"), getClient(), null, parameters);

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/extensions/Segment.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/extensions/Segment.java
@@ -91,7 +91,9 @@ public class Segment extends Entity implements IJsonBackedObject {
     /**
      * The Ref Types.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
 	@Nullable
     public EntityType3CollectionPage refTypes;
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/DerivedComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/DerivedComplexTypeRequest.java
@@ -22,7 +22,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Derived Complex Type Request.
+ * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
  */
+@Deprecated
 public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
 
@@ -47,7 +49,9 @@ public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest imple
     /**
      * The Enum Property.
      * 
+     * @deprecated enum1 is deprecated. Please use string.
      */
+    @Deprecated
     @SerializedName(value = "enumProperty", alternate = {"EnumProperty"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EmptyBaseComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EmptyBaseComplexTypeRequest.java
@@ -20,7 +20,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Empty Base Complex Type Request.
+ * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
  */
+@Deprecated
 public class EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
     /** the OData type of the object as returned by the service */

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EntityType3.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EntityType3.java
@@ -21,7 +21,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Entity Type3.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3 extends Entity implements IJsonBackedObject {
 
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EntityType3ForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/EntityType3ForwardParameterSet.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 
 /**
  * The class for the Entity Type3Forward Parameter Set.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardParameterSet {
     /**
      * The to Recipients.

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/IBaseGraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/IBaseGraphServiceClient.java
@@ -30,7 +30,9 @@ public interface IBaseGraphServiceClient extends IBaseClient {
      * Gets the collection of TestTypes objects
      *
      * @return the request builder for the collection of TestTypes objects
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     EntityType3CollectionRequestBuilder testTypes();
 
@@ -39,7 +41,9 @@ public interface IBaseGraphServiceClient extends IBaseClient {
      *
      * @param id the id of the TestTypes to retrieve
      * @return the request builder for the TestTypes object
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     EntityType3RequestBuilder testTypes(@Nonnull final String id);
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/ResponseObject.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/ResponseObject.java
@@ -20,7 +20,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Response Object.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class ResponseObject implements IJsonBackedObject {
 
     /** the OData type of the object as returned by the service */

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/SingletonEntity2.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/SingletonEntity2.java
@@ -29,7 +29,9 @@ public class SingletonEntity2 extends Entity implements IJsonBackedObject {
     /**
      * The Test Single Nav2.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @SerializedName(value = "testSingleNav2", alternate = {"TestSingleNav2"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestEntity.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestEntity.java
@@ -49,7 +49,9 @@ public class TestEntity extends Entity implements IJsonBackedObject {
     /**
      * The Test Explicit Nav.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @SerializedName(value = "testExplicitNav", alternate = {"TestExplicitNav"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestType.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestType.java
@@ -29,7 +29,9 @@ public class TestType extends Entity implements IJsonBackedObject {
     /**
      * The Property Alpha.
      * 
+     * @deprecated emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.
      */
+    @Deprecated
     @SerializedName(value = "propertyAlpha", alternate = {"PropertyAlpha"})
     @Expose
 	@Nullable

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestTypeQueryParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/extensions/TestTypeQueryParameterSet.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 
 /**
  * The class for the Test Type Query Parameter Set.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryParameterSet {
     /**
      * The requests.

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/generated/Enum1.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/generated/Enum1.java
@@ -8,7 +8,9 @@ package com.microsoft.graph.models.generated;
 
 /**
  * The Enum Enum1.
+ * @deprecated enum1 is deprecated. Please use string.
 */
+@Deprecated
 public enum Enum1
 {
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/BaseGraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/BaseGraphServiceClient.java
@@ -55,7 +55,9 @@ public class BaseGraphServiceClient extends BaseClient implements IBaseGraphServ
      * Gets the collection of TestTypes objects
      *
      * @return the request builder for the collection of TestTypes objects
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3CollectionRequestBuilder testTypes() {
         return new EntityType3CollectionRequestBuilder(getServiceRoot() + "/testTypes", this, null);
@@ -66,7 +68,9 @@ public class BaseGraphServiceClient extends BaseClient implements IBaseGraphServ
      *
      * @param id the id of the TestTypes to retrieve
      * @return the request builder for the TestTypes object
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3RequestBuilder testTypes(@Nonnull final String id) {
         return new EntityType3RequestBuilder(getServiceRoot() + "/testTypes/" + id, this, null);

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionPage.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionPage.java
@@ -15,7 +15,9 @@ import com.microsoft.graph.http.BaseCollectionPage;
 
 /**
  * The class for the Entity Type3Collection Page.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionPage extends BaseCollectionPage<EntityType3, EntityType3CollectionRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequest.java
@@ -33,7 +33,9 @@ import com.microsoft.graph.http.ReferenceRequestBody;
 
 /**
  * The class for the Entity Type3Collection Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionReferenceRequest extends BaseCollectionWithReferencesRequest<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionWithReferencesRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionReferenceRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Collection Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionReferenceRequestBuilder extends BaseCollectionReferenceRequestBuilder<EntityType3, EntityType3ReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionReferenceRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionRequest.java
@@ -28,7 +28,9 @@ import com.microsoft.graph.requests.extensions.EntityType3CollectionRequest;
 
 /**
  * The class for the Entity Type3Collection Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionRequest extends BaseEntityCollectionRequest<EntityType3, EntityType3CollectionResponse, EntityType3CollectionPage> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionRequestBuilder.java
@@ -27,7 +27,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Collection Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionRequestBuilder extends BaseCollectionRequestBuilder<EntityType3, EntityType3RequestBuilder, EntityType3CollectionResponse, EntityType3CollectionPage, EntityType3CollectionRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionResponse.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionResponse.java
@@ -12,7 +12,9 @@ import com.microsoft.graph.http.BaseCollectionResponse;
 
 /**
  * The class for the Entity Type3Collection Response.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionResponse extends BaseCollectionResponse<EntityType3> {
 
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesPage.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesPage.java
@@ -30,7 +30,9 @@ import com.microsoft.graph.http.BaseCollectionPage;
 
 /**
  * The class for the Entity Type3Collection With References Page.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesPage extends BaseCollectionPage<EntityType3, EntityType3CollectionWithReferencesRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequest.java
@@ -34,7 +34,9 @@ import com.microsoft.graph.concurrency.IExecutors;
 
 /**
  * The class for the Entity Type3Collection With References Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesRequest extends BaseCollectionWithReferencesRequest<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionWithReferencesRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3CollectionWithReferencesRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Collection With References Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3CollectionWithReferencesRequestBuilder extends BaseCollectionWithReferencesRequestBuilder<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder, EntityType3WithReferenceRequestBuilder, EntityType3CollectionResponse, EntityType3CollectionWithReferencesPage, EntityType3CollectionReferenceRequest, EntityType3CollectionReferenceRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ForwardRequest.java
@@ -21,7 +21,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Forward Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardRequest extends BaseRequest<Void> {
     /**
      * The request for this EntityType3Forward

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ForwardRequestBuilder.java
@@ -19,7 +19,9 @@ import javax.annotation.Nonnull;
 
 /**
  * The class for the Entity Type3Forward Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<EntityType3> {
 
     private EntityType3ForwardParameterSet body;

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequest.java
@@ -27,7 +27,9 @@ import com.google.gson.JsonObject;
 
 /**
  * The class for the Entity Type3Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ReferenceRequest extends BaseReferenceRequest<EntityType3> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3ReferenceRequestBuilder.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3ReferenceRequestBuilder extends BaseReferenceRequestBuilder<EntityType3, EntityType3ReferenceRequest> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3Request.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.http.HttpMethod;
 
 /**
  * The class for the Entity Type3Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3Request extends BaseRequest<EntityType3> {
 	
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3RequestBuilder.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.models.extensions.EntityType3ForwardParameterSet;
 
 /**
  * The class for the Entity Type3Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
 
     /**
@@ -65,7 +67,9 @@ public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
      * Gets a builder to execute the method
      * @return the request builder
      * @param parameters the parameters for the service method
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
     @Nonnull
     public EntityType3ForwardRequestBuilder forward(@Nonnull final EntityType3ForwardParameterSet parameters) {
         return new EntityType3ForwardRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.forward"), getClient(), null, parameters);

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequest.java
@@ -26,7 +26,9 @@ import com.microsoft.graph.serializer.IJsonBackedObject;
 
 /**
  * The class for the Entity Type3With Reference Request.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3WithReferenceRequest extends BaseWithReferenceRequest<EntityType3> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/EntityType3WithReferenceRequestBuilder.java
@@ -23,7 +23,9 @@ import com.microsoft.graph.core.IBaseClient;
 
 /**
  * The class for the Entity Type3With Reference Request Builder.
+ * @deprecated entityType3 is deprecated. Please use singletonEntity1.
  */
+@Deprecated
 public class EntityType3WithReferenceRequestBuilder extends BaseWithReferenceRequestBuilder<EntityType3, EntityType3WithReferenceRequest, EntityType3ReferenceRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionPage.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionPage.java
@@ -24,7 +24,9 @@ import com.microsoft.graph.requests.extensions.TestTypeQueryCollectionResponse;
 
 /**
  * The class for the Test Type Query Collection Page.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionPage extends BaseCollectionPage<ResponseObject, TestTypeQueryCollectionRequestBuilder> {
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequest.java
@@ -28,7 +28,9 @@ import com.microsoft.graph.concurrency.IExecutors;
 
 /**
  * The class for the Test Type Query Collection Request.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionRequest extends BaseActionCollectionRequest<ResponseObject, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage> {
 
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionRequestBuilder.java
@@ -27,7 +27,9 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
 
 /**
  * The class for the Test Type Query Collection Request Builder.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<ResponseObject, TestTypeQueryCollectionRequestBuilder, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage, TestTypeQueryCollectionRequest> {
 
     private TestTypeQueryParameterSet body;

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionResponse.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeQueryCollectionResponse.java
@@ -15,7 +15,9 @@ import com.microsoft.graph.http.BaseCollectionResponse;
 
 /**
  * The class for the Test Type Query Collection Response.
+ * @deprecated responseObject is deprecated. Please use something else.
  */
+@Deprecated
 public class TestTypeQueryCollectionResponse extends BaseCollectionResponse<ResponseObject> {
 
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/extensions/TestTypeRequestBuilder.java
@@ -65,7 +65,9 @@ public class TestTypeRequestBuilder extends BaseRequestBuilder<TestType> {
      * Gets a builder to execute the method
      * @return the request builder collection
      * @param parameters the parameters for the service method
+     * @deprecated responseObject is deprecated. Please use something else.
      */
+    @Deprecated
     @Nonnull
     public TestTypeQueryCollectionRequestBuilder query(@Nonnull final TestTypeQueryParameterSet parameters) {
         return new TestTypeQueryCollectionRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.query"), getClient(), null, parameters);

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/extensions/Segment.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/extensions/Segment.java
@@ -91,7 +91,9 @@ public class Segment extends Entity implements IJsonBackedObject {
     /**
      * The Ref Types.
      * 
+     * @deprecated entityType3 is deprecated. Please use singletonEntity1.
      */
+    @Deprecated
 	@Nullable
     public EntityType3CollectionPage refTypes;
 


### PR DESCRIPTION
fixes #343 
fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/603
adds support for OData deprecation annotations in java:

> Note: this didn't generate any change in the v1 sdk as we don't have v1 deprecated types. [But here is a diff](https://github.com/microsoftgraph/msgraph-beta-sdk-java/compare/temp/v3-tests?expand=1) (also containing all the v3 changes) for beta. (search for @ deprecated (no space))