### PR TITLE
bugfix/java subnamespace import

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
@@ -693,6 +693,17 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.Java
                             currentMethod.Class.TypeName());
                 sb.Append("\n");
             }
+            if (currentMethod.IsComposable &&
+                currentMethod.ReturnType != null &&
+                currentMethod.ReturnType is OdcmClass returnTypeClass) {
+                    var returnTypeNamespace = returnTypeClass.Namespace.Name.AddPrefix();
+                    returnTypeClass
+                        .NavigationProperties(true)
+                        .Where(x => !x.GetPropertyNamespace().Equals(returnTypeNamespace))
+                        .Select(x => $"import {x.GetPropertyNamespace()}.{GetPrefixForRequests()}.{x.Projection.Type.TypeRequestBuilder()};\n")
+                        .ToList()
+                        .ForEach(x => sb.Append(x));
+                }
 
             var imports = host.CurrentType.AsOdcmMethod().WithOverloads().SelectMany(x => ImportClassesOfMethodParameters(x));
             sb.Append(imports.Any() ? imports.Aggregate((x, y) => $"{x}{Environment.NewLine}{y}") : string.Empty);

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.graph2.callrecords.requests;
 import com.microsoft.graph2.callrecords.requests.CallRecordItemRequest;
+import com.microsoft.graph.requests.EntityType2RequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecord;
 import com.microsoft.graph.http.BaseFunctionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecordItemParameterSet;

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.graph2.callrecords.requests;
 import com.microsoft.graph2.callrecords.requests.CallRecordItemRequest;
+import com.microsoft.graph.requests.EntityType2RequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecord;
 import com.microsoft.graph.http.BaseFunctionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecordItemParameterSet;


### PR DESCRIPTION
- fixes a bug where types in subnamespaces would not be imported for java composable methods
- updates test files for java composable method subnamespace import

related https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/85