### PR TITLE
Make class and interface generation consistent

### DIFF
--- a/Templates/templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -93,6 +93,10 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty, 
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 
+    var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType(((CustomT4Host)Host).CurrentModel);
+    if (serviceNavigationProperty == null)
+        return string.Empty;
+
     var stringBuilder = new StringBuilder();
 
 	stringBuilder.Append(Environment.NewLine);

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/IGroupMembersCollectionReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/IGroupMembersCollectionReferencesRequest.cs
@@ -20,17 +20,5 @@ namespace Microsoft.Graph
     public partial interface IGroupMembersCollectionReferencesRequest : IBaseRequest
     {
         
-        /// <summary>
-        /// Adds the specified DirectoryObject to the collection via POST.
-        /// </summary>
-        /// <param name="directoryObject">The DirectoryObject to add.</param>
-        System.Threading.Tasks.Task AddAsync(DirectoryObject directoryObject);
-
-        /// <summary>
-        /// Adds the specified DirectoryObject to the collection via POST.
-        /// </summary>
-        /// <param name="directoryObject">The DirectoryObject to add.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
-        System.Threading.Tasks.Task AddAsync(DirectoryObject directoryObject, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Fixes #406

This blocks generating AddAsync for a collection reference request, if we can't find the non-contained collection either as a top level entity set or as a contained navigation property of a top level singleton.

I have also considered the option of adding it regardless without checking the condition, because reference request doesn't make sense without AddAsync, but that requires us to resolve where the navigation property is located for building its name. (cc: @ddyett)

I have compared current V1 and Beta outputs for C# and they match exactly with and without the change.

That is expected because when the condition for inconsistency occurs, it causes a build failure. So we used to remove those inconsistencies by XSLT.

@MIchaelMainer, this should unblock current Beta generation after ediscovery name collision is resolved.