### PR TITLE
Update schedule, rename master to main

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -8,7 +8,7 @@ schedules:
   displayName: Tuesday generation (PST 2am, EST 5am, EAT 3pm)
   branches:
     include:
-    - dev
+    - main
   always: true
 
 resources:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ main, dev ]
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #429 

- Updates the schedule to use `main`
- Updates the PR checks to use `main`