### PR TITLE
MethodRequestBuilders to use fully qualified name for cross namespace references

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -517,10 +517,11 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
         /// <returns></returns>
         public static List<NavigationPropertyInfo> GetAllNavigationPropertyInfo(this List<OdcmProperty> navProperties)
         {
+            var classNamespace = navProperties.FirstOrDefault()?.GetClassNamespace();
             return navProperties.Select(p =>
             {
-                var returnClassRequestBuilderName = String.Format("{0}RequestBuilder", p.Type.Name.ToCheckedCase());
-                var returnInterfaceRequestBuilderName = String.Format("I{0}", returnClassRequestBuilderName);
+                var returnClassRequestBuilderName = p.Type.GetTypeString(classNamespace, "{0}RequestBuilder");
+                var returnInterfaceRequestBuilderName = p.Type.GetTypeString(classNamespace, "I{0}RequestBuilder");
                 var name = p.Name.ToCheckedCase();
                 var segment = p.Name;
                 var description = p.Description ?? string.Empty;

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -63,12 +63,12 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets the request builder for Recipients.
         /// 
         /// </summary>
-        /// <returns>The <see cref="IEntityType2RequestBuilder"/>.</returns>
-        public IEntityType2RequestBuilder Recipients
+        /// <returns>The <see cref="Microsoft.Graph.IEntityType2RequestBuilder"/>.</returns>
+        public Microsoft.Graph.IEntityType2RequestBuilder Recipients
         {
             get
             {
-                return new EntityType2RequestBuilder(this.AppendSegmentToRequestUrl("recipients"), this.Client);
+                return new Microsoft.Graph.EntityType2RequestBuilder(this.AppendSegmentToRequestUrl("recipients"), this.Client);
             }
         }
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/ICallRecordItemRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/ICallRecordItemRequestBuilder.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -35,8 +35,8 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets the request builder for Recipients.
         /// 
         /// </summary>
-        /// <returns>The <see cref="IEntityType2RequestBuilder"/>.</returns>
-        IEntityType2RequestBuilder Recipients  { get; }
+        /// <returns>The <see cref="Microsoft.Graph.IEntityType2RequestBuilder"/>.</returns>
+        Microsoft.Graph.IEntityType2RequestBuilder Recipients  { get; }
         /// <summary>
         /// Gets the request builder for Sessions.
         /// 


### PR DESCRIPTION
- Unblocks beta generation in staging.
- Fixes #492
- Successful build with the change: https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=44362&view=ms.vss-test-web.build-test-results-tab

It turns out we already had a case in the test data but fully qualified name was missed in the PRs (I only changed the test output data in this PR to the expected fully qualified name). Maybe we should consider adding a compilation test to the test data in the corresponding .NET repo (#494). This was what I was doing in local dev environment while developing the namespaces feature.