### PR TITLE
Fix next link initialization

### DIFF
--- a/Templates/templates/CSharp/Base/SharedCSharp.template.tt
+++ b/Templates/templates/CSharp/Base/SharedCSharp.template.tt
@@ -334,5 +334,40 @@ public string GetMethodRequestPrimitiveReturnTypeString(string type)
     }
 }
 
+/// <summary>
+/// Used in EntityCollectionResponse.cs.tt, EntityCollectionWithReferencesResponse and  MethodCollectionResponse.cs.tt
+/// to get the function to initialized the NextPageRequest object in the response of the collection request
+/// and to copy the Additional data to the CollectionPage instance
+/// </summary>
+/// <param name="iBaseClientTypeName"> type of the IBaseClient to use in creating the method</param>
+/// <returns>the string representation of the method</returns>
+public string GetInitializeCollectionPropertiesMethod(string iBaseClientTypeName)
+{
+    return @"/// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        " + string.Format("internal void InitializeCollectionProperties({0} client)", iBaseClientTypeName)
+                + @"
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue(""@odata.nextLink"", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }";
+}
 
 #>

--- a/Templates/templates/CSharp/Base/SharedCSharp.template.tt
+++ b/Templates/templates/CSharp/Base/SharedCSharp.template.tt
@@ -334,40 +334,5 @@ public string GetMethodRequestPrimitiveReturnTypeString(string type)
     }
 }
 
-/// <summary>
-/// Used in EntityCollectionResponse.cs.tt, EntityCollectionWithReferencesResponse and  MethodCollectionResponse.cs.tt
-/// to get the function to initialized the NextPageRequest object in the response of the collection request
-/// and to copy the Additional data to the CollectionPage instance
-/// </summary>
-/// <param name="iBaseClientTypeName"> type of the IBaseClient to use in creating the method</param>
-/// <returns>the string representation of the method</returns>
-public string GetInitializeCollectionPropertiesMethod(string iBaseClientTypeName)
-{
-    return @"/// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        " + string.Format("internal void InitializeCollectionProperties({0} client)", iBaseClientTypeName)
-                + @"
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue(""@odata.nextLink"", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }";
-}
 
 #>

--- a/Templates/templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/templates/CSharp/Model/EntityType.cs.tt
@@ -143,7 +143,19 @@ if (attributeStringBuilder.Length > 0) {
         /// </summary>
         <#=attributeDefinition#>
         public I<#=propertyCollectionPage#> <#=propertyName.GetSanitizedPropertyName()#> { get; set; }
+
+<#
+                    if (property.IsComplex())
+                    {
+                        var collectionPropertyName = property.Name.ToCheckedCase().GetSanitizedPropertyName();
+#>
+        /// <summary>
+        /// Gets or sets <#=collectionPropertyName.ToLowerFirstChar()#>NextLink.
+        /// </summary>
+        [JsonPropertyName("<#=collectionPropertyName.ToLowerFirstChar()#>@odata.nextLink")]
+        public string <#=collectionPropertyName#>NextLink { get; set; }
     <#
+                    }
                 }
                 else
                 {

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -48,24 +48,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -52,12 +52,14 @@ namespace <#=@namespace#>
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -46,9 +46,10 @@ namespace <#=@namespace#>
         {
             this.Method = <#=templateWriter.GetMethod#>;
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -55,11 +55,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -50,18 +50,16 @@ namespace <#=@namespace#>
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequest.cs.tt
@@ -49,6 +49,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -12,7 +12,7 @@ var entityName = prop.Class.Name.ToCheckedCase();
 var propName = prop.Name.ToCheckedCase();
 var collectionResponse = string.Concat(entityName, propName, "CollectionResponse");
 var collectionPage = string.Concat(entityName, propName, "CollectionPage");
-var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
+
 #>
 namespace <#=@namespace#>
 {
@@ -41,7 +41,5 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -12,7 +12,7 @@ var entityName = prop.Class.Name.ToCheckedCase();
 var propName = prop.Name.ToCheckedCase();
 var collectionResponse = string.Concat(entityName, propName, "CollectionResponse");
 var collectionPage = string.Concat(entityName, propName, "CollectionPage");
-
+var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
 #>
 namespace <#=@namespace#>
 {
@@ -41,5 +41,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -37,6 +37,12 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         public I<#=collectionPage#> Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -48,12 +48,14 @@ namespace <#=@namespace#>
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -46,18 +46,16 @@ namespace <#=@namespace#>
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -44,24 +44,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -51,11 +51,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -42,9 +42,10 @@ namespace <#=@namespace#>
         {
             this.Method = <#=templateWriter.GetMethod#>;
             var response = await this.SendAsync<<#=collectionResponse#>>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesRequest.cs.tt
@@ -45,6 +45,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -37,6 +37,12 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         public I<#=collectionPage#> Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -12,7 +12,7 @@ var entityName = prop.Class.Name.ToCheckedCase();
 var propName = prop.Name.ToCheckedCase();
 var collectionResponse = string.Concat(entityName, propName, "CollectionWithReferencesResponse");
 var collectionPage = string.Concat(entityName, propName, "CollectionWithReferencesPage");
-var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
+
 #>
 namespace <#=@namespace#>
 {
@@ -41,7 +41,5 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -12,7 +12,7 @@ var entityName = prop.Class.Name.ToCheckedCase();
 var propName = prop.Name.ToCheckedCase();
 var collectionResponse = string.Concat(entityName, propName, "CollectionWithReferencesResponse");
 var collectionPage = string.Concat(entityName, propName, "CollectionWithReferencesPage");
-
+var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
 #>
 namespace <#=@namespace#>
 {
@@ -41,5 +41,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
@@ -123,15 +123,16 @@ namespace <#=@namespace#>
                 {
                     <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.AdditionalData = <#=thisEntity_Name#>ToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    <#=thisEntity_Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(<#=thisEntity_Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out var nextPageLink))
                     {
-                        <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 <#

--- a/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
@@ -128,11 +128,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
@@ -108,7 +108,7 @@ namespace <#=@namespace#>
         {
 #>
 
-            if (<#=thisEntity_Name#>ToInitialize != null && <#=thisEntity_Name#>ToInitialize.AdditionalData != null)
+            if (<#=thisEntity_Name#>ToInitialize != null)
             {
 <#
             foreach(var property in navigationCollectionProperties)
@@ -118,23 +118,11 @@ namespace <#=@namespace#>
                 if (property.IsComplex())
                 {
 #>
-
                 if (<#=thisEntity_Name#>ToInitialize.<#=propertyName#> != null && <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.CurrentPage != null)
                 {
+                    <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(this.Client, <#=thisEntity_Name#>ToInitialize.<#=propertyName#>NextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.AdditionalData = <#=thisEntity_Name#>ToInitialize.AdditionalData;
-
-                    if(<#=thisEntity_Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 <#
                 }

--- a/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityRequest.cs.tt
@@ -125,13 +125,14 @@ namespace <#=@namespace#>
 
                     if(<#=thisEntity_Name#>ToInitialize.AdditionalData.TryGetValue("<#=propertyName.ToLowerFirstChar()#>@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             <#=thisEntity_Name#>ToInitialize.<#=propertyName#>.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -58,9 +58,10 @@ namespace <#=@namespace#>
         #>
 
             var response = await this.PollForOperationCompletionAsync(progress, cancellationToken);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
 
             <#
             if (isSpecialCollection)

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -61,6 +61,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
 
             <#

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -69,11 +69,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.OneDriveClient,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -66,13 +66,14 @@ namespace <#=@namespace#>
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.OneDriveClient,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -60,23 +60,8 @@ namespace <#=@namespace#>
             var response = await this.PollForOperationCompletionAsync(progress, cancellationToken);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
+                response.InitializeCollectionProperties(this.Client);
 
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.OneDriveClient,
-                                element.GetString());
-                        }
-                    }
-                }
             <#
             if (isSpecialCollection)
             {

--- a/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodAsyncMonitor.cs.tt
@@ -64,16 +64,16 @@ namespace <#=@namespace#>
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.OneDriveClient,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.OneDriveClient,
+                                nextPageLinkString);
+                        }
                     }
                 }
             <#

--- a/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
@@ -12,7 +12,6 @@ var isSpecialCollection = method.LongDescriptionContains("specialCollection");
 var responseNamePrefix = method.Class.Name.ToCheckedCase() + method.Name.Substring(method.Name.IndexOf('.') + 1).ToCheckedCase();
 var collectionResponse = responseNamePrefix + "CollectionResponse";
 var collectionPage = responseNamePrefix + "CollectionPage";
-var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
 #>
 
 namespace <#=@namespace#>
@@ -57,7 +56,5 @@ namespace <#=@namespace#>
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
@@ -52,6 +52,12 @@ namespace <#=@namespace#>
         #>
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]

--- a/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
@@ -12,6 +12,7 @@ var isSpecialCollection = method.LongDescriptionContains("specialCollection");
 var responseNamePrefix = method.Class.Name.ToCheckedCase() + method.Name.Substring(method.Name.IndexOf('.') + 1).ToCheckedCase();
 var collectionResponse = responseNamePrefix + "CollectionResponse";
 var collectionPage = responseNamePrefix + "CollectionPage";
+var iBaseClientTypeName = @namespace.GetCoreLibraryType("IBaseClient");
 #>
 
 namespace <#=@namespace#>
@@ -56,5 +57,7 @@ namespace <#=@namespace#>
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        <#=this.GetInitializeCollectionPropertiesMethod(iBaseClientTypeName)#>
     }
 }

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -212,11 +212,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -344,11 +344,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -477,11 +477,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -600,11 +600,11 @@ namespace <#=@namespace#>
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -207,16 +207,16 @@ namespace <#=@namespace#>
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -338,16 +338,16 @@ namespace <#=@namespace#>
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -470,16 +470,16 @@ namespace <#=@namespace#>
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -592,16 +592,16 @@ namespace <#=@namespace#>
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -209,13 +209,14 @@ namespace <#=@namespace#>
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -340,13 +341,14 @@ namespace <#=@namespace#>
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -472,13 +474,14 @@ namespace <#=@namespace#>
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -594,13 +597,14 @@ namespace <#=@namespace#>
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -201,9 +201,10 @@ namespace <#=@namespace#>
     {
 #>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=methodParameter#>, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 
@@ -316,9 +317,10 @@ namespace <#=@namespace#>
     {
 #>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 
@@ -432,9 +434,10 @@ namespace <#=@namespace#>
     {
 #>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 
@@ -538,9 +541,10 @@ namespace <#=@namespace#>
     {
 #>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -204,6 +204,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
@@ -320,6 +321,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
@@ -437,6 +439,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
@@ -544,6 +547,7 @@ namespace <#=@namespace#>
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodRequest.cs.tt
@@ -203,24 +203,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=methodParameter#>, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 
@@ -335,24 +318,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 
@@ -468,24 +434,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 
@@ -591,24 +540,7 @@ namespace <#=@namespace#>
             var response = await this.SendAsync<<#=entityName#><#=methodName#>CollectionResponse>(<#=returnEntityParameter.GetSanitizedParameterName()#>, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -33,12 +33,24 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonPropertyName("calls")]
         public ICloudCommunicationsCallsCollectionPage Calls { get; set; }
+
+        /// <summary>
+        /// Gets or sets callsNextLink.
+        /// </summary>
+        [JsonPropertyName("calls@odata.nextLink")]
+        public string CallsNextLink { get; set; }
     
         /// <summary>
         /// Gets or sets call records.
         /// </summary>
         [JsonPropertyName("callRecords")]
         public ICloudCommunicationsCallRecordsCollectionPage CallRecords { get; set; }
+
+        /// <summary>
+        /// Gets or sets callRecordsNextLink.
+        /// </summary>
+        [JsonPropertyName("callRecords@odata.nextLink")]
+        public string CallRecordsNextLink { get; set; }
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonPropertyName("members")]
         public IGroupMembersCollectionWithReferencesPage Members { get; set; }
+
+        /// <summary>
+        /// Gets or sets membersNextLink.
+        /// </summary>
+        [JsonPropertyName("members@odata.nextLink")]
+        public string MembersNextLink { get; set; }
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -39,12 +39,24 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonPropertyName("timesOff")]
         public IScheduleTimesOffCollectionPage TimesOff { get; set; }
+
+        /// <summary>
+        /// Gets or sets timesOffNextLink.
+        /// </summary>
+        [JsonPropertyName("timesOff@odata.nextLink")]
+        public string TimesOffNextLink { get; set; }
     
         /// <summary>
         /// Gets or sets time off requests.
         /// </summary>
         [JsonPropertyName("timeOffRequests")]
         public IScheduleTimeOffRequestsCollectionPage TimeOffRequests { get; set; }
+
+        /// <summary>
+        /// Gets or sets timeOffRequestsNextLink.
+        /// </summary>
+        [JsonPropertyName("timeOffRequests@odata.nextLink")]
+        public string TimeOffRequestsNextLink { get; set; }
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<CloudCommunicationsCallRecordsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<CloudCommunicationsCallRecordsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph
         public ICloudCommunicationsCallRecordsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -27,5 +27,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<CloudCommunicationsCallsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<CloudCommunicationsCallsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph
         public ICloudCommunicationsCallsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
@@ -27,5 +27,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph
 
                     if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("calls@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -270,13 +271,14 @@ namespace Microsoft.Graph
 
                     if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("callRecords@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph
                 {
                     cloudCommunicationsToInitialize.Calls.AdditionalData = cloudCommunicationsToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    cloudCommunicationsToInitialize.AdditionalData.TryGetValue("calls@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("calls@odata.nextLink", out var nextPageLink))
                     {
-                        cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -267,15 +268,16 @@ namespace Microsoft.Graph
                 {
                     cloudCommunicationsToInitialize.CallRecords.AdditionalData = cloudCommunicationsToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    cloudCommunicationsToInitialize.AdditionalData.TryGetValue("callRecords@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("callRecords@odata.nextLink", out var nextPageLink))
                     {
-                        cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
@@ -244,43 +244,19 @@ namespace Microsoft.Graph
         private void InitializeCollectionProperties(CloudCommunications cloudCommunicationsToInitialize)
         {
 
-            if (cloudCommunicationsToInitialize != null && cloudCommunicationsToInitialize.AdditionalData != null)
+            if (cloudCommunicationsToInitialize != null)
             {
-
                 if (cloudCommunicationsToInitialize.Calls != null && cloudCommunicationsToInitialize.Calls.CurrentPage != null)
                 {
+                    cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(this.Client, cloudCommunicationsToInitialize.CallsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     cloudCommunicationsToInitialize.Calls.AdditionalData = cloudCommunicationsToInitialize.AdditionalData;
-
-                    if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("calls@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
-
                 if (cloudCommunicationsToInitialize.CallRecords != null && cloudCommunicationsToInitialize.CallRecords.CurrentPage != null)
                 {
+                    cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(this.Client, cloudCommunicationsToInitialize.CallRecordsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     cloudCommunicationsToInitialize.CallRecords.AdditionalData = cloudCommunicationsToInitialize.AdditionalData;
-
-                    if(cloudCommunicationsToInitialize.AdditionalData.TryGetValue("callRecords@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             cloudCommunicationsToInitialize.Calls.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -274,11 +274,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             cloudCommunicationsToInitialize.CallRecords.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<GraphServiceTestTypesCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<GraphServiceTestTypesCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -28,5 +28,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
@@ -24,34 +24,15 @@ namespace Microsoft.Graph
         public IGraphServiceTestTypesCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -43,9 +43,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<GroupMembersCollectionWithReferencesResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -45,24 +45,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<GroupMembersCollectionWithReferencesResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -47,18 +47,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesRequest.cs
@@ -49,12 +49,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph
         public IGroupMembersCollectionWithReferencesPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
@@ -27,5 +27,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             groupToInitialize.Members.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
@@ -244,25 +244,13 @@ namespace Microsoft.Graph
         private void InitializeCollectionProperties(Group groupToInitialize)
         {
 
-            if (groupToInitialize != null && groupToInitialize.AdditionalData != null)
+            if (groupToInitialize != null)
             {
-
                 if (groupToInitialize.Members != null && groupToInitialize.Members.CurrentPage != null)
                 {
+                    groupToInitialize.Members.InitializeNextPageRequest(this.Client, groupToInitialize.MembersNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     groupToInitialize.Members.AdditionalData = groupToInitialize.AdditionalData;
-
-                    if(groupToInitialize.AdditionalData.TryGetValue("members@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            groupToInitialize.Members.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph
                 {
                     groupToInitialize.Members.AdditionalData = groupToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    groupToInitialize.AdditionalData.TryGetValue("members@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(groupToInitialize.AdditionalData.TryGetValue("members@odata.nextLink", out var nextPageLink))
                     {
-                        groupToInitialize.Members.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            groupToInitialize.Members.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph
 
                     if(groupToInitialize.AdditionalData.TryGetValue("members@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             groupToInitialize.Members.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
@@ -244,43 +244,19 @@ namespace Microsoft.Graph
         private void InitializeCollectionProperties(Schedule scheduleToInitialize)
         {
 
-            if (scheduleToInitialize != null && scheduleToInitialize.AdditionalData != null)
+            if (scheduleToInitialize != null)
             {
-
                 if (scheduleToInitialize.TimesOff != null && scheduleToInitialize.TimesOff.CurrentPage != null)
                 {
+                    scheduleToInitialize.TimesOff.InitializeNextPageRequest(this.Client, scheduleToInitialize.TimesOffNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     scheduleToInitialize.TimesOff.AdditionalData = scheduleToInitialize.AdditionalData;
-
-                    if(scheduleToInitialize.AdditionalData.TryGetValue("timesOff@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            scheduleToInitialize.TimesOff.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
-
                 if (scheduleToInitialize.TimeOffRequests != null && scheduleToInitialize.TimeOffRequests.CurrentPage != null)
                 {
+                    scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(this.Client, scheduleToInitialize.TimeOffRequestsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     scheduleToInitialize.TimeOffRequests.AdditionalData = scheduleToInitialize.AdditionalData;
-
-                    if(scheduleToInitialize.AdditionalData.TryGetValue("timeOffRequests@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph
                 {
                     scheduleToInitialize.TimesOff.AdditionalData = scheduleToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    scheduleToInitialize.AdditionalData.TryGetValue("timesOff@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(scheduleToInitialize.AdditionalData.TryGetValue("timesOff@odata.nextLink", out var nextPageLink))
                     {
-                        scheduleToInitialize.TimesOff.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            scheduleToInitialize.TimesOff.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -267,15 +268,16 @@ namespace Microsoft.Graph
                 {
                     scheduleToInitialize.TimeOffRequests.AdditionalData = scheduleToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    scheduleToInitialize.AdditionalData.TryGetValue("timeOffRequests@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(scheduleToInitialize.AdditionalData.TryGetValue("timeOffRequests@odata.nextLink", out var nextPageLink))
                     {
-                        scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             scheduleToInitialize.TimesOff.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -274,11 +274,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph
 
                     if(scheduleToInitialize.AdditionalData.TryGetValue("timesOff@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             scheduleToInitialize.TimesOff.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -270,13 +271,14 @@ namespace Microsoft.Graph
 
                     if(scheduleToInitialize.AdditionalData.TryGetValue("timeOffRequests@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             scheduleToInitialize.TimeOffRequests.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<ScheduleTimeOffRequestsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<ScheduleTimeOffRequestsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph
         public IScheduleTimeOffRequestsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -27,5 +27,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<ScheduleTimesOffCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<ScheduleTimesOffCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
@@ -27,5 +27,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph
         public IScheduleTimesOffCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
@@ -28,5 +28,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
@@ -24,34 +24,15 @@ namespace Microsoft.Graph
         public ITestTypeQueryCollectionPage Value { get; set; }
         
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -49,9 +49,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.POST;
             var response = await this.SendAsync<TestTypeQueryCollectionResponse>(this.RequestBody, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -60,11 +60,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -57,13 +57,14 @@ namespace Microsoft.Graph
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -51,24 +51,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<TestTypeQueryCollectionResponse>(this.RequestBody, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryRequest.cs
@@ -55,16 +55,16 @@ namespace Microsoft.Graph
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
@@ -28,5 +28,30 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
@@ -24,34 +24,15 @@ namespace Microsoft.Graph
         public IUnifiedRoleEligibilityRequestFilterByCurrentUserCollectionPage Value { get; set; }
         
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Graph
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -43,24 +43,7 @@ namespace Microsoft.Graph
             var response = await this.SendAsync<UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -41,9 +41,10 @@ namespace Microsoft.Graph
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Graph
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -47,16 +47,16 @@ namespace Microsoft.Graph
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserRequest.cs
@@ -49,13 +49,14 @@ namespace Microsoft.Graph
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -87,12 +87,24 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonPropertyName("sessions")]
         public ICallRecordSessionsCollectionPage Sessions { get; set; }
+
+        /// <summary>
+        /// Gets or sets sessionsNextLink.
+        /// </summary>
+        [JsonPropertyName("sessions@odata.nextLink")]
+        public string SessionsNextLink { get; set; }
     
         /// <summary>
         /// Gets or sets recipients.
         /// </summary>
         [JsonPropertyName("recipients")]
         public ICallRecordRecipientsCollectionPage Recipients { get; set; }
+
+        /// <summary>
+        /// Gets or sets recipientsNextLink.
+        /// </summary>
+        [JsonPropertyName("recipients@odata.nextLink")]
+        public string RecipientsNextLink { get; set; }
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -70,6 +70,12 @@ namespace Microsoft.Graph2.CallRecords
         [Obsolete("entityType3 is deprecated. Please use singletonEntity1.")]
         [JsonPropertyName("refTypes")]
         public ISegmentRefTypesCollectionWithReferencesPage RefTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets refTypesNextLink.
+        /// </summary>
+        [JsonPropertyName("refTypes@odata.nextLink")]
+        public string RefTypesNextLink { get; set; }
     
         /// <summary>
         /// Gets or sets ref type.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -69,6 +69,12 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonPropertyName("segments")]
         public ISessionSegmentsCollectionPage Segments { get; set; }
+
+        /// <summary>
+        /// Gets or sets segmentsNextLink.
+        /// </summary>
+        [JsonPropertyName("segments@odata.nextLink")]
+        public string SegmentsNextLink { get; set; }
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph2.CallRecords
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<CallRecordRecipientsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph2.CallRecords
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph2.CallRecords
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph2.CallRecords
             var response = await this.SendAsync<CallRecordRecipientsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -27,5 +27,30 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph2.CallRecords
         public ICallRecordRecipientsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph2.CallRecords
 
                     if(callRecordToInitialize.AdditionalData.TryGetValue("sessions@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             callRecordToInitialize.Sessions.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }
@@ -270,13 +271,14 @@ namespace Microsoft.Graph2.CallRecords
 
                     if(callRecordToInitialize.AdditionalData.TryGetValue("recipients@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             callRecordToInitialize.Recipients.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     callRecordToInitialize.Sessions.AdditionalData = callRecordToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    callRecordToInitialize.AdditionalData.TryGetValue("sessions@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(callRecordToInitialize.AdditionalData.TryGetValue("sessions@odata.nextLink", out var nextPageLink))
                     {
-                        callRecordToInitialize.Sessions.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            callRecordToInitialize.Sessions.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 
@@ -267,15 +268,16 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     callRecordToInitialize.Recipients.AdditionalData = callRecordToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    callRecordToInitialize.AdditionalData.TryGetValue("recipients@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(callRecordToInitialize.AdditionalData.TryGetValue("recipients@odata.nextLink", out var nextPageLink))
                     {
-                        callRecordToInitialize.Recipients.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            callRecordToInitialize.Recipients.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
@@ -244,43 +244,19 @@ namespace Microsoft.Graph2.CallRecords
         private void InitializeCollectionProperties(CallRecord callRecordToInitialize)
         {
 
-            if (callRecordToInitialize != null && callRecordToInitialize.AdditionalData != null)
+            if (callRecordToInitialize != null)
             {
-
                 if (callRecordToInitialize.Sessions != null && callRecordToInitialize.Sessions.CurrentPage != null)
                 {
+                    callRecordToInitialize.Sessions.InitializeNextPageRequest(this.Client, callRecordToInitialize.SessionsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     callRecordToInitialize.Sessions.AdditionalData = callRecordToInitialize.AdditionalData;
-
-                    if(callRecordToInitialize.AdditionalData.TryGetValue("sessions@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            callRecordToInitialize.Sessions.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
-
                 if (callRecordToInitialize.Recipients != null && callRecordToInitialize.Recipients.CurrentPage != null)
                 {
+                    callRecordToInitialize.Recipients.InitializeNextPageRequest(this.Client, callRecordToInitialize.RecipientsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     callRecordToInitialize.Recipients.AdditionalData = callRecordToInitialize.AdditionalData;
-
-                    if(callRecordToInitialize.AdditionalData.TryGetValue("recipients@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            callRecordToInitialize.Recipients.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             callRecordToInitialize.Sessions.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }
@@ -274,11 +274,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             callRecordToInitialize.Recipients.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph2.CallRecords
             var response = await this.SendAsync<CallRecordSessionsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph2.CallRecords
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<CallRecordSessionsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph2.CallRecords
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph2.CallRecords
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -27,5 +27,30 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph2.CallRecords
         public ICallRecordSessionsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -43,9 +43,10 @@ namespace Microsoft.Graph2.CallRecords
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<SegmentRefTypesCollectionWithReferencesResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -49,12 +49,14 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Graph2.CallRecords
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -45,24 +45,7 @@ namespace Microsoft.Graph2.CallRecords
             var response = await this.SendAsync<SegmentRefTypesCollectionWithReferencesResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesRequest.cs
@@ -47,18 +47,16 @@ namespace Microsoft.Graph2.CallRecords
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
@@ -27,5 +27,30 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph2.CallRecords
         public ISegmentRefTypesCollectionWithReferencesPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
@@ -244,25 +244,13 @@ namespace Microsoft.Graph2.CallRecords
         private void InitializeCollectionProperties(Segment segmentToInitialize)
         {
 
-            if (segmentToInitialize != null && segmentToInitialize.AdditionalData != null)
+            if (segmentToInitialize != null)
             {
-
                 if (segmentToInitialize.RefTypes != null && segmentToInitialize.RefTypes.CurrentPage != null)
                 {
+                    segmentToInitialize.RefTypes.InitializeNextPageRequest(this.Client, segmentToInitialize.RefTypesNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     segmentToInitialize.RefTypes.AdditionalData = segmentToInitialize.AdditionalData;
-
-                    if(segmentToInitialize.AdditionalData.TryGetValue("refTypes@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            segmentToInitialize.RefTypes.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph2.CallRecords
 
                     if(segmentToInitialize.AdditionalData.TryGetValue("refTypes@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             segmentToInitialize.RefTypes.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             segmentToInitialize.RefTypes.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     segmentToInitialize.RefTypes.AdditionalData = segmentToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    segmentToInitialize.AdditionalData.TryGetValue("refTypes@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(segmentToInitialize.AdditionalData.TryGetValue("refTypes@odata.nextLink", out var nextPageLink))
                     {
-                        segmentToInitialize.RefTypes.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            segmentToInitialize.RefTypes.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
@@ -24,34 +24,15 @@ namespace Microsoft.Graph2.CallRecords
         public ISegmentTestActionCollectionPage Value { get; set; }
         
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
@@ -28,5 +28,30 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -50,24 +50,7 @@ namespace Microsoft.Graph2.CallRecords
             var response = await this.SendAsync<SegmentTestActionCollectionResponse>(this.RequestBody, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    response.Value.AdditionalData = response.AdditionalData;
-
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -54,16 +54,16 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     response.Value.AdditionalData = response.AdditionalData;
 
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -56,13 +56,14 @@ namespace Microsoft.Graph2.CallRecords
 
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Graph2.CallRecords
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionRequest.cs
@@ -48,9 +48,10 @@ namespace Microsoft.Graph2.CallRecords
         {
             this.Method = HttpMethods.POST;
             var response = await this.SendAsync<SegmentTestActionCollectionResponse>(this.RequestBody, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
@@ -253,13 +253,14 @@ namespace Microsoft.Graph2.CallRecords
 
                     if(sessionToInitialize.AdditionalData.TryGetValue("segments@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             sessionToInitialize.Segments.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
@@ -244,25 +244,13 @@ namespace Microsoft.Graph2.CallRecords
         private void InitializeCollectionProperties(Session sessionToInitialize)
         {
 
-            if (sessionToInitialize != null && sessionToInitialize.AdditionalData != null)
+            if (sessionToInitialize != null)
             {
-
                 if (sessionToInitialize.Segments != null && sessionToInitialize.Segments.CurrentPage != null)
                 {
+                    sessionToInitialize.Segments.InitializeNextPageRequest(this.Client, sessionToInitialize.SegmentsNextLink);
+                    // Copy the additional data collection to the page itself so that information is not lost
                     sessionToInitialize.Segments.AdditionalData = sessionToInitialize.AdditionalData;
-
-                    if(sessionToInitialize.AdditionalData.TryGetValue("segments@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            sessionToInitialize.Segments.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
                 }
 
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
@@ -256,11 +256,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             sessionToInitialize.Segments.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionRequest.cs
@@ -251,15 +251,16 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     sessionToInitialize.Segments.AdditionalData = sessionToInitialize.AdditionalData;
 
-                    object nextPageLink;
-                    sessionToInitialize.AdditionalData.TryGetValue("segments@odata.nextLink", out nextPageLink);
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(sessionToInitialize.AdditionalData.TryGetValue("segments@odata.nextLink", out var nextPageLink))
                     {
-                        sessionToInitialize.Segments.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            sessionToInitialize.Segments.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
                 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -71,24 +71,7 @@ namespace Microsoft.Graph2.CallRecords
             var response = await this.SendAsync<SessionSegmentsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
             if (response != null && response.Value != null && response.Value.CurrentPage != null)
             {
-                if (response.AdditionalData != null)
-                {
-                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                    {
-                        // Ensure it is a non empty JsonElement string
-                        if (nextPageLink is System.Text.Json.JsonElement element
-                            && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.GetString()))
-                        {
-                            response.Value.InitializeNextPageRequest(
-                                this.Client,
-                                element.GetString());
-                        }
-                    }
-                    // Copy the additional data collection to the page itself so that information is not lost
-                    response.Value.AdditionalData = response.AdditionalData;
-                }
-
+                response.InitializeCollectionProperties(this.Client);
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Graph2.CallRecords
                 {
                     if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        var nextPageLinkString = nextPageLink.ToString();
-                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        // Ensure it is a non empty JsonElement string
+                        if (nextPageLink is System.Text.Json.JsonElement element
+                            && element.ValueKind == System.Text.Json.JsonValueKind.String
+                            && !string.IsNullOrEmpty(element.ToString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                nextPageLinkString);
+                                element.ToString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Graph2.CallRecords
         {
             this.Method = HttpMethods.GET;
             var response = await this.SendAsync<SessionSegmentsCollectionResponse>(null, cancellationToken).ConfigureAwait(false);
-            if (response != null && response.Value != null && response.Value.CurrentPage != null)
+            if (response?.Value?.CurrentPage != null)
             {
-                response.InitializeCollectionProperties(this.Client);
+                response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Graph2.CallRecords
                         // Ensure it is a non empty JsonElement string
                         if (nextPageLink is System.Text.Json.JsonElement element
                             && element.ValueKind == System.Text.Json.JsonValueKind.String
-                            && !string.IsNullOrEmpty(element.ToString()))
+                            && !string.IsNullOrEmpty(element.GetString()))
                         {
                             response.Value.InitializeNextPageRequest(
                                 this.Client,
-                                element.ToString());
+                                element.GetString());
                         }
                     }
                     // Copy the additional data collection to the page itself so that information is not lost

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Graph2.CallRecords
             if (response?.Value?.CurrentPage != null)
             {
                 response.Value.InitializeNextPageRequest(this.Client, response.NextLink);
+                // Copy the additional data collection to the page itself so that information is not lost
                 response.Value.AdditionalData = response.AdditionalData;
                 return response.Value;
             }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionRequest.cs
@@ -73,18 +73,16 @@ namespace Microsoft.Graph2.CallRecords
             {
                 if (response.AdditionalData != null)
                 {
-                    object nextPageLink;
-                    response.AdditionalData.TryGetValue("@odata.nextLink", out nextPageLink);
-
-                    var nextPageLinkString = nextPageLink as string;
-
-                    if (!string.IsNullOrEmpty(nextPageLinkString))
+                    if(response.AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
                     {
-                        response.Value.InitializeNextPageRequest(
-                            this.Client,
-                            nextPageLinkString);
+                        var nextPageLinkString = nextPageLink.ToString();
+                        if (nextPageLink.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrEmpty(nextPageLinkString))
+                        {
+                            response.Value.InitializeNextPageRequest(
+                                this.Client,
+                                nextPageLinkString);
+                        }
                     }
-
                     // Copy the additional data collection to the page itself so that information is not lost
                     response.Value.AdditionalData = response.AdditionalData;
                 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -27,5 +27,30 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Initializes the NextPageRequest from the AdditionalData if possible
+        /// and copies the Additional data to the CollectionPage instance
+        /// </summary>
+        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
+        {
+            if(AdditionalData != null)
+            {
+                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
+                {
+                    // Ensure it is a non empty JsonElement string
+                    if (nextPageLink is System.Text.Json.JsonElement element
+                        && element.ValueKind == System.Text.Json.JsonValueKind.String
+                        && !string.IsNullOrEmpty(element.GetString()))
+                    {
+                        Value.InitializeNextPageRequest(
+                            client,
+                            element.GetString());
+                    }
+                }
+                // Copy the additional data collection to the page itself so that information is not lost
+                Value.AdditionalData = AdditionalData;
+            }
+        }
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
@@ -23,34 +23,15 @@ namespace Microsoft.Graph2.CallRecords
         public ISessionSegmentsCollectionPage Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the nextLink string value.
+        /// </summary>
+        [JsonPropertyName("@odata.nextLink")]
+        public string NextLink { get; set; }
+
+        /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
-
-        /// <summary>
-        /// Initializes the NextPageRequest from the AdditionalData if possible
-        /// and copies the Additional data to the CollectionPage instance
-        /// </summary>
-        internal void InitializeCollectionProperties(Microsoft.Graph.IBaseClient client)
-        {
-            if(AdditionalData != null)
-            {
-                if(AdditionalData.TryGetValue("@odata.nextLink", out var nextPageLink))
-                {
-                    // Ensure it is a non empty JsonElement string
-                    if (nextPageLink is System.Text.Json.JsonElement element
-                        && element.ValueKind == System.Text.Json.JsonValueKind.String
-                        && !string.IsNullOrEmpty(element.GetString()))
-                    {
-                        Value.InitializeNextPageRequest(
-                            client,
-                            element.GetString());
-                    }
-                }
-                // Copy the additional data collection to the page itself so that information is not lost
-                Value.AdditionalData = AdditionalData;
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/275

It fixes the initialization of collection properties since the use of the `as operator keyword` used in the previous Newtonsoft compatible code cannot be used with System.Text.Json's [JsonElement](https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement?view=net-5.0) since it is a struct and not nullable. This results to the nextlinks not being initialized.

Tests have been updated to capture this as well.

Generation PRs
V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/960
Beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/277
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/512)