### PR TITLE
Fix generation pipeline stages

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -94,6 +94,8 @@ variables:
   cleanMetadataFileV1: '$(Build.SourcesDirectory)/msgraph-metadata/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml'
   cleanMetadataFileV1OutputPath: '$(Build.SourcesDirectory)/msgraph-metadata/clean_v10_metadata/'
   cleanMetadataFileBetaOutputPath: '$(Build.SourcesDirectory)/msgraph-metadata/clean_beta_metadata/'
+  cleanMetadataFolderBeta: 'clean_beta_metadata'
+  cleanMetadataFolderV1: 'clean_v10_metadata'
   rawMetadataFileBeta: 'https://graph.microsoft.com/beta/$metadata'
   rawMetadataFileV1: 'https://graph.microsoft.com/v1.0/$metadata' # We want to run against the metadata we have captured.
   typewriterDirectory: '$(Build.SourcesDirectory)/typewriter'
@@ -111,6 +113,7 @@ variables:
 
   publishChanges: ${{ parameters.publishChanges }}
   overrideSkipCI: ${{ parameters.overrideSkipCI }}
+  skipMetadataCaptureAndClean: ${{ parameters.skipMetadataCaptureAndClean }}
 
   phpVersion: 7.2
 
@@ -142,6 +145,7 @@ stages:
         outputPath: $(cleanMetadataFileV1OutputPath)
         repoName: "msgraph-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
 
 # Same description as stage_v1_metadata
 - stage: stage_beta_metadata
@@ -159,6 +163,7 @@ stages:
         outputPath: $(cleanMetadataFileBetaOutputPath)
         repoName: "msgraph-beta-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileBeta)
+        cleanMetadataFolder: $(cleanMetadataFolderBeta)
 
 - stage: stage_csharp_v1
   dependsOn:
@@ -180,6 +185,7 @@ stages:
         repoName: 'msgraph-sdk-dotnet'
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/dotnet.yml
           parameters:
@@ -206,6 +212,7 @@ stages:
         repoName: 'msgraph-beta-sdk-dotnet'
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
+        cleanMetadataFolder: $(cleanMetadataFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/dotnet.yml
           parameters:
@@ -232,6 +239,7 @@ stages:
         repoName: 'msgraph-sdk-java'
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/java.yml
           parameters:
@@ -257,6 +265,7 @@ stages:
         repoName: 'msgraph-beta-sdk-java'
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
+        cleanMetadataFolder: $(cleanMetadataFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/java.yml
           parameters:
@@ -282,6 +291,7 @@ stages:
         repoName: 'msgraph-sdk-php'
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/php-v1.yml
 
@@ -305,6 +315,7 @@ stages:
         repoName: 'msgraph-sdk-php'
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
+        cleanMetadataFolder: $(cleanMetadataFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/php-beta.yml
 
@@ -328,6 +339,7 @@ stages:
         repoName: 'msgraph-typescript-typings'
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/typescript.yml
 
@@ -351,6 +363,7 @@ stages:
         repoName: 'msgraph-typescript-typings'
         branchName: $(typeScriptBetaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
+        cleanMetadataFolder: $(cleanMetadataFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/typescript.yml
         optionalPostCheckoutStep:
@@ -380,5 +393,6 @@ stages:
         repoName: 'msgraph-sdk-objc-models'
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
+        cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/objc.yml

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -20,6 +20,8 @@ parameters:
 - name: 'cleanMetadataFile'
   type: string
   default: $(cleanMetadataFileV1)
+- name: 'cleanMetadataFolder'
+  type: string
 
 steps:
 
@@ -73,7 +75,7 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: '$(Build.ArtifactStagingDirectory)'
-    artifactName: '${{ parameters.endpoint }} metadata'
+    artifactName: ${{ parameters.cleanMetadataFolder }}
 
 # Use the clean metadata from the last step to generate DotNet files.
 

--- a/.azure-pipelines/generation-templates/language-generation.yml
+++ b/.azure-pipelines/generation-templates/language-generation.yml
@@ -28,8 +28,13 @@ parameters:
 - name: cleanMetadataFile
   type: string
 
+- name: cleanMetadataFolder
+  type: string
+
 steps:
 - template: set-up-for-generation.yml
+  parameters:
+    cleanMetadataFolder: ${{ parameters.cleanMetadataFolder }}
 
 - checkout: ${{ parameters.repoName }}
   displayName: 'checkout ${{ parameters.repoName }}'

--- a/.azure-pipelines/generation-templates/set-up-for-generation.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation.yml
@@ -18,11 +18,7 @@ steps:
 # if capture and clean step is not skipped
 # then download the artifact from capture and clean steps
 # follow the same folder structure as msgraph-metadata repo
-#- pwsh: |
-#    mkdir msgraph-metadata
-#  workingDirectory: $(Build.SourcesDirectory)
-#  condition: eq(variables.skipMetadataCaptureAndClean, false)
-
+# so that metadata reference path is always the same
 - task: DownloadBuildArtifacts@0
   inputs:
     buildType: 'current'

--- a/.azure-pipelines/generation-templates/set-up-for-generation.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation.yml
@@ -27,7 +27,7 @@ steps:
   inputs:
     buildType: 'current'
     downloadType: 'single'
-    artifactName: $(cleanMetadataFolder)
+    artifactName: ${{ parameters.cleanMetadataFolder }}
     downloadPath: '$(Build.SourcesDirectory)/msgraph-metadata'
   condition: eq(variables.skipMetadataCaptureAndClean, false)
   displayName: Downloading metadata from artifacts

--- a/.azure-pipelines/generation-templates/set-up-for-generation.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation.yml
@@ -1,5 +1,35 @@
+parameters:
+  - name: version
+    type: string
+  - name: cleanMetadataFolder
+    type: string
+
 steps:
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
-- template: checkout-metadata.yml
 - template: download-typewriter.yml
+
+# checkout metadata repo if capture and clean step is skipped
+- checkout: msgraph-metadata
+  displayName: checkout metadata
+  fetchDepth: 1
+  persistCredentials: true
+  submodules: recursive
+  condition: eq(variables.skipMetadataCaptureAndClean, true)
+
+# if capture and clean step is not skipped
+# then download the artifact from capture and clean steps
+# follow the same folder structure as msgraph-metadata repo
+- pwsh: |
+    mkdir msgraph-metadata
+  workingDirectory: $(Build.SourcesDirectory)
+  condition: eq(variables.skipMetadataCaptureAndClean, false)
+
+- task: DownloadBuildArtifacts@0
+  inputs:
+    buildType: 'current'
+    downloadType: 'single'
+    artifactName: $(cleanMetadataFolder)
+    downloadPath: '$(Build.SourcesDirectory)/msgraph-metadata'
+  condition: eq(variables.skipMetadataCaptureAndClean, false)
+  displayName: Downloading metadata from artifacts

--- a/.azure-pipelines/generation-templates/set-up-for-generation.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation.yml
@@ -18,10 +18,10 @@ steps:
 # if capture and clean step is not skipped
 # then download the artifact from capture and clean steps
 # follow the same folder structure as msgraph-metadata repo
-- pwsh: |
-    mkdir msgraph-metadata
-  workingDirectory: $(Build.SourcesDirectory)
-  condition: eq(variables.skipMetadataCaptureAndClean, false)
+#- pwsh: |
+#    mkdir msgraph-metadata
+#  workingDirectory: $(Build.SourcesDirectory)
+#  condition: eq(variables.skipMetadataCaptureAndClean, false)
 
 - task: DownloadBuildArtifacts@0
   inputs:

--- a/.azure-pipelines/generation-templates/set-up-for-generation.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation.yml
@@ -1,6 +1,4 @@
 parameters:
-  - name: version
-    type: string
   - name: cleanMetadataFolder
     type: string
 

--- a/scripts/git-push-cleanmetadata.ps1
+++ b/scripts/git-push-cleanmetadata.ps1
@@ -1,4 +1,4 @@
-if (!$env:PublishChanges)
+if ($env:PublishChanges -eq $False)
 {
     Write-Host "Not publishing changes per the run parameter!" -ForegroundColor Green
     return;

--- a/scripts/git-push-files.ps1
+++ b/scripts/git-push-files.ps1
@@ -1,6 +1,4 @@
-Write-Host "PublishChanges is set to $env:PublishChanges" -ForegroundColor Green
-
-if (!$env:PublishChanges)
+if ($env:PublishChanges -eq $False)
 {
     Write-Host "Not publishing changes as a branch per the run parameter!" -ForegroundColor Green
     return;
@@ -8,13 +6,13 @@ if (!$env:PublishChanges)
 
 Write-Host "About to add files....." -ForegroundColor Green
 
-if ($env:OverrideSkipCI)
+if ($env:OverrideSkipCI -eq $True)
 {
     Write-Host "Overriding [skip ci] flag.." -ForegroundColor Yellow
 }
 
 git add . | Write-Host
-if (!$env:OverrideSkipCI -and ($env:BUILD_REASON -eq 'Manual')) # Skip CI if manually running this pipeline.
+if (($env:OverrideSkipCI -eq $False) -and ($env:BUILD_REASON -eq 'Manual')) # Skip CI if manually running this pipeline.
 {
     git commit -m "Update generated files with build $env:BUILD_BUILDID [skip ci]" | Write-Host
 }

--- a/scripts/git-push-files.ps1
+++ b/scripts/git-push-files.ps1
@@ -1,3 +1,5 @@
+Write-Host "PublishChanges is set to $env:PublishChanges" -ForegroundColor Green
+
 if (!$env:PublishChanges)
 {
     Write-Host "Not publishing changes as a branch per the run parameter!" -ForegroundColor Green


### PR DESCRIPTION
Fixes #450 by using metadata as an artifact instead of checking out the metadata repo in an earlier snapshot.

In the case that "skip metadata clean and capture" is set, the pipeline continues to use `msgraph-metadata` repo directly. If it is not set, it downloads the uploaded artifact from the build.

I used the same folder structure between explicit checkout vs downloading from artifact to simplify file path inputs to typewriter.

Fixes #454 by using `-eq` with environment variable checks because they are strings by default and there is an implicit type conversion even if assigned value is boolean.

I ran the full pipeline with "skip metadata clean and capture" not set and set. There is no difference generated in the subsequent run.

Diffs:
[ObjC](https://github.com/microsoftgraph/msgraph-sdk-objc-models/compare/zengin/test/40856..zengin/test/40857) Note that pbxproj generation is indeterministic in the lines it generates, that's why there is a diff only in that file.
[Java](https://github.com/microsoftgraph/msgraph-sdk-java/compare/zengin/test/40856..zengin/test/40857)
[DotNet](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/zengin/test/40856..zengin/test/40857)
[TypeScript](https://github.com/microsoftgraph/msgraph-typescript-typings/compare/zengin/test/40856..zengin/test/40857)
[Java Beta](https://github.com/microsoftgraph/msgraph-beta-sdk-java/compare/zengin/testbeta/40856..zengin/testbeta/40857)
[DotNet Beta](https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/compare/zengin/testbeta/40856..zengin/testbeta/40857)
[Typescript Beta](https://github.com/microsoftgraph/msgraph-typescript-typings/compare/zengin/testbeta/40856..zengin/testbeta/40857)

PHP generation is broken on #453 

Similarly no diff is generated with the latest V1 and Beta generations and the generations I had after these changes. We only have documentation changes.
See DotNet comparison as an example:
https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/v1.0/pipelinebuild/40826..zengin/test/40857

Java shows type summary diff as well in addition to doc changes, but it is because there is no typesummary commit on my special branch:
https://github.com/microsoftgraph/msgraph-sdk-java/compare/v1.0/pipelinebuild/40826..zengin/test/40857