### PR TITLE
Fix file comparison condition where there are new files

### DIFF
--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -94,10 +94,11 @@ namespace Typewriter.Test
             var outputDirectoryInfo = new DirectoryInfo(outputDirectory);
             var dataDirectoryInfo = new DirectoryInfo(dataDirectory);
 
-            if (outputDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length != dataDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length)
-            {
-                Assert.Fail("Number of generated files don't match with number of expected files!");
-            }
+            Assert.AreEqual(dataDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length,
+                outputDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length,
+                $@"Number of generated files don't match with number of expected files! Compare these two folders:
+{dataDirectory}
+{outputDirectory}");
 
             // Assert
             var testOutputBuilder = new StringBuilder();

--- a/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
+++ b/test/Typewriter.Test/MultipleNamespacesTestRunner.cs
@@ -91,6 +91,14 @@ namespace Typewriter.Test
 
             Generator.GenerateFiles(csdlContents, options);
 
+            var outputDirectoryInfo = new DirectoryInfo(outputDirectory);
+            var dataDirectoryInfo = new DirectoryInfo(dataDirectory);
+
+            if (outputDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length != dataDirectoryInfo.GetFiles("*.*", SearchOption.AllDirectories).Length)
+            {
+                Assert.Fail("Number of generated files don't match with number of expected files!");
+            }
+
             // Assert
             var testOutputBuilder = new StringBuilder();
             var errorCounter = 0;


### PR DESCRIPTION
Fixes #444

This adds an early file count check to make sure that generated file count matches with expected. Previously we were not testing for newly generated files because we were only walking the expected file tree and checking whether those files appear in the actual output. This was missing new additions to the actual output.

I have tested with latest code, this condition passes.
I have also cherry-picked the same changes and applied into an earlier state of the repo where there was a mismatch and the condition failed there.