### PR TITLE
bugfix/java v3 missing javadoc

### DIFF
--- a/Templates/templates/Java/requests/BaseClient.java.tt
+++ b/Templates/templates/Java/requests/BaseClient.java.tt
@@ -50,7 +50,7 @@ import okhttp3.Request;
      * @return builder to start configuring the client
      */
     @Nonnull
-    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(Class<nativeClient> nativeClientClass, Class<nativeRequest> nativeRequestClass) {
+    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(@Nonnull final Class<nativeClient> nativeClientClass, @Nonnull final Class<nativeRequest> nativeRequestClass) {
         return new Builder<>();
     }
     /**

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/GraphServiceClient.java
@@ -67,7 +67,7 @@ public class GraphServiceClient<nativeRequestType> extends BaseClient<nativeRequ
      * @return builder to start configuring the client
      */
     @Nonnull
-    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(Class<nativeClient> nativeClientClass, Class<nativeRequest> nativeRequestClass) {
+    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(@Nonnull final Class<nativeClient> nativeClientClass, @Nonnull final Class<nativeRequest> nativeRequestClass) {
         return new Builder<>();
     }
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GraphServiceClient.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/GraphServiceClient.java
@@ -67,7 +67,7 @@ public class GraphServiceClient<nativeRequestType> extends BaseClient<nativeRequ
      * @return builder to start configuring the client
      */
     @Nonnull
-    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(Class<nativeClient> nativeClientClass, Class<nativeRequest> nativeRequestClass) {
+    public static <nativeClient, nativeRequest> Builder<nativeClient, nativeRequest> builder(@Nonnull final Class<nativeClient> nativeClientClass, @Nonnull final Class<nativeRequest> nativeRequestClass) {
         return new Builder<>();
     }
     /**


### PR DESCRIPTION
- fixes a bug where some javadoc would be missing causingbuild to fail on v3
- updates test files

related https://github.com/microsoftgraph/msgraph-sdk-java/pull/650
(sorry about the mess for this one, I missed a few things on the original PR...)