### PR TITLE
Close class block unconditionally

### DIFF
--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -198,6 +198,6 @@ namespace <#=@namespace#>
             this.QueryOptions.Add(new <#=queryOptionTypeName#>("$orderby", value));
             return this;
         }
-    }
 <# } #>
+    }
 }


### PR DESCRIPTION
Fixes a bug where the class block is closed only if Sortable is true. Moved the closing curly bracket outside the condition.

This was blocking the generation if we keep the capability annotations from metadata.