### PR TITLE
Adds ability to override the base url in httpclient constructor

### DIFF
--- a/Templates/templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityClient.cs.tt
@@ -65,9 +65,11 @@ namespace <#=@namespace#>
         /// </summary>
         /// <param name="httpClient">The <see cref="HttpClient"/> to use for making requests to Microsoft Graph. Use the <see cref="GraphClientFactory"/>
         /// to get a pre-configured HttpClient that is optimized for use with the Microsoft Graph service API. </param>
+        /// <param name="baseUrl">The base service URL. For example, "<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>".</param>
         public <#=clientName#>(
-            HttpClient httpClient)
-            : base("<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>", httpClient)
+            HttpClient httpClient,
+            string baseUrl = "<#=ConfigurationService.Settings.DefaultBaseEndpointUrl#>")
+            : base(baseUrl, httpClient)
         {
         }
     <#

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceClient.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceClient.cs
@@ -64,9 +64,11 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="httpClient">The <see cref="HttpClient"/> to use for making requests to Microsoft Graph. Use the <see cref="GraphClientFactory"/>
         /// to get a pre-configured HttpClient that is optimized for use with the Microsoft Graph service API. </param>
+        /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0".</param>
         public GraphServiceClient(
-            HttpClient httpClient)
-            : base("https://graph.microsoft.com/v1.0", httpClient)
+            HttpClient httpClient,
+            string baseUrl = "https://graph.microsoft.com/v1.0")
+            : base(baseUrl, httpClient)
         {
         }
     


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/916.

It enables the users of the SDK to define their own base address for the request builders in the event they are using their own httpclient and varying clouds.

Generation PRs:
V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/959
Beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/276

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/511)