### PR TITLE
bugfix/collections response java v3

### DIFF
--- a/Templates/templates/Java/requests/BaseEntityCollectionReferenceRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionReferenceRequest.java.tt
@@ -29,7 +29,7 @@ import <#=importNamespace#>.http.ReferenceRequestBody;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionReferenceRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionReferenceRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeCollectionResponse()#>.class, <#=c.TypeCollectionWithReferencesPage()#>.class, <#=c.TypeCollectionWithReferencesRequestBuilder()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityCollectionReferenceRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionReferenceRequestBuilder.java.tt
@@ -19,7 +19,7 @@ import <#=importNamespace#>.core.IBaseClient;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionReferenceRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionReferenceRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeReferenceRequestBuilder()#>.class, <#= c.TypeCollectionReferenceRequest() #>.class);
     }
 }

--- a/Templates/templates/Java/requests/BaseEntityCollectionRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionRequest.java.tt
@@ -24,7 +24,7 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeCollectionResponse()#>.class, <#=c.TypeCollectionPage()#>.class, <#=c.TypeCollectionRequestBuilder() #>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityCollectionRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionRequestBuilder.java.tt
@@ -49,7 +49,7 @@ import <#=method#>;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeRequestBuilder()#>.class, <#=c.TypeCollectionRequest()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityCollectionWithReferencesRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionWithReferencesRequest.java.tt
@@ -29,7 +29,7 @@ import <#=importNamespace#>.http.BaseCollectionWithReferencesRequestBuilder;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionWithReferencesRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionWithReferencesRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeCollectionResponse()#>.class, <#=c.TypeCollectionWithReferencesPage()#>.class, <#=c.TypeCollectionWithReferencesRequestBuilder()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionWithReferencesRequestBuilder.java.tt
@@ -20,7 +20,7 @@ import <#=importNamespace#>.core.IBaseClient;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionWithReferencesRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionWithReferencesRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeReferenceRequestBuilder()#>.class, <#=c.TypeCollectionReferenceRequest()#>.class, <#=c.TypeCollectionReferenceRequestBuilder()#>.class);
     }
 }

--- a/Templates/templates/Java/requests/BaseEntityReferenceRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityReferenceRequest.java.tt
@@ -23,7 +23,7 @@ import com.google.gson.JsonObject;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeReferenceRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeReferenceRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.ClassTypeName()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityReferenceRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityReferenceRequestBuilder.java.tt
@@ -20,7 +20,7 @@ import <#=importNamespace#>.core.IBaseClient;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeReferenceRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeReferenceRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeReferenceRequest()#>.class);
     }
 }

--- a/Templates/templates/Java/requests/BaseEntityRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityRequest.java.tt
@@ -22,7 +22,7 @@ import <#=importNamespace#>.http.HttpMethod;
      * @param responseClass  the class of the response
      */
     public <#=c.TypeRequest()#>(@Nonnull final String requestUrl,
-            @Nonnull final <#=c.IBaseClientType()#> client,
+            @Nonnull final <#=c.IBaseClientType()#><?> client,
             @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions,
             @Nonnull final Class<<# if(!host.TemplateName.Equals("EntityRequest")){ #>? extends <#}#><#=c.ClassTypeName()#>> responseClass) {
         super(requestUrl, client, requestOptions, responseClass);
@@ -36,7 +36,7 @@ import <#=importNamespace#>.http.HttpMethod;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.ClassTypeName()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityRequestBuilder.java.tt
@@ -24,7 +24,7 @@ import <#=method#>;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityStreamRequestBuilder.java.tt
@@ -25,7 +25,7 @@ import <#=method#>;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeStreamRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeStreamRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityWithReferenceRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityWithReferenceRequest.java.tt
@@ -22,7 +22,7 @@ import <#=importNamespace#>.serializer.IJsonBackedObject;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeWithReferencesRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeWithReferencesRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.ClassTypeName()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseEntityWithReferenceRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityWithReferenceRequestBuilder.java.tt
@@ -19,7 +19,7 @@ import <#=importNamespace#>.core.IBaseClient;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeWithReferencesRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeWithReferencesRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.TypeWithReferencesRequest()#>.class, <#=c.TypeReferenceRequestBuilder()#>.class);
     }
 }

--- a/Templates/templates/Java/requests/BaseMethodCollectionRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodCollectionRequest.java.tt
@@ -52,7 +52,7 @@ import <#=importNamespace#>.http.<#=baseType#>;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeCollectionRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeCollectionRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
 <# if (c.AsOdcmMethod().ReturnType != null) { #>
         super(requestUrl, client, requestOptions, <#=c.TypeCollectionResponse()#>.class, <#=c.TypeCollectionPage()#>.class, <#=c.TypeCollectionRequestBuilder() #>.class);
 <# } else { #>

--- a/Templates/templates/Java/requests/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodCollectionRequestBuilder.java.tt
@@ -23,7 +23,19 @@ import <#=importNamespace#>.http.<#= (c.AsOdcmMethod().IsFunction ? "BaseFunctio
 <# bool isAction = !c.AsOdcmMethod().IsFunction; #>
 <#=TypeHelperJava.CreateClassDef(c.TypeCollectionRequestBuilder(), c.GetMethodCollectionRequestBuilderSuperClass(), null, c.Deprecation?.Description)#>
 
-<#if(c.AsOdcmMethod().MethodHasParameters() && isAction) { #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().All(x => x.MethodHasParameters())) { #>
+    /**
+     * The request builder for this collection of <#=c.ClassTypeName()#>
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public <#=c.TypeCollectionRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions, <#=c.TypeCollectionRequestBuilder()#>.class, <#=c.TypeCollectionRequest()#>.class);
+    }
+<# } #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters()) && isAction) { #>
     private <#=c.AsOdcmMethod().TypeParameterSet() #> body;
 <# } #>
 <# foreach (var method in c.AsOdcmMethod().WithOverloadsOfDistinctName()) { #>

--- a/Templates/templates/Java/requests/BaseMethodCollectionRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodCollectionRequestBuilder.java.tt
@@ -37,7 +37,7 @@ import <#=importNamespace#>.http.<#= (c.AsOdcmMethod().IsFunction ? "BaseFunctio
      * @param parameters     the parameters for the service method
 <# } #>
      */
-    public <#=c.TypeCollectionRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions<#if(method.MethodHasParameters()) { #>, @Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
+    public <#=c.TypeCollectionRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions<#if(method.MethodHasParameters()) { #>, @Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         super(requestUrl, client, requestOptions, <#=c.TypeCollectionRequestBuilder()#>.class, <#=c.TypeCollectionRequest()#>.class);
 <#if(method.MethodHasParameters()) { #>
 <# if (isAction) { #>

--- a/Templates/templates/Java/requests/BaseMethodRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequest.java.tt
@@ -25,7 +25,7 @@ import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.AsOdcmMethod().TypePara
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.ReturnType()#>.class);
     }
 

--- a/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
@@ -21,7 +21,19 @@ import javax.annotation.Nonnull;
 <# bool isAction = !c.AsOdcmMethod().IsFunction; #>
 <#=TypeHelperJava.CreateClassDef(c.TypeRequestBuilder(), c.GetMethodRequestBuilderSuperClass(), null, c.Deprecation?.Description)#>
 
-<#if(c.AsOdcmMethod().MethodHasParameters() && isAction) { #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().All(x => x.MethodHasParameters())) { #>
+    /**
+     * The request builder for this <#=c.TypeName()#>
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public <#=c.TypeRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
+<# } #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters()) && isAction) { #>
     private <#=c.AsOdcmMethod().TypeParameterSet() #> body;
 <# } #>
 <# foreach(var method in c.AsOdcmMethod().WithOverloadsOfDistinctName()) { #>

--- a/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
      * @param parameters     the parameters for the service method
 <# } #>
      */
-    public <#=c.TypeRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions<#if(method.MethodHasParameters()) { #>, @Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
+    public <#=c.TypeRequestBuilder()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions<#if(method.MethodHasParameters()) { #>, @Nonnull final <#=method.TypeParameterSet()#> parameters<# } #>) {
         super(requestUrl, client, requestOptions);
 <#if(method.MethodHasParameters()) { #>
 <# if (isAction) { #>

--- a/Templates/templates/Java/requests/BaseStreamRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseStreamRequest.java.tt
@@ -20,7 +20,7 @@ import java.io.InputStream;
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public <#=c.TypeStreamRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
+    public <#=c.TypeStreamRequest()#>(@Nonnull final String requestUrl, @Nonnull final <#=c.IBaseClientType()#><?> client, @Nullable final java.util.List<? extends <#=importNamespace#>.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, <#=c.ClassTypeName()#>.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallCollectionRequest.java
@@ -35,7 +35,7 @@ public class CallCollectionRequest extends BaseEntityCollectionRequest<Call, Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallCollectionResponse.class, CallCollectionPage.class, CallCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class CallCollectionRequestBuilder extends BaseCollectionRequestBuilder<C
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRequestBuilder.class, CallCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallReferenceRequest.java
@@ -34,7 +34,7 @@ public class CallReferenceRequest extends BaseReferenceRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class CallReferenceRequestBuilder extends BaseReferenceRequestBuilder<Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallRequest.java
@@ -30,7 +30,7 @@ public class CallRequest extends BaseRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallRequestBuilder.java
@@ -29,7 +29,7 @@ public class CallRequestBuilder extends BaseRequestBuilder<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallWithReferenceRequest.java
@@ -33,7 +33,7 @@ public class CallWithReferenceRequest extends BaseWithReferenceRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CallWithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class CallWithReferenceRequestBuilder extends BaseWithReferenceRequestBui
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallWithReferenceRequest.class, CallReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CloudCommunicationsRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CloudCommunicationsRequest.java
@@ -34,7 +34,7 @@ public class CloudCommunicationsRequest extends BaseRequest<CloudCommunications>
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CloudCommunicationsRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CloudCommunicationsRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CloudCommunications.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CloudCommunicationsRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/CloudCommunicationsRequestBuilder.java
@@ -33,7 +33,7 @@ public class CloudCommunicationsRequestBuilder extends BaseRequestBuilder<CloudC
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CloudCommunicationsRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CloudCommunicationsRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequest.java
@@ -40,7 +40,7 @@ public class DirectoryObjectCollectionReferenceRequest extends BaseCollectionWit
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectCollectionResponse.class, DirectoryObjectCollectionWithReferencesPage.class, DirectoryObjectCollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectCollectionReferenceRequestBuilder extends BaseCollec
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequestBuilder.class, DirectoryObjectCollectionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequest.java
@@ -40,7 +40,7 @@ public class DirectoryObjectCollectionWithReferencesRequest extends BaseCollecti
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectCollectionResponse.class, DirectoryObjectCollectionWithReferencesPage.class, DirectoryObjectCollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectCollectionWithReferencesRequestBuilder extends BaseC
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequestBuilder.class, DirectoryObjectCollectionReferenceRequest.class, DirectoryObjectCollectionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectReferenceRequest.java
@@ -34,7 +34,7 @@ public class DirectoryObjectReferenceRequest extends BaseReferenceRequest<Direct
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectReferenceRequestBuilder extends BaseReferenceRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectRequest.java
@@ -32,7 +32,7 @@ public class DirectoryObjectRequest extends BaseRequest<DirectoryObject> {
      * @param responseClass  the class of the response
      */
     public DirectoryObjectRequest(@Nonnull final String requestUrl,
-            @Nonnull final IBaseClient client,
+            @Nonnull final IBaseClient<?> client,
             @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions,
             @Nonnull final Class<? extends DirectoryObject> responseClass) {
         super(requestUrl, client, requestOptions, responseClass);
@@ -45,7 +45,7 @@ public class DirectoryObjectRequest extends BaseRequest<DirectoryObject> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectRequestBuilder.java
@@ -29,7 +29,7 @@ public class DirectoryObjectRequestBuilder extends BaseRequestBuilder<DirectoryO
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequest.java
@@ -33,7 +33,7 @@ public class DirectoryObjectWithReferenceRequest extends BaseWithReferenceReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class DirectoryObjectWithReferenceRequestBuilder extends BaseWithReferenc
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectWithReferenceRequest.class, DirectoryObjectReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EndpointRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EndpointRequest.java
@@ -30,7 +30,7 @@ public class EndpointRequest extends BaseRequest<Endpoint> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EndpointRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EndpointRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Endpoint.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EndpointRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EndpointRequestBuilder.java
@@ -29,7 +29,7 @@ public class EndpointRequestBuilder extends BaseRequestBuilder<Endpoint> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EndpointRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EndpointRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityRequest.java
@@ -32,7 +32,7 @@ public class EntityRequest extends BaseRequest<Entity> {
      * @param responseClass  the class of the response
      */
     public EntityRequest(@Nonnull final String requestUrl,
-            @Nonnull final IBaseClient client,
+            @Nonnull final IBaseClient<?> client,
             @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions,
             @Nonnull final Class<Entity> responseClass) {
         super(requestUrl, client, requestOptions, responseClass);
@@ -45,7 +45,7 @@ public class EntityRequest extends BaseRequest<Entity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Entity.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityRequestBuilder.java
@@ -29,7 +29,7 @@ public class EntityRequestBuilder extends BaseRequestBuilder<Entity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2CollectionRequest.java
@@ -35,7 +35,7 @@ public class EntityType2CollectionRequest extends BaseEntityCollectionRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2CollectionResponse.class, EntityType2CollectionPage.class, EntityType2CollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2CollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType2CollectionRequestBuilder extends BaseCollectionRequestBu
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2RequestBuilder.class, EntityType2CollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2ReferenceRequest.java
@@ -34,7 +34,7 @@ public class EntityType2ReferenceRequest extends BaseReferenceRequest<EntityType
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2ReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class EntityType2ReferenceRequestBuilder extends BaseReferenceRequestBuil
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2ReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2Request.java
@@ -30,7 +30,7 @@ public class EntityType2Request extends BaseRequest<EntityType2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2RequestBuilder.java
@@ -29,7 +29,7 @@ public class EntityType2RequestBuilder extends BaseRequestBuilder<EntityType2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2WithReferenceRequest.java
@@ -33,7 +33,7 @@ public class EntityType2WithReferenceRequest extends BaseWithReferenceRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType2WithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class EntityType2WithReferenceRequestBuilder extends BaseWithReferenceReq
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2WithReferenceRequest.class, EntityType2ReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionReferenceRequest.java
@@ -44,7 +44,7 @@ public class EntityType3CollectionReferenceRequest extends BaseCollectionWithRef
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionWithReferencesPage.class, EntityType3CollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionReferenceRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3CollectionReferenceRequestBuilder extends BaseCollection
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequestBuilder.class, EntityType3CollectionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionRequest.java
@@ -38,7 +38,7 @@ public class EntityType3CollectionRequest extends BaseEntityCollectionRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionPage.class, EntityType3CollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionRequestBuilder.java
@@ -38,7 +38,7 @@ public class EntityType3CollectionRequestBuilder extends BaseCollectionRequestBu
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3RequestBuilder.class, EntityType3CollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequest.java
@@ -44,7 +44,7 @@ public class EntityType3CollectionWithReferencesRequest extends BaseCollectionWi
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionWithReferencesPage.class, EntityType3CollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3CollectionWithReferencesRequestBuilder extends BaseColle
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequestBuilder.class, EntityType3CollectionReferenceRequest.class, EntityType3CollectionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ForwardRequest.java
@@ -30,7 +30,7 @@ public class EntityType3ForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ForwardRequestBuilder.java
@@ -24,6 +24,16 @@ import javax.annotation.Nonnull;
 @Deprecated
 public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<EntityType3> {
 
+    /**
+     * The request builder for this EntityType3Forward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private EntityType3ForwardParameterSet body;
     /**
      * The request builder for this EntityType3Forward
@@ -33,7 +43,7 @@ public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<E
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final EntityType3ForwardParameterSet parameters) {
+    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final EntityType3ForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ReferenceRequest.java
@@ -38,7 +38,7 @@ public class EntityType3ReferenceRequest extends BaseReferenceRequest<EntityType
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3ReferenceRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3ReferenceRequestBuilder extends BaseReferenceRequestBuil
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3Request.java
@@ -34,7 +34,7 @@ public class EntityType3Request extends BaseRequest<EntityType3> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3RequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3WithReferenceRequest.java
@@ -37,7 +37,7 @@ public class EntityType3WithReferenceRequest extends BaseWithReferenceRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/EntityType3WithReferenceRequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType3WithReferenceRequestBuilder extends BaseWithReferenceReq
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3WithReferenceRequest.class, EntityType3ReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupCollectionRequest.java
@@ -34,7 +34,7 @@ public class GroupCollectionRequest extends BaseEntityCollectionRequest<Group, G
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, GroupCollectionResponse.class, GroupCollectionPage.class, GroupCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupCollectionRequestBuilder.java
@@ -33,7 +33,7 @@ public class GroupCollectionRequestBuilder extends BaseCollectionRequestBuilder<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, GroupRequestBuilder.class, GroupCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupRequest.java
@@ -34,7 +34,7 @@ public class GroupRequest extends BaseRequest<Group> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Group.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GroupRequestBuilder.java
@@ -33,7 +33,7 @@ public class GroupRequestBuilder extends BaseRequestBuilder<Group> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageContentStreamRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageContentStreamRequest.java
@@ -31,7 +31,7 @@ public class OnenotePageContentStreamRequest extends BaseStreamRequest<OnenotePa
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageContentStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageContentStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, OnenotePage.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageContentStreamRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageContentStreamRequestBuilder.java
@@ -30,7 +30,7 @@ public class OnenotePageContentStreamRequestBuilder extends BaseRequestBuilder<I
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageContentStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageContentStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageForwardRequest.java
@@ -28,7 +28,7 @@ public class OnenotePageForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageForwardRequestBuilder.java
@@ -22,6 +22,16 @@ import javax.annotation.Nonnull;
  */
 public class OnenotePageForwardRequestBuilder extends BaseActionRequestBuilder<OnenotePage> {
 
+    /**
+     * The request builder for this OnenotePageForward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private OnenotePageForwardParameterSet body;
     /**
      * The request builder for this OnenotePageForward
@@ -31,7 +41,7 @@ public class OnenotePageForwardRequestBuilder extends BaseActionRequestBuilder<O
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final OnenotePageForwardParameterSet parameters) {
+    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final OnenotePageForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageRequest.java
@@ -31,7 +31,7 @@ public class OnenotePageRequest extends BaseRequest<OnenotePage> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, OnenotePage.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/OnenotePageRequestBuilder.java
@@ -31,7 +31,7 @@ public class OnenotePageRequestBuilder extends BaseRequestBuilder<OnenotePage> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/PlannerGroupRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/PlannerGroupRequest.java
@@ -30,7 +30,7 @@ public class PlannerGroupRequest extends BaseRequest<PlannerGroup> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PlannerGroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PlannerGroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, PlannerGroup.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/PlannerGroupRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/PlannerGroupRequestBuilder.java
@@ -29,7 +29,7 @@ public class PlannerGroupRequestBuilder extends BaseRequestBuilder<PlannerGroup>
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PlannerGroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PlannerGroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/ScheduleRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/ScheduleRequest.java
@@ -34,7 +34,7 @@ public class ScheduleRequest extends BaseRequest<Schedule> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public ScheduleRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public ScheduleRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Schedule.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/ScheduleRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/ScheduleRequestBuilder.java
@@ -33,7 +33,7 @@ public class ScheduleRequestBuilder extends BaseRequestBuilder<Schedule> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public ScheduleRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public ScheduleRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity1Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity1Request extends BaseRequest<SingletonEntity1> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity1.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity1RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity1RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity1RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity2Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity2Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity2Request extends BaseRequest<SingletonEntity2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity2RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/SingletonEntity2RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity2RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestEntityRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestEntityRequest.java
@@ -33,7 +33,7 @@ public class TestEntityRequest extends BaseRequest<TestEntity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestEntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestEntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestEntity.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestEntityRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestEntityRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestEntityRequestBuilder extends BaseRequestBuilder<TestEntity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestEntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestEntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeQueryCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeQueryCollectionRequest.java
@@ -44,7 +44,7 @@ public class TestTypeQueryCollectionRequest extends BaseActionCollectionRequest<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeQueryCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeQueryCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeQueryCollectionResponse.class, TestTypeQueryCollectionPage.class, TestTypeQueryCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeQueryCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeQueryCollectionRequestBuilder.java
@@ -31,6 +31,16 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
 @Deprecated
 public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<ResponseObject, TestTypeQueryCollectionRequestBuilder, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage, TestTypeQueryCollectionRequest> {
 
+    /**
+     * The request builder for this collection of TestType
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions, TestTypeQueryCollectionRequestBuilder.class, TestTypeQueryCollectionRequest.class);
+    }
     private TestTypeQueryParameterSet body;
     /**
      * The request builder for this collection of TestType
@@ -40,7 +50,7 @@ public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionR
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final TestTypeQueryParameterSet parameters) {
+    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final TestTypeQueryParameterSet parameters) {
         super(requestUrl, client, requestOptions, TestTypeQueryCollectionRequestBuilder.class, TestTypeQueryCollectionRequest.class);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeReferenceRequest.java
@@ -36,7 +36,7 @@ public class TestTypeReferenceRequest extends BaseReferenceRequest<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeReferenceRequestBuilder.java
@@ -33,7 +33,7 @@ public class TestTypeReferenceRequestBuilder extends BaseReferenceRequestBuilder
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeRequest.java
@@ -32,7 +32,7 @@ public class TestTypeRequest extends BaseRequest<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestTypeRequestBuilder extends BaseRequestBuilder<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeWithReferenceRequest.java
@@ -35,7 +35,7 @@ public class TestTypeWithReferenceRequest extends BaseWithReferenceRequest<TestT
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TestTypeWithReferenceRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestTypeWithReferenceRequestBuilder extends BaseWithReferenceReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeWithReferenceRequest.class, TestTypeReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffCollectionRequest.java
@@ -35,7 +35,7 @@ public class TimeOffCollectionRequest extends BaseEntityCollectionRequest<TimeOf
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffCollectionResponse.class, TimeOffCollectionPage.class, TimeOffCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class TimeOffCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestBuilder.class, TimeOffCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequest.java
@@ -30,7 +30,7 @@ public class TimeOffRequest extends BaseRequest<TimeOff> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOff.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestBuilder.java
@@ -29,7 +29,7 @@ public class TimeOffRequestBuilder extends BaseRequestBuilder<TimeOff> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestCollectionRequest.java
@@ -36,7 +36,7 @@ public class TimeOffRequestCollectionRequest extends BaseEntityCollectionRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestCollectionResponse.class, TimeOffRequestCollectionPage.class, TimeOffRequestCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestCollectionRequestBuilder.java
@@ -35,7 +35,7 @@ public class TimeOffRequestCollectionRequestBuilder extends BaseCollectionReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestRequestBuilder.class, TimeOffRequestCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestRequest.java
@@ -30,7 +30,7 @@ public class TimeOffRequestRequest extends BaseRequest<TimeOffRequest> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/TimeOffRequestRequestBuilder.java
@@ -29,7 +29,7 @@ public class TimeOffRequestRequestBuilder extends BaseRequestBuilder<TimeOffRequ
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequest.java
@@ -35,7 +35,7 @@ public class UserCollectionRequest extends BaseEntityCollectionRequest<User, Use
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, UserCollectionResponse.class, UserCollectionPage.class, UserCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class UserCollectionRequestBuilder extends BaseCollectionRequestBuilder<U
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, UserRequestBuilder.class, UserCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserRequest.java
@@ -30,7 +30,7 @@ public class UserRequest extends BaseRequest<User> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, User.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserRequestBuilder.java
@@ -29,7 +29,7 @@ public class UserRequestBuilder extends BaseRequestBuilder<User> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequest.java
@@ -35,7 +35,7 @@ public class CallRecordCollectionRequest extends BaseEntityCollectionRequest<Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecordCollectionResponse.class, CallRecordCollectionPage.class, CallRecordCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequestBuilder.java
@@ -36,7 +36,7 @@ public class CallRecordCollectionRequestBuilder extends BaseCollectionRequestBui
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecordRequestBuilder.class, CallRecordCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.java
@@ -28,7 +28,7 @@ public class CallRecordItemRequest extends BaseRequest<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordItemRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordItemRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecord.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -26,9 +26,19 @@ public class CallRecordItemRequestBuilder extends BaseFunctionRequestBuilder<Cal
      * @param requestUrl     the request URL
      * @param client         the service client
      * @param requestOptions the options for this request
+     */
+    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
+    /**
+     * The request builder for this CallRecordItem
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final CallRecordItemParameterSet parameters) {
+    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final CallRecordItemParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         if(parameters != null) {
             functionOptions = parameters.getFunctionOptions();

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordRequest.java
@@ -34,7 +34,7 @@ public class CallRecordRequest extends BaseRequest<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecord.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordRequestBuilder.java
@@ -33,7 +33,7 @@ public class CallRecordRequestBuilder extends BaseRequestBuilder<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/OptionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/OptionRequest.java
@@ -30,7 +30,7 @@ public class OptionRequest extends BaseRequest<Option> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OptionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OptionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Option.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/OptionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/OptionRequestBuilder.java
@@ -29,7 +29,7 @@ public class OptionRequestBuilder extends BaseRequestBuilder<Option> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OptionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OptionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoRequest.java
@@ -30,7 +30,7 @@ public class PhotoRequest extends BaseRequest<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Photo.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoRequestBuilder.java
@@ -29,7 +29,7 @@ public class PhotoRequestBuilder extends BaseRequestBuilder<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoStreamRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoStreamRequest.java
@@ -31,7 +31,7 @@ public class PhotoStreamRequest extends BaseStreamRequest<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Photo.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoStreamRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/PhotoStreamRequestBuilder.java
@@ -30,7 +30,7 @@ public class PhotoStreamRequestBuilder extends BaseRequestBuilder<InputStream> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequest.java
@@ -37,7 +37,7 @@ public class SegmentCollectionRequest extends BaseEntityCollectionRequest<Segmen
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentCollectionResponse.class, SegmentCollectionPage.class, SegmentCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequestBuilder.java
@@ -38,7 +38,7 @@ public class SegmentCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentRequestBuilder.class, SegmentCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentForwardRequest.java
@@ -28,7 +28,7 @@ public class SegmentForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentForwardRequestBuilder.java
@@ -22,6 +22,16 @@ import javax.annotation.Nonnull;
  */
 public class SegmentForwardRequestBuilder extends BaseActionRequestBuilder<Segment> {
 
+    /**
+     * The request builder for this SegmentForward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private SegmentForwardParameterSet body;
     /**
      * The request builder for this SegmentForward
@@ -31,7 +41,7 @@ public class SegmentForwardRequestBuilder extends BaseActionRequestBuilder<Segme
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentForwardParameterSet parameters) {
+    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentRequest.java
@@ -38,7 +38,7 @@ public class SegmentRequest extends BaseRequest<Segment> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Segment.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.java
@@ -39,7 +39,7 @@ public class SegmentRequestBuilder extends BaseRequestBuilder<Segment> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequest.java
@@ -42,7 +42,7 @@ public class SegmentTestActionCollectionRequest extends BaseActionCollectionRequ
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentTestActionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentTestActionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentTestActionCollectionResponse.class, SegmentTestActionCollectionPage.class, SegmentTestActionCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequestBuilder.java
@@ -29,6 +29,16 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
  */
 public class SegmentTestActionCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<Session, SegmentTestActionCollectionRequestBuilder, SegmentTestActionCollectionResponse, SegmentTestActionCollectionPage, SegmentTestActionCollectionRequest> {
 
+    /**
+     * The request builder for this collection of Segment
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions, SegmentTestActionCollectionRequestBuilder.class, SegmentTestActionCollectionRequest.class);
+    }
     private SegmentTestActionParameterSet body;
     /**
      * The request builder for this collection of Segment
@@ -38,7 +48,7 @@ public class SegmentTestActionCollectionRequestBuilder extends BaseActionCollect
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentTestActionParameterSet parameters) {
+    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentTestActionParameterSet parameters) {
         super(requestUrl, client, requestOptions, SegmentTestActionCollectionRequestBuilder.class, SegmentTestActionCollectionRequest.class);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionCollectionRequest.java
@@ -35,7 +35,7 @@ public class SessionCollectionRequest extends BaseEntityCollectionRequest<Sessio
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionCollectionResponse.class, SessionCollectionPage.class, SessionCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class SessionCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionRequestBuilder.class, SessionCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionReferenceRequest.java
@@ -36,7 +36,7 @@ public class SessionReferenceRequest extends BaseReferenceRequest<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionReferenceRequestBuilder.java
@@ -33,7 +33,7 @@ public class SessionReferenceRequestBuilder extends BaseReferenceRequestBuilder<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionRequest.java
@@ -32,7 +32,7 @@ public class SessionRequest extends BaseRequest<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionRequestBuilder.java
@@ -31,7 +31,7 @@ public class SessionRequestBuilder extends BaseRequestBuilder<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequest.java
@@ -35,7 +35,7 @@ public class SessionWithReferenceRequest extends BaseWithReferenceRequest<Sessio
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequestBuilder.java
@@ -32,7 +32,7 @@ public class SessionWithReferenceRequestBuilder extends BaseWithReferenceRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionWithReferenceRequest.class, SessionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SingletonEntity1Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity1Request extends BaseRequest<SingletonEntity1> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity1.class);
     }
 

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SingletonEntity1RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/SingletonEntity1RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity1RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallCollectionRequest.java
@@ -35,7 +35,7 @@ public class CallCollectionRequest extends BaseEntityCollectionRequest<Call, Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallCollectionResponse.class, CallCollectionPage.class, CallCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class CallCollectionRequestBuilder extends BaseCollectionRequestBuilder<C
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRequestBuilder.class, CallCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallReferenceRequest.java
@@ -34,7 +34,7 @@ public class CallReferenceRequest extends BaseReferenceRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class CallReferenceRequestBuilder extends BaseReferenceRequestBuilder<Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallRequest.java
@@ -30,7 +30,7 @@ public class CallRequest extends BaseRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallRequestBuilder.java
@@ -29,7 +29,7 @@ public class CallRequestBuilder extends BaseRequestBuilder<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallWithReferenceRequest.java
@@ -33,7 +33,7 @@ public class CallWithReferenceRequest extends BaseWithReferenceRequest<Call> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Call.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CallWithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class CallWithReferenceRequestBuilder extends BaseWithReferenceRequestBui
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallWithReferenceRequest.class, CallReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CloudCommunicationsRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CloudCommunicationsRequest.java
@@ -34,7 +34,7 @@ public class CloudCommunicationsRequest extends BaseRequest<CloudCommunications>
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CloudCommunicationsRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CloudCommunicationsRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CloudCommunications.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CloudCommunicationsRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/CloudCommunicationsRequestBuilder.java
@@ -33,7 +33,7 @@ public class CloudCommunicationsRequestBuilder extends BaseRequestBuilder<CloudC
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CloudCommunicationsRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CloudCommunicationsRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequest.java
@@ -40,7 +40,7 @@ public class DirectoryObjectCollectionReferenceRequest extends BaseCollectionWit
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectCollectionResponse.class, DirectoryObjectCollectionWithReferencesPage.class, DirectoryObjectCollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectCollectionReferenceRequestBuilder extends BaseCollec
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequestBuilder.class, DirectoryObjectCollectionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequest.java
@@ -40,7 +40,7 @@ public class DirectoryObjectCollectionWithReferencesRequest extends BaseCollecti
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectCollectionResponse.class, DirectoryObjectCollectionWithReferencesPage.class, DirectoryObjectCollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectCollectionWithReferencesRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectCollectionWithReferencesRequestBuilder extends BaseC
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectCollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectCollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequestBuilder.class, DirectoryObjectCollectionReferenceRequest.class, DirectoryObjectCollectionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectReferenceRequest.java
@@ -34,7 +34,7 @@ public class DirectoryObjectReferenceRequest extends BaseReferenceRequest<Direct
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class DirectoryObjectReferenceRequestBuilder extends BaseReferenceRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectRequest.java
@@ -32,7 +32,7 @@ public class DirectoryObjectRequest extends BaseRequest<DirectoryObject> {
      * @param responseClass  the class of the response
      */
     public DirectoryObjectRequest(@Nonnull final String requestUrl,
-            @Nonnull final IBaseClient client,
+            @Nonnull final IBaseClient<?> client,
             @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions,
             @Nonnull final Class<? extends DirectoryObject> responseClass) {
         super(requestUrl, client, requestOptions, responseClass);
@@ -45,7 +45,7 @@ public class DirectoryObjectRequest extends BaseRequest<DirectoryObject> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectRequestBuilder.java
@@ -29,7 +29,7 @@ public class DirectoryObjectRequestBuilder extends BaseRequestBuilder<DirectoryO
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequest.java
@@ -33,7 +33,7 @@ public class DirectoryObjectWithReferenceRequest extends BaseWithReferenceReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObject.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/DirectoryObjectWithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class DirectoryObjectWithReferenceRequestBuilder extends BaseWithReferenc
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public DirectoryObjectWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public DirectoryObjectWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, DirectoryObjectWithReferenceRequest.class, DirectoryObjectReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EndpointRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EndpointRequest.java
@@ -30,7 +30,7 @@ public class EndpointRequest extends BaseRequest<Endpoint> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EndpointRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EndpointRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Endpoint.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EndpointRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EndpointRequestBuilder.java
@@ -29,7 +29,7 @@ public class EndpointRequestBuilder extends BaseRequestBuilder<Endpoint> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EndpointRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EndpointRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityRequest.java
@@ -32,7 +32,7 @@ public class EntityRequest extends BaseRequest<Entity> {
      * @param responseClass  the class of the response
      */
     public EntityRequest(@Nonnull final String requestUrl,
-            @Nonnull final IBaseClient client,
+            @Nonnull final IBaseClient<?> client,
             @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions,
             @Nonnull final Class<Entity> responseClass) {
         super(requestUrl, client, requestOptions, responseClass);
@@ -45,7 +45,7 @@ public class EntityRequest extends BaseRequest<Entity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Entity.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityRequestBuilder.java
@@ -29,7 +29,7 @@ public class EntityRequestBuilder extends BaseRequestBuilder<Entity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2CollectionRequest.java
@@ -35,7 +35,7 @@ public class EntityType2CollectionRequest extends BaseEntityCollectionRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2CollectionResponse.class, EntityType2CollectionPage.class, EntityType2CollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2CollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType2CollectionRequestBuilder extends BaseCollectionRequestBu
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2RequestBuilder.class, EntityType2CollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2ReferenceRequest.java
@@ -34,7 +34,7 @@ public class EntityType2ReferenceRequest extends BaseReferenceRequest<EntityType
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2ReferenceRequestBuilder.java
@@ -31,7 +31,7 @@ public class EntityType2ReferenceRequestBuilder extends BaseReferenceRequestBuil
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2ReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2Request.java
@@ -30,7 +30,7 @@ public class EntityType2Request extends BaseRequest<EntityType2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2RequestBuilder.java
@@ -29,7 +29,7 @@ public class EntityType2RequestBuilder extends BaseRequestBuilder<EntityType2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2WithReferenceRequest.java
@@ -33,7 +33,7 @@ public class EntityType2WithReferenceRequest extends BaseWithReferenceRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType2WithReferenceRequestBuilder.java
@@ -30,7 +30,7 @@ public class EntityType2WithReferenceRequestBuilder extends BaseWithReferenceReq
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType2WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType2WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType2WithReferenceRequest.class, EntityType2ReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionReferenceRequest.java
@@ -44,7 +44,7 @@ public class EntityType3CollectionReferenceRequest extends BaseCollectionWithRef
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionWithReferencesPage.class, EntityType3CollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionReferenceRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3CollectionReferenceRequestBuilder extends BaseCollection
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequestBuilder.class, EntityType3CollectionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionRequest.java
@@ -38,7 +38,7 @@ public class EntityType3CollectionRequest extends BaseEntityCollectionRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionPage.class, EntityType3CollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionRequestBuilder.java
@@ -38,7 +38,7 @@ public class EntityType3CollectionRequestBuilder extends BaseCollectionRequestBu
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3RequestBuilder.class, EntityType3CollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequest.java
@@ -44,7 +44,7 @@ public class EntityType3CollectionWithReferencesRequest extends BaseCollectionWi
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionWithReferencesRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3CollectionResponse.class, EntityType3CollectionWithReferencesPage.class, EntityType3CollectionWithReferencesRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3CollectionWithReferencesRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3CollectionWithReferencesRequestBuilder extends BaseColle
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3CollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3CollectionWithReferencesRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequestBuilder.class, EntityType3CollectionReferenceRequest.class, EntityType3CollectionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ForwardRequest.java
@@ -30,7 +30,7 @@ public class EntityType3ForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ForwardRequestBuilder.java
@@ -24,6 +24,16 @@ import javax.annotation.Nonnull;
 @Deprecated
 public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<EntityType3> {
 
+    /**
+     * The request builder for this EntityType3Forward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private EntityType3ForwardParameterSet body;
     /**
      * The request builder for this EntityType3Forward
@@ -33,7 +43,7 @@ public class EntityType3ForwardRequestBuilder extends BaseActionRequestBuilder<E
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final EntityType3ForwardParameterSet parameters) {
+    public EntityType3ForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final EntityType3ForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ReferenceRequest.java
@@ -38,7 +38,7 @@ public class EntityType3ReferenceRequest extends BaseReferenceRequest<EntityType
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3ReferenceRequestBuilder.java
@@ -35,7 +35,7 @@ public class EntityType3ReferenceRequestBuilder extends BaseReferenceRequestBuil
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3ReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3ReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3Request.java
@@ -34,7 +34,7 @@ public class EntityType3Request extends BaseRequest<EntityType3> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3RequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType3RequestBuilder extends BaseRequestBuilder<EntityType3> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3WithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3WithReferenceRequest.java
@@ -37,7 +37,7 @@ public class EntityType3WithReferenceRequest extends BaseWithReferenceRequest<En
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3WithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3WithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/EntityType3WithReferenceRequestBuilder.java
@@ -34,7 +34,7 @@ public class EntityType3WithReferenceRequestBuilder extends BaseWithReferenceReq
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public EntityType3WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public EntityType3WithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, EntityType3WithReferenceRequest.class, EntityType3ReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupCollectionRequest.java
@@ -34,7 +34,7 @@ public class GroupCollectionRequest extends BaseEntityCollectionRequest<Group, G
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, GroupCollectionResponse.class, GroupCollectionPage.class, GroupCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupCollectionRequestBuilder.java
@@ -33,7 +33,7 @@ public class GroupCollectionRequestBuilder extends BaseCollectionRequestBuilder<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, GroupRequestBuilder.class, GroupCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupRequest.java
@@ -34,7 +34,7 @@ public class GroupRequest extends BaseRequest<Group> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Group.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GroupRequestBuilder.java
@@ -33,7 +33,7 @@ public class GroupRequestBuilder extends BaseRequestBuilder<Group> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public GroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public GroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageContentStreamRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageContentStreamRequest.java
@@ -31,7 +31,7 @@ public class OnenotePageContentStreamRequest extends BaseStreamRequest<OnenotePa
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageContentStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageContentStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, OnenotePage.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageContentStreamRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageContentStreamRequestBuilder.java
@@ -30,7 +30,7 @@ public class OnenotePageContentStreamRequestBuilder extends BaseRequestBuilder<I
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageContentStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageContentStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageForwardRequest.java
@@ -28,7 +28,7 @@ public class OnenotePageForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageForwardRequestBuilder.java
@@ -22,6 +22,16 @@ import javax.annotation.Nonnull;
  */
 public class OnenotePageForwardRequestBuilder extends BaseActionRequestBuilder<OnenotePage> {
 
+    /**
+     * The request builder for this OnenotePageForward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private OnenotePageForwardParameterSet body;
     /**
      * The request builder for this OnenotePageForward
@@ -31,7 +41,7 @@ public class OnenotePageForwardRequestBuilder extends BaseActionRequestBuilder<O
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final OnenotePageForwardParameterSet parameters) {
+    public OnenotePageForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final OnenotePageForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageRequest.java
@@ -31,7 +31,7 @@ public class OnenotePageRequest extends BaseRequest<OnenotePage> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, OnenotePage.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/OnenotePageRequestBuilder.java
@@ -31,7 +31,7 @@ public class OnenotePageRequestBuilder extends BaseRequestBuilder<OnenotePage> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OnenotePageRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OnenotePageRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/PlannerGroupRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/PlannerGroupRequest.java
@@ -30,7 +30,7 @@ public class PlannerGroupRequest extends BaseRequest<PlannerGroup> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PlannerGroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PlannerGroupRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, PlannerGroup.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/PlannerGroupRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/PlannerGroupRequestBuilder.java
@@ -29,7 +29,7 @@ public class PlannerGroupRequestBuilder extends BaseRequestBuilder<PlannerGroup>
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PlannerGroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PlannerGroupRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/ScheduleRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/ScheduleRequest.java
@@ -34,7 +34,7 @@ public class ScheduleRequest extends BaseRequest<Schedule> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public ScheduleRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public ScheduleRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Schedule.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/ScheduleRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/ScheduleRequestBuilder.java
@@ -33,7 +33,7 @@ public class ScheduleRequestBuilder extends BaseRequestBuilder<Schedule> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public ScheduleRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public ScheduleRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity1Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity1Request extends BaseRequest<SingletonEntity1> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity1.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity1RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity1RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity1RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity2Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity2Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity2Request extends BaseRequest<SingletonEntity2> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity2Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity2.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity2RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/SingletonEntity2RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity2RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity2RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestEntityRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestEntityRequest.java
@@ -33,7 +33,7 @@ public class TestEntityRequest extends BaseRequest<TestEntity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestEntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestEntityRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestEntity.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestEntityRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestEntityRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestEntityRequestBuilder extends BaseRequestBuilder<TestEntity> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestEntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestEntityRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeQueryCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeQueryCollectionRequest.java
@@ -44,7 +44,7 @@ public class TestTypeQueryCollectionRequest extends BaseActionCollectionRequest<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeQueryCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeQueryCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeQueryCollectionResponse.class, TestTypeQueryCollectionPage.class, TestTypeQueryCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeQueryCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeQueryCollectionRequestBuilder.java
@@ -31,6 +31,16 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
 @Deprecated
 public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<ResponseObject, TestTypeQueryCollectionRequestBuilder, TestTypeQueryCollectionResponse, TestTypeQueryCollectionPage, TestTypeQueryCollectionRequest> {
 
+    /**
+     * The request builder for this collection of TestType
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions, TestTypeQueryCollectionRequestBuilder.class, TestTypeQueryCollectionRequest.class);
+    }
     private TestTypeQueryParameterSet body;
     /**
      * The request builder for this collection of TestType
@@ -40,7 +50,7 @@ public class TestTypeQueryCollectionRequestBuilder extends BaseActionCollectionR
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final TestTypeQueryParameterSet parameters) {
+    public TestTypeQueryCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final TestTypeQueryParameterSet parameters) {
         super(requestUrl, client, requestOptions, TestTypeQueryCollectionRequestBuilder.class, TestTypeQueryCollectionRequest.class);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeReferenceRequest.java
@@ -36,7 +36,7 @@ public class TestTypeReferenceRequest extends BaseReferenceRequest<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeReferenceRequestBuilder.java
@@ -33,7 +33,7 @@ public class TestTypeReferenceRequestBuilder extends BaseReferenceRequestBuilder
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeRequest.java
@@ -32,7 +32,7 @@ public class TestTypeRequest extends BaseRequest<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestTypeRequestBuilder extends BaseRequestBuilder<TestType> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeWithReferenceRequest.java
@@ -35,7 +35,7 @@ public class TestTypeWithReferenceRequest extends BaseWithReferenceRequest<TestT
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestType.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TestTypeWithReferenceRequestBuilder.java
@@ -32,7 +32,7 @@ public class TestTypeWithReferenceRequestBuilder extends BaseWithReferenceReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TestTypeWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TestTypeWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TestTypeWithReferenceRequest.class, TestTypeReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffCollectionRequest.java
@@ -35,7 +35,7 @@ public class TimeOffCollectionRequest extends BaseEntityCollectionRequest<TimeOf
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffCollectionResponse.class, TimeOffCollectionPage.class, TimeOffCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class TimeOffCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestBuilder.class, TimeOffCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequest.java
@@ -30,7 +30,7 @@ public class TimeOffRequest extends BaseRequest<TimeOff> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOff.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestBuilder.java
@@ -29,7 +29,7 @@ public class TimeOffRequestBuilder extends BaseRequestBuilder<TimeOff> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestCollectionRequest.java
@@ -36,7 +36,7 @@ public class TimeOffRequestCollectionRequest extends BaseEntityCollectionRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestCollectionResponse.class, TimeOffRequestCollectionPage.class, TimeOffRequestCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestCollectionRequestBuilder.java
@@ -35,7 +35,7 @@ public class TimeOffRequestCollectionRequestBuilder extends BaseCollectionReques
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequestRequestBuilder.class, TimeOffRequestCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestRequest.java
@@ -30,7 +30,7 @@ public class TimeOffRequestRequest extends BaseRequest<TimeOffRequest> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, TimeOffRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/TimeOffRequestRequestBuilder.java
@@ -29,7 +29,7 @@ public class TimeOffRequestRequestBuilder extends BaseRequestBuilder<TimeOffRequ
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public TimeOffRequestRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public TimeOffRequestRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequest.java
@@ -35,7 +35,7 @@ public class UserCollectionRequest extends BaseEntityCollectionRequest<User, Use
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, UserCollectionResponse.class, UserCollectionPage.class, UserCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class UserCollectionRequestBuilder extends BaseCollectionRequestBuilder<U
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, UserRequestBuilder.class, UserCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserRequest.java
@@ -30,7 +30,7 @@ public class UserRequest extends BaseRequest<User> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, User.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserRequestBuilder.java
@@ -29,7 +29,7 @@ public class UserRequestBuilder extends BaseRequestBuilder<User> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public UserRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public UserRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequest.java
@@ -35,7 +35,7 @@ public class CallRecordCollectionRequest extends BaseEntityCollectionRequest<Cal
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecordCollectionResponse.class, CallRecordCollectionPage.class, CallRecordCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordCollectionRequestBuilder.java
@@ -36,7 +36,7 @@ public class CallRecordCollectionRequestBuilder extends BaseCollectionRequestBui
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecordRequestBuilder.class, CallRecordCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequest.java
@@ -28,7 +28,7 @@ public class CallRecordItemRequest extends BaseRequest<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordItemRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordItemRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecord.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -26,9 +26,19 @@ public class CallRecordItemRequestBuilder extends BaseFunctionRequestBuilder<Cal
      * @param requestUrl     the request URL
      * @param client         the service client
      * @param requestOptions the options for this request
+     */
+    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
+    /**
+     * The request builder for this CallRecordItem
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final CallRecordItemParameterSet parameters) {
+    public CallRecordItemRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final CallRecordItemParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         if(parameters != null) {
             functionOptions = parameters.getFunctionOptions();

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordRequest.java
@@ -34,7 +34,7 @@ public class CallRecordRequest extends BaseRequest<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, CallRecord.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordRequestBuilder.java
@@ -33,7 +33,7 @@ public class CallRecordRequestBuilder extends BaseRequestBuilder<CallRecord> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public CallRecordRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public CallRecordRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/OptionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/OptionRequest.java
@@ -30,7 +30,7 @@ public class OptionRequest extends BaseRequest<Option> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OptionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OptionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Option.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/OptionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/OptionRequestBuilder.java
@@ -29,7 +29,7 @@ public class OptionRequestBuilder extends BaseRequestBuilder<Option> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public OptionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public OptionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoRequest.java
@@ -30,7 +30,7 @@ public class PhotoRequest extends BaseRequest<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Photo.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoRequestBuilder.java
@@ -29,7 +29,7 @@ public class PhotoRequestBuilder extends BaseRequestBuilder<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoStreamRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoStreamRequest.java
@@ -31,7 +31,7 @@ public class PhotoStreamRequest extends BaseStreamRequest<Photo> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoStreamRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Photo.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoStreamRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/PhotoStreamRequestBuilder.java
@@ -30,7 +30,7 @@ public class PhotoStreamRequestBuilder extends BaseRequestBuilder<InputStream> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public PhotoStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public PhotoStreamRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequest.java
@@ -37,7 +37,7 @@ public class SegmentCollectionRequest extends BaseEntityCollectionRequest<Segmen
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentCollectionResponse.class, SegmentCollectionPage.class, SegmentCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentCollectionRequestBuilder.java
@@ -38,7 +38,7 @@ public class SegmentCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentRequestBuilder.class, SegmentCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentForwardRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentForwardRequest.java
@@ -28,7 +28,7 @@ public class SegmentForwardRequest extends BaseRequest<Void> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentForwardRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Void.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentForwardRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentForwardRequestBuilder.java
@@ -22,6 +22,16 @@ import javax.annotation.Nonnull;
  */
 public class SegmentForwardRequestBuilder extends BaseActionRequestBuilder<Segment> {
 
+    /**
+     * The request builder for this SegmentForward
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions);
+    }
     private SegmentForwardParameterSet body;
     /**
      * The request builder for this SegmentForward
@@ -31,7 +41,7 @@ public class SegmentForwardRequestBuilder extends BaseActionRequestBuilder<Segme
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentForwardParameterSet parameters) {
+    public SegmentForwardRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentForwardParameterSet parameters) {
         super(requestUrl, client, requestOptions);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentRequest.java
@@ -38,7 +38,7 @@ public class SegmentRequest extends BaseRequest<Segment> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Segment.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.java
@@ -39,7 +39,7 @@ public class SegmentRequestBuilder extends BaseRequestBuilder<Segment> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequest.java
@@ -42,7 +42,7 @@ public class SegmentTestActionCollectionRequest extends BaseActionCollectionRequ
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SegmentTestActionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SegmentTestActionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SegmentTestActionCollectionResponse.class, SegmentTestActionCollectionPage.class, SegmentTestActionCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionRequestBuilder.java
@@ -29,6 +29,16 @@ import com.microsoft.graph.http.BaseActionCollectionRequestBuilder;
  */
 public class SegmentTestActionCollectionRequestBuilder extends BaseActionCollectionRequestBuilder<Session, SegmentTestActionCollectionRequestBuilder, SegmentTestActionCollectionResponse, SegmentTestActionCollectionPage, SegmentTestActionCollectionRequest> {
 
+    /**
+     * The request builder for this collection of Segment
+     *
+     * @param requestUrl     the request URL
+     * @param client         the service client
+     * @param requestOptions the options for this request
+     */
+    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+        super(requestUrl, client, requestOptions, SegmentTestActionCollectionRequestBuilder.class, SegmentTestActionCollectionRequest.class);
+    }
     private SegmentTestActionParameterSet body;
     /**
      * The request builder for this collection of Segment
@@ -38,7 +48,7 @@ public class SegmentTestActionCollectionRequestBuilder extends BaseActionCollect
      * @param requestOptions the options for this request
      * @param parameters     the parameters for the service method
      */
-    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentTestActionParameterSet parameters) {
+    public SegmentTestActionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions, @Nonnull final SegmentTestActionParameterSet parameters) {
         super(requestUrl, client, requestOptions, SegmentTestActionCollectionRequestBuilder.class, SegmentTestActionCollectionRequest.class);
         this.body = parameters;
     }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionCollectionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionCollectionRequest.java
@@ -35,7 +35,7 @@ public class SessionCollectionRequest extends BaseEntityCollectionRequest<Sessio
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionCollectionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionCollectionResponse.class, SessionCollectionPage.class, SessionCollectionRequestBuilder.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionCollectionRequestBuilder.java
@@ -34,7 +34,7 @@ public class SessionCollectionRequestBuilder extends BaseCollectionRequestBuilde
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionCollectionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionRequestBuilder.class, SessionCollectionRequest.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionReferenceRequest.java
@@ -36,7 +36,7 @@ public class SessionReferenceRequest extends BaseReferenceRequest<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionReferenceRequestBuilder.java
@@ -33,7 +33,7 @@ public class SessionReferenceRequestBuilder extends BaseReferenceRequestBuilder<
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionReferenceRequest.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionRequest.java
@@ -32,7 +32,7 @@ public class SessionRequest extends BaseRequest<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionRequestBuilder.java
@@ -31,7 +31,7 @@ public class SessionRequestBuilder extends BaseRequestBuilder<Session> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequest.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequest.java
@@ -35,7 +35,7 @@ public class SessionWithReferenceRequest extends BaseWithReferenceRequest<Sessio
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionWithReferenceRequest(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, Session.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SessionWithReferenceRequestBuilder.java
@@ -32,7 +32,7 @@ public class SessionWithReferenceRequestBuilder extends BaseWithReferenceRequest
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SessionWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SessionWithReferenceRequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SessionWithReferenceRequest.class, SessionReferenceRequestBuilder.class);
     }
 }

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SingletonEntity1Request.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SingletonEntity1Request.java
@@ -31,7 +31,7 @@ public class SingletonEntity1Request extends BaseRequest<SingletonEntity1> {
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1Request(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions, SingletonEntity1.class);
     }
 

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SingletonEntity1RequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/SingletonEntity1RequestBuilder.java
@@ -30,7 +30,7 @@ public class SingletonEntity1RequestBuilder extends BaseRequestBuilder<Singleton
      * @param client         the service client
      * @param requestOptions the options for this request
      */
-    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
+    public SingletonEntity1RequestBuilder(@Nonnull final String requestUrl, @Nonnull final IBaseClient<?> client, @Nullable final java.util.List<? extends com.microsoft.graph.options.Option> requestOptions) {
         super(requestUrl, client, requestOptions);
     }
 


### PR DESCRIPTION
- fixes a bug where generic requests would be refering to the non-generic client type
- fixes a bug where method request builders would be missing a default constructors without parameter sets in some cases
- updates test files


generation result https://github.com/microsoftgraph/msgraph-sdk-java/pull/661
related https://github.com/microsoftgraph/msgraph-sdk-java/issues/660