### PR TITLE
bugfix/java json memory

### DIFF
--- a/Templates/templates/Java/models/BaseMethodParameterSet.java.tt
+++ b/Templates/templates/Java/models/BaseMethodParameterSet.java.tt
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import <#=importNamespace#>.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -102,7 +101,5 @@ var parameterName = parameter.ParamName().SanitizePropertyName(parameter).ToLowe
         }
 <# } #>
         return result;
-    }
-<#=TypeHelperJava.CreateRawJsonObject(false)#>
     }
 }

--- a/Templates/templates/Java/requests/BaseMethodCollectionResponse.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodCollectionResponse.java.tt
@@ -18,16 +18,7 @@ import <#=importNamespace#>.http.BaseCollectionResponse;
 <#=TypeHelperJava.CreateClassDef(c.TypeCollectionResponse(), "BaseCollectionResponse<"+(c as OdcmMethod).OdcmMethodReturnType()+">", null, c.Deprecation?.Description)#>
 
 <# if (((c as OdcmMethod).ReturnType is OdcmPrimitiveType) || ((c as OdcmMethod).ReturnType is OdcmEnum) ) { #>
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    @Override
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
+<#=TypeHelperJava.CreateRawJsonObject()#>
     }
 <# } #>
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
@@ -1080,48 +1080,16 @@ import javax.annotation.Nonnull;";
             return sb.ToString();
         }
 
-        public static string CreateRawJsonObject(bool overrideGetSerializerMethod = true)
+        public static string CreateRawJsonObject()
         {
             return
     @"    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */"+ (overrideGetSerializerMethod ? "\n\t@Override" : "") +@"
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 ";
         }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Call.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Call.java
@@ -36,45 +36,12 @@ public class Call extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/CloudCommunications.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/CloudCommunications.java
@@ -50,45 +50,12 @@ public class CloudCommunications extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("calls")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/DerivedComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/DerivedComplexTypeRequest.java
@@ -59,45 +59,12 @@ public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest imple
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/DirectoryObject.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/DirectoryObject.java
@@ -36,45 +36,12 @@ public class DirectoryObject extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EmptyBaseComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EmptyBaseComplexTypeRequest.java
@@ -41,45 +41,12 @@ public class EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EmptyComplexType.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EmptyComplexType.java
@@ -39,45 +39,12 @@ public class EmptyComplexType implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Endpoint.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Endpoint.java
@@ -36,45 +36,12 @@ public class Endpoint extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Entity.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Entity.java
@@ -48,45 +48,12 @@ public class Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType2.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType2.java
@@ -27,45 +27,12 @@ public class EntityType2 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType3.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType3.java
@@ -29,45 +29,12 @@ public class EntityType3 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType3ForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/EntityType3ForwardParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -209,46 +208,5 @@ public class EntityType3ForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Group.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Group.java
@@ -36,45 +36,12 @@ public class Group extends DirectoryObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("members")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Identity.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Identity.java
@@ -57,45 +57,12 @@ public class Identity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/IdentitySet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/IdentitySet.java
@@ -67,45 +67,12 @@ public class IdentitySet implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/OnenotePage.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/OnenotePage.java
@@ -27,45 +27,12 @@ public class OnenotePage extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/OnenotePageForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/OnenotePageForwardParameterSet.java
@@ -11,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -150,46 +149,5 @@ public class OnenotePageForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/PlannerGroup.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/PlannerGroup.java
@@ -27,45 +27,12 @@ public class PlannerGroup extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Recipient.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Recipient.java
@@ -57,45 +57,12 @@ public class Recipient implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/ResponseObject.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/ResponseObject.java
@@ -41,45 +41,12 @@ public class ResponseObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Schedule.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/Schedule.java
@@ -59,45 +59,12 @@ public class Schedule extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("timesOff")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/SingletonEntity1.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/SingletonEntity1.java
@@ -37,45 +37,12 @@ public class SingletonEntity1 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/SingletonEntity2.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/SingletonEntity2.java
@@ -39,45 +39,12 @@ public class SingletonEntity2 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestEntity.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestEntity.java
@@ -59,45 +59,12 @@ public class TestEntity extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestType.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestType.java
@@ -39,45 +39,12 @@ public class TestType extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestTypeQueryParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TestTypeQueryParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -97,46 +96,5 @@ public class TestTypeQueryParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("requests", requests));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TimeOff.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TimeOff.java
@@ -36,45 +36,12 @@ public class TimeOff extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/TimeOffRequest.java
@@ -36,45 +36,12 @@ public class TimeOffRequest extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/User.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/User.java
@@ -36,45 +36,12 @@ public class User extends DirectoryObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GraphServiceClient.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 import com.microsoft.graph.core.IBaseClient;
 import com.microsoft.graph.core.BaseClient;
 import com.microsoft.graph.http.IHttpProvider;
-import com.microsoft.graph.httpcore.ICoreAuthenticationProvider;
+import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.serializer.ISerializer;
 import okhttp3.OkHttpClient;
@@ -122,7 +122,7 @@ public class GraphServiceClient extends BaseClient implements IBaseClient {
          */
         @Nonnull
         @Override
-        public Builder<httpClientType> authenticationProvider(@Nonnull final ICoreAuthenticationProvider auth) {
+        public Builder<httpClientType> authenticationProvider(@Nonnull final IAuthenticationProvider auth) {
             super.authenticationProvider(auth);
             return this;
         }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/CallRecord.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/CallRecord.java
@@ -134,45 +134,12 @@ public class CallRecord extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("sessions")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/CallRecordItemParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/CallRecordItemParameterSet.java
@@ -11,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -94,46 +93,5 @@ public class CallRecordItemParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("name", name));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ClientUserAgent.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ClientUserAgent.java
@@ -47,45 +47,12 @@ public class ClientUserAgent extends UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/DeviceInfo.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/DeviceInfo.java
@@ -66,45 +66,12 @@ public class DeviceInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Endpoint.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Endpoint.java
@@ -49,45 +49,12 @@ public class Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/FailureInfo.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/FailureInfo.java
@@ -58,45 +58,12 @@ public class FailureInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/FeedbackTokenSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/FeedbackTokenSet.java
@@ -40,45 +40,12 @@ public class FeedbackTokenSet implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Media.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Media.java
@@ -79,45 +79,12 @@ public class Media implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/MediaStream.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/MediaStream.java
@@ -103,45 +103,12 @@ public class MediaStream implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/NetworkInfo.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/NetworkInfo.java
@@ -96,45 +96,12 @@ public class NetworkInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Option.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Option.java
@@ -27,45 +27,12 @@ public class Option extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ParticipantEndpoint.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ParticipantEndpoint.java
@@ -47,45 +47,12 @@ public class ParticipantEndpoint extends Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Photo.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Photo.java
@@ -47,45 +47,12 @@ public class Photo extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Segment.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Segment.java
@@ -126,45 +126,12 @@ public class Segment extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("refTypes")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SegmentForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SegmentForwardParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -207,46 +206,5 @@ public class SegmentForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SegmentTestActionParameterSet.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SegmentTestActionParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -95,46 +94,5 @@ public class SegmentTestActionParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("value", value));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ServiceEndpoint.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ServiceEndpoint.java
@@ -27,45 +27,12 @@ public class ServiceEndpoint extends Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ServiceUserAgent.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/ServiceUserAgent.java
@@ -37,45 +37,12 @@ public class ServiceUserAgent extends UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Session.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/Session.java
@@ -96,45 +96,12 @@ public class Session extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("segments")) {

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SingletonEntity1.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/SingletonEntity1.java
@@ -37,45 +37,12 @@ public class SingletonEntity1 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/UserAgent.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/UserAgent.java
@@ -57,45 +57,12 @@ public class UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/UserFeedback.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/models/UserFeedback.java
@@ -68,45 +68,12 @@ public class UserFeedback implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Call.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Call.java
@@ -36,45 +36,12 @@ public class Call extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/CloudCommunications.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/CloudCommunications.java
@@ -50,45 +50,12 @@ public class CloudCommunications extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("calls")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/DerivedComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/DerivedComplexTypeRequest.java
@@ -59,45 +59,12 @@ public class DerivedComplexTypeRequest extends EmptyBaseComplexTypeRequest imple
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/DirectoryObject.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/DirectoryObject.java
@@ -36,45 +36,12 @@ public class DirectoryObject extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EmptyBaseComplexTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EmptyBaseComplexTypeRequest.java
@@ -41,45 +41,12 @@ public class EmptyBaseComplexTypeRequest implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EmptyComplexType.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EmptyComplexType.java
@@ -39,45 +39,12 @@ public class EmptyComplexType implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Endpoint.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Endpoint.java
@@ -36,45 +36,12 @@ public class Endpoint extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Entity.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Entity.java
@@ -48,45 +48,12 @@ public class Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType2.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType2.java
@@ -27,45 +27,12 @@ public class EntityType2 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType3.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType3.java
@@ -29,45 +29,12 @@ public class EntityType3 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType3ForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/EntityType3ForwardParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -209,46 +208,5 @@ public class EntityType3ForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Group.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Group.java
@@ -36,45 +36,12 @@ public class Group extends DirectoryObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("members")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Identity.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Identity.java
@@ -57,45 +57,12 @@ public class Identity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/IdentitySet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/IdentitySet.java
@@ -67,45 +67,12 @@ public class IdentitySet implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/OnenotePage.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/OnenotePage.java
@@ -27,45 +27,12 @@ public class OnenotePage extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/OnenotePageForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/OnenotePageForwardParameterSet.java
@@ -11,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -150,46 +149,5 @@ public class OnenotePageForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/PlannerGroup.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/PlannerGroup.java
@@ -27,45 +27,12 @@ public class PlannerGroup extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Recipient.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Recipient.java
@@ -57,45 +57,12 @@ public class Recipient implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/ResponseObject.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/ResponseObject.java
@@ -41,45 +41,12 @@ public class ResponseObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Schedule.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/Schedule.java
@@ -59,45 +59,12 @@ public class Schedule extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("timesOff")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/SingletonEntity1.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/SingletonEntity1.java
@@ -37,45 +37,12 @@ public class SingletonEntity1 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/SingletonEntity2.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/SingletonEntity2.java
@@ -39,45 +39,12 @@ public class SingletonEntity2 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestEntity.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestEntity.java
@@ -59,45 +59,12 @@ public class TestEntity extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestType.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestType.java
@@ -39,45 +39,12 @@ public class TestType extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestTypeQueryParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TestTypeQueryParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -97,46 +96,5 @@ public class TestTypeQueryParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("requests", requests));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TimeOff.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TimeOff.java
@@ -36,45 +36,12 @@ public class TimeOff extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/TimeOffRequest.java
@@ -36,45 +36,12 @@ public class TimeOffRequest extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/User.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/User.java
@@ -36,45 +36,12 @@ public class User extends DirectoryObject implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GraphServiceClient.java
@@ -19,7 +19,7 @@ import javax.annotation.Nonnull;
 import com.microsoft.graph.core.IBaseClient;
 import com.microsoft.graph.core.BaseClient;
 import com.microsoft.graph.http.IHttpProvider;
-import com.microsoft.graph.httpcore.ICoreAuthenticationProvider;
+import com.microsoft.graph.authentication.IAuthenticationProvider;
 import com.microsoft.graph.logger.ILogger;
 import com.microsoft.graph.serializer.ISerializer;
 import okhttp3.OkHttpClient;
@@ -122,7 +122,7 @@ public class GraphServiceClient extends BaseClient implements IBaseClient {
          */
         @Nonnull
         @Override
-        public Builder<httpClientType> authenticationProvider(@Nonnull final ICoreAuthenticationProvider auth) {
+        public Builder<httpClientType> authenticationProvider(@Nonnull final IAuthenticationProvider auth) {
             super.authenticationProvider(auth);
             return this;
         }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/CallRecord.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/CallRecord.java
@@ -134,45 +134,12 @@ public class CallRecord extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("sessions")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/CallRecordItemParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/CallRecordItemParameterSet.java
@@ -11,7 +11,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -94,46 +93,5 @@ public class CallRecordItemParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("name", name));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ClientUserAgent.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ClientUserAgent.java
@@ -47,45 +47,12 @@ public class ClientUserAgent extends UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/DeviceInfo.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/DeviceInfo.java
@@ -66,45 +66,12 @@ public class DeviceInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Endpoint.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Endpoint.java
@@ -49,45 +49,12 @@ public class Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/FailureInfo.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/FailureInfo.java
@@ -58,45 +58,12 @@ public class FailureInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/FeedbackTokenSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/FeedbackTokenSet.java
@@ -40,45 +40,12 @@ public class FeedbackTokenSet implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Media.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Media.java
@@ -79,45 +79,12 @@ public class Media implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/MediaStream.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/MediaStream.java
@@ -103,45 +103,12 @@ public class MediaStream implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/NetworkInfo.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/NetworkInfo.java
@@ -96,45 +96,12 @@ public class NetworkInfo implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Option.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Option.java
@@ -27,45 +27,12 @@ public class Option extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ParticipantEndpoint.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ParticipantEndpoint.java
@@ -47,45 +47,12 @@ public class ParticipantEndpoint extends Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Photo.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Photo.java
@@ -47,45 +47,12 @@ public class Photo extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Segment.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Segment.java
@@ -126,45 +126,12 @@ public class Segment extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("refTypes")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SegmentForwardParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SegmentForwardParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -207,46 +206,5 @@ public class SegmentForwardParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("comment", comment));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SegmentTestActionParameterSet.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SegmentTestActionParameterSet.java
@@ -12,7 +12,6 @@ import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import com.google.gson.JsonObject;
-import com.microsoft.graph.serializer.ISerializer;
 import java.util.EnumSet;
 import java.util.ArrayList;
 
@@ -95,46 +94,5 @@ public class SegmentTestActionParameterSet {
             result.add(new com.microsoft.graph.options.FunctionOption("value", value));
         }
         return result;
-    }
-    /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
-     * Sets the raw JSON object
-     *
-     * @param serializer the serializer
-     * @param json the JSON object to set this object to
-     */
-    public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
-
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ServiceEndpoint.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ServiceEndpoint.java
@@ -27,45 +27,12 @@ public class ServiceEndpoint extends Endpoint implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ServiceUserAgent.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/ServiceUserAgent.java
@@ -37,45 +37,12 @@ public class ServiceUserAgent extends UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Session.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/Session.java
@@ -96,45 +96,12 @@ public class Session extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
 
         if (json.has("segments")) {

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SingletonEntity1.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/SingletonEntity1.java
@@ -37,45 +37,12 @@ public class SingletonEntity1 extends Entity implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/UserAgent.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/UserAgent.java
@@ -57,45 +57,12 @@ public class UserAgent implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/UserFeedback.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/models/UserFeedback.java
@@ -68,45 +68,12 @@ public class UserFeedback implements IJsonBackedObject {
 
 
     /**
-     * The raw representation of this class
-     */
-    private JsonObject rawObject;
-
-    /**
-     * The serializer
-     */
-    private ISerializer serializer;
-
-    /**
-     * Gets the raw representation of this class
-     *
-     * @return the raw representation of this class
-     */
-    @Nullable
-    public JsonObject getRawObject() {
-        return rawObject;
-    }
-
-    /**
-     * Gets serializer
-     *
-     * @return the serializer
-     */
-	@Override
-    @Nullable
-    public ISerializer getSerializer() {
-        return serializer;
-    }
-
-    /**
      * Sets the raw JSON object
      *
      * @param serializer the serializer
      * @param json the JSON object to set this object to
      */
     public void setRawObject(@Nonnull final ISerializer serializer, @Nonnull final JsonObject json) {
-        this.serializer = serializer;
-        rawObject = json;
 
     }
 }


### PR DESCRIPTION
- updates test files
- removes getJsonObject and getSerializer from entities to remove memory footprint

related https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/122
generation result https://github.com/microsoftgraph/msgraph-sdk-java/pull/625