### PR TITLE
Change cron definition in YAML to single quote

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -4,7 +4,7 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 10 * * TUE"
+- cron: '0 10 * * TUE'
   displayName: Tuesday generation (PST 2am, EST 5am, EAT 3pm)
   branches:
     include:


### PR DESCRIPTION
Fixes #441 per https://stackoverflow.com/questions/56756536/scheduled-builds-never-trigger-in-azure-devops-pipeline