### PR TITLE
Unblock beta generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -78,10 +78,10 @@ parameters:
     displayName: Skip metadata capture and clean
     type: boolean
 
-  - name: publishChangesIntoABranch
+  - name: publishChanges
     default: true
     type: boolean
-    displayName: Publish changes into a branch?
+    displayName: Publish changes?
 
 variables:
   buildConfiguration: 'Release'
@@ -95,8 +95,7 @@ variables:
   typewriterExecutable: '$(typewriterDirectory)/Typewriter'
   scriptsDirectory: '$(Build.SourcesDirectory)/MSGraph-SDK-Code-Generator/scripts'
   transformScript: '$(Build.SourcesDirectory)/msgraph-metadata/transforms/csdl/preprocess_csdl.xsl'
-  docsDirectoryV1: '$(Build.SourcesDirectory)/microsoft-graph-docs'
-  docsDirectoryBeta: '$(Build.SourcesDirectory)/microsoft-graph-docs'
+  docsDirectory: '$(Build.SourcesDirectory)/microsoft-graph-docs'
 
   v1Branch: ${{ parameters.v1BranchPrefix }}/$(Build.BuildId)
   betaBranch: ${{ parameters.betaBranchPrefix }}/$(Build.BuildId)
@@ -105,7 +104,7 @@ variables:
   # fatal: cannot lock ref 'refs/heads/beta/pipelinebuild/35157': 'refs/heads/beta' exists; cannot create 'refs/heads/beta/pipelinebuild/35157'
   typeScriptBetaBranch: ${{ parameters.typeScriptBetaBranchPrefix }}/$(Build.BuildId)
 
-  publishChangesIntoABranch: ${{ parameters.publishChangesIntoABranch }}
+  publishChanges: ${{ parameters.publishChanges }}
 
   phpVersion: 7.2
 
@@ -135,7 +134,7 @@ stages:
         endpoint: 'v1.0'
         inputMetadata: $(rawMetadataFileV1)
         outputPath: $(cleanMetadataFileV1OutputPath)
-        docsDirectory: $(docsDirectoryV1)
+        docsDirectory: $(docsDirectory)
         repoName: "msgraph-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileV1)
 

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -95,8 +95,8 @@ variables:
   typewriterExecutable: '$(typewriterDirectory)/Typewriter'
   scriptsDirectory: '$(Build.SourcesDirectory)/MSGraph-SDK-Code-Generator/scripts'
   transformScript: '$(Build.SourcesDirectory)/msgraph-metadata/transforms/csdl/preprocess_csdl.xsl'
-  docsDirectoryV1: '$(Build.SourcesDirectory)/microsoft-graph-docs/api-reference/v1.0'
-  docsDirectoryBeta: '$(Build.SourcesDirectory)/microsoft-graph-docs/api-reference/beta'
+  docsDirectoryV1: '$(Build.SourcesDirectory)/microsoft-graph-docs'
+  docsDirectoryBeta: '$(Build.SourcesDirectory)/microsoft-graph-docs'
 
   v1Branch: ${{ parameters.v1BranchPrefix }}/$(Build.BuildId)
   betaBranch: ${{ parameters.betaBranchPrefix }}/$(Build.BuildId)

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -134,7 +134,6 @@ stages:
         endpoint: 'v1.0'
         inputMetadata: $(rawMetadataFileV1)
         outputPath: $(cleanMetadataFileV1OutputPath)
-        docsDirectory: $(docsDirectory)
         repoName: "msgraph-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileV1)
 
@@ -152,7 +151,6 @@ stages:
         endpoint: 'beta'
         inputMetadata: $(rawMetadataFileBeta)
         outputPath: $(cleanMetadataFileBetaOutputPath)
-        docsDirectory: $(docsDirectoryBeta)
         repoName: "msgraph-beta-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileBeta)
 

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -65,6 +65,7 @@ steps:
     endpointVersion: ${{ parameters.endpoint }}
   displayName: 'run Typewriter to clean ${{ parameters.endpoint }} metadata'
 
+# publish metadata as an artifact
 - task: CopyFiles@2
   inputs:
     sourceFolder: ${{ parameters.outputPath }}
@@ -125,6 +126,7 @@ steps:
 
   displayName: push clean ${{ parameters.endpoint }} metadata to msgraph-metadata repo
   env:
-    endpointVersion: ${{ parameters.endpoint }}
+    EndpointVersion: ${{ parameters.endpoint }}
+    PublishChanges: $(publishChanges)
   workingDirectory: '$(Build.SourcesDirectory)/msgraph-metadata'
   enabled: true

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -14,9 +14,6 @@ parameters:
 - name: 'outputPath'
   type: string
   default: $(System.ArtifactsDirectory)
-- name: 'docsDirectory'
-  type: string
-  default: $(docsDirectoryV1)
 - name: 'repoName'
   type: string
   default: "msgraph-sdk-dotnet"
@@ -59,7 +56,7 @@ steps:
     InputMetadataFile: ${{ parameters.inputMetadata }}
     TypewriterExecutable: $(typewriterExecutable)
     TypewriterDirectory: $(typewriterDirectory)
-    DocsDirectory: ${{ parameters.docsDirectory }}
+    DocsDirectory: $(docsDirectory)
     GenerationMode: 'TransformWithDocs'
     Transform: $(transformScript)
     endpointVersion: ${{ parameters.endpoint }}

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -65,6 +65,18 @@ steps:
     endpointVersion: ${{ parameters.endpoint }}
   displayName: 'run Typewriter to clean ${{ parameters.endpoint }} metadata'
 
+- task: CopyFiles@2
+  inputs:
+    sourceFolder: ${{ parameters.outputPath }}
+    contents: '**/*'
+    targetFolder: '$(Build.ArtifactStagingDirectory)'
+  displayName: Copy generated metadata
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: '$(Build.ArtifactStagingDirectory)'
+    artifactName: '${{ parameters.endpoint }} metadata'
+
 # Use the clean metadata from the last step to generate DotNet files.
 
 - template: use-dotnet-sdk.yml

--- a/.azure-pipelines/generation-templates/checkout-metadata.yml
+++ b/.azure-pipelines/generation-templates/checkout-metadata.yml
@@ -3,3 +3,4 @@ steps:
   displayName: checkout metadata
   fetchDepth: 1
   persistCredentials: true
+  submodules: recursive

--- a/.azure-pipelines/generation-templates/language-generation.yml
+++ b/.azure-pipelines/generation-templates/language-generation.yml
@@ -69,5 +69,5 @@ steps:
   displayName: 'Git: push generated files'
   env:
     BranchName: ${{ parameters.branchName }}
-    PublishChanges: $(publishChangesIntoABranch)
+    PublishChanges: $(publishChanges)
   workingDirectory: ${{ parameters.repoName }}

--- a/scripts/git-push-cleanmetadata.ps1
+++ b/scripts/git-push-cleanmetadata.ps1
@@ -1,4 +1,10 @@
-Write-Host "About to add clean $env:endpointVersion metadata file....."
+if (!$env:PublishChanges)
+{
+    Write-Host "Not publishing changes per the run parameter!" -ForegroundColor Green
+    return;
+}
+
+Write-Host "About to add clean $env:EndpointVersion metadata file....."
 
 git add . | Write-Host
 if ($env:BUILD_REASON -eq 'Manual') # Skip CI if manually running this pipeline.
@@ -10,7 +16,7 @@ else
     git commit -m "Update clean metadata file with $env:BUILD_BUILDID" | Write-Host
 }
 
-Write-Host "Added and commited cleaned $env:endpointVersion metadata." -ForegroundColor Green
+Write-Host "Added and commited cleaned $env:EndpointVersion metadata." -ForegroundColor Green
 
 git push --set-upstream origin master | Write-Host
 Write-Host "Pushed the results of the build $env:BUILD_BUILDID to the master branch." -ForegroundColor Green

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -115,7 +115,7 @@ namespace Typewriter
 
             try
             {
-                docSet = new DocSet(options.DocsRoot);
+                docSet = new DocSet(Path.Join(options.DocsRoot, "api-reference", options.EndpointVersion));
             }
             catch (FileNotFoundException ex)
             {
@@ -123,6 +123,13 @@ namespace Typewriter
                 return null;
             }
 
+            Logger.Info("Parsing documentation files");
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            docSet.ScanDocumentation(string.Empty, issues);
+
+            // Json transformation for empty base types should default to null
+            // but they default to empty string. Clean those up here.
             foreach (var resource in docSet.Resources)
             {
                 if (resource.BaseType == string.Empty)
@@ -131,10 +138,6 @@ namespace Typewriter
                 }
             }
 
-            Logger.Info("Parsing documentation files");
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-            docSet.ScanDocumentation(string.Empty, issues);
             stopwatch.Stop();
             Logger.Info($"Took {stopwatch.Elapsed} to parse {docSet.Files.Length} source files.");
 

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -123,6 +123,14 @@ namespace Typewriter
                 return null;
             }
 
+            foreach (var resource in docSet.Resources)
+            {
+                if (resource.BaseType == string.Empty)
+                {
+                    resource.BaseType = null;
+                }
+            }
+
             Logger.Info("Parsing documentation files");
             var stopwatch = new Stopwatch();
             stopwatch.Start();

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -115,7 +115,7 @@ namespace Typewriter
 
             try
             {
-                docSet = new DocSet(Path.Join(options.DocsRoot, "api-reference", options.EndpointVersion));
+                docSet = new DocSet(options.DocsRoot);
             }
             catch (FileNotFoundException ex)
             {

--- a/src/Typewriter/Generator.cs
+++ b/src/Typewriter/Generator.cs
@@ -86,7 +86,7 @@ namespace Typewriter
 
             using (var reader = new StringReader(csdlContents))
             using (var doc = XmlReader.Create(reader))
-            using (XmlTextWriter writer = new XmlTextWriter(pathToCleanMetadata, Encoding.ASCII))
+            using (XmlTextWriter writer = new XmlTextWriter(pathToCleanMetadata, Encoding.UTF8))
             {
                 writer.Indentation = 2;
                 writer.Formatting = Formatting.Indented;


### PR DESCRIPTION
This PR includes the following fixes:

- Curly apostrophe was showing up as ? because ASCII encoding of the XML (e.g. `Defender’s actions` was showing up as `Defender?s actions`). Changed encoding to UTF8.
  - The fix replacing curly apostrophe with regular: https://github.com/microsoftgraph/microsoft-graph-docs/pull/11538. It is blocked because the text in question is auto generated.
- Checking in metadata changes are now optional for testing purposes (repurposed publishChanges parameter)
- Added a step into metadata cleaning pipeline to publish generated metadata as an artifact for debugging purposes.
- Docs have a lot of empty base type explicitly defined as empty strings. Those empty strings were showing up as base types in the clean metadata which was blocking the OpenAPI conversion. Fixed that by forcing base types to be null instead of empty string when they are set as empty string.
- Cleaned up documentation references in the YAML. DocsDirectory (or DocsRoot in generator code) should point to the root directory of the repo instead of specific version.
- Added a recursive checkout to metadata repo because it now has OpenAPI validation as a submodule.