### PR TITLE
Fix the setting of odata.type in the constructor

### DIFF
--- a/Templates/templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -111,14 +111,6 @@ public string GetPostAsyncMethod(OdcmProperty odcmProperty, string @namespace, s
         stringBuilder.Append(Environment.NewLine);
         stringBuilder.AppendFormat("            this.Method = {0};", templateWriter.PostMethod);
 
-        var entity = odcmProperty.Projection.Type.AsOdcmClass();
-
-        if (entity != null && entity.IsAbstract)
-        {
-            stringBuilder.Append(Environment.NewLine);
-            stringBuilder.AppendFormat("            {0}.ODataType = string.Concat(\"#\", StringHelper.ConvertTypeToLowerCamelCase({0}.GetType().FullName));", sanitizedPropertyName);
-        }
-
         stringBuilder.Append(Environment.NewLine);
         if (isGraphResponseMethod)
         {

--- a/Templates/templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/templates/CSharp/Model/ComplexType.cs.tt
@@ -84,11 +84,7 @@ if (attributeStringBuilder.Length > 0) {
     public <#=classType#> <#=typeDeclaration#>
     {
 <#
-        // Do not generate a cstor if this is abstract.
-        if (complex.IsAbstract)
-        {
-        }
-        else if (isBaseTypeReferenced)
+        if (!complex.IsAbstract && isBaseTypeReferenced)
         {
 #>        /// <summary>
         /// Initializes a new instance of the <see cref="<#=cstorTypeDeclaration#>"/> class.

--- a/Templates/templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/templates/CSharp/Model/ComplexType.cs.tt
@@ -48,6 +48,8 @@ if (complex.IsDeprecated)
    attributeStringBuilder.Append(complex.GetDeprecationString());
 }
 
+// We'll use this to generate a default OData.type only if the base is abstract or if its base is possibly referenced as a type in a property.
+var isBaseTypeReferenced = complex.IsBaseTypeReferenced() || (complex.Base != null && complex.Base.IsAbstract);
 
 // We only want to add the derived type converter to the class that has any derived types
 // and for abstract classes as they will have to be initialized as a derived type
@@ -82,9 +84,12 @@ if (attributeStringBuilder.Length > 0) {
     public <#=classType#> <#=typeDeclaration#>
     {
 <#
-// Generate a constructor to initialize the @odata.type property when this type is not abstract.
-if (!complex.IsAbstract)
-{
+        // Do not generate a cstor if this is abstract.
+        if (complex.IsAbstract)
+        {
+        }
+        else if (isBaseTypeReferenced)
+        {
 #>        /// <summary>
         /// Initializes a new instance of the <see cref="<#=cstorTypeDeclaration#>"/> class.
         /// </summary>
@@ -93,7 +98,7 @@ if (!complex.IsAbstract)
             this.ODataType = "<#=complex.FullName#>";
         }
 <#
-}
+        }
         foreach(var property in complex.Properties)
         {
 

--- a/Templates/templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/templates/CSharp/Model/EntityType.cs.tt
@@ -44,6 +44,9 @@ if (entity.IsDeprecated)
    attributeStringBuilder.Append(entity.GetDeprecationString());
 }
 
+// We'll use this to generate a default OData.type only if the base is abstract or if its base is possibly referenced as a type in a property.
+// Note that we exclude the entity type in this search to avoid setting the type under entity
+var isBaseTypeReferenced = entity.IsBaseTypeReferenced() || (entity.Base != null && entity.Base.Name != "entity" && entity.Base.IsAbstract);
 
 // We only want to add the derived type converter to the class that has any derived types
 // and for abstract classes as they will have to be initialized as a derived type
@@ -82,28 +85,28 @@ if (attributeStringBuilder.Length > 0) {
         {
     #>
 
-		///<summary>
-		/// The internal <#=entityName#> constructor
-		///</summary>
+        ///<summary>
+        /// The internal <#=entityName#> constructor
+        ///</summary>
         protected internal <#=cstorTypeDeclaration#>()
         {
             // Don't allow initialization of abstract entity types
         }
     <#
         }
-		else
-		{
-	#>
+        else if (isBaseTypeReferenced)
+        {
+    #>
 
-		///<summary>
-		/// The <#=entityName#> constructor
-		///</summary>
+        ///<summary>
+        /// The <#=entityName#> constructor
+        ///</summary>
         public <#=cstorTypeDeclaration#>()
         {
             this.ODataType = "<#=entity.FullName#>";
         }
-	<#
-		}
+    <#
+        }
         foreach(var property in entity.Properties)
         {
             var propertyTypeString = property.GetTypeString(entity.Namespace.GetNamespaceName());

--- a/Templates/templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/templates/CSharp/Model/EntityType.cs.tt
@@ -105,7 +105,7 @@ if (attributeStringBuilder.Length > 0) {
         {
             this.ODataType = "<#=entity.FullName#>";
         }
-    <#
+<#
         }
         foreach(var property in entity.Properties)
         {

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -357,17 +357,15 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
                     .Where( m => !m.IsFunction) // only get the Actions
                     .Any(m => m.Parameters
                         .Any( param => param.Type.Name == odcmClass.Base.Name 
-                                  && param.Type.Name != "entity"));
+                                  && !"entity".Equals(param.Type.Name, StringComparison.OrdinalIgnoreCase)));
 
                 var isReferencedInClass = odcmClass.Namespace.Types
-                    .Select(someType => someType)
-                    .Where(someType => someType is OdcmClass)
-                    .Any(someType => ((OdcmClass) someType).Properties
+                    .OfType<OdcmClass>()
+                    .Any(someType => someType.Properties
                         .Any(x => x.Type.Name == odcmClass.Base.Name 
-                                  && x.Type.Name != "entity"));
+                                  && !"entity".Equals(x.Type.Name, StringComparison.OrdinalIgnoreCase)));
 
                 return (isReferencedInAction || isReferencedInClass);
-
             }
         }
 

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -182,7 +182,7 @@ namespace Typewriter.Test
         }
 
         [Test]
-        public void It_generates_dotNet_odatatype_initialization_for_complextypes()
+        public void It_does_not_generates_dotNet_odata_type_initialization_for_complex_types_with_no_inheritance()
         {
             const string outputDirectory = "output";
 
@@ -215,8 +215,8 @@ namespace Typewriter.Test
                 }
             }
 
-            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the setter code in the cstor.");
-            Assert.IsTrue(hasCstorString, $"The expected test token cstor string, '{testCstorString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+            Assert.IsFalse(hasTestString, $"The expected test token string, '{testString}', was set in the generated test file. We didn't properly generate the setter code in the cstor.");
+            Assert.IsFalse(hasCstorString, $"The expected test token cstor string, '{testCstorString}', was set in the generated test file. We didn't properly generate the cstor code.");
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace Typewriter.Test
 
 
         [Test]
-        public void It_generates_dotNet_odatatype_initialization_for_entitytypes()
+        public void It_doesnt_generate_dotNet_odatatype_initialization_for_entitytypes()
         {
             const string outputDirectory = "output";
 
@@ -280,7 +280,38 @@ namespace Typewriter.Test
                     break;
                 }
             }
-            Assert.IsTrue(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+            Assert.False(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the cstor code.");
+        }
+
+        [Test]
+        public void It_generates_dotNet_odatatype_initialization_for_entitytypes_with_base_referenced()
+        {
+            const string outputDirectory = "output";
+
+            Options options = new Options()
+            {
+                Output = outputDirectory,
+                Language = "CSharp",
+                GenerationMode = GenerationMode.Files
+            };
+
+            Generator.GenerateFiles(testMetadata, options);
+
+            FileInfo fileInfo = new FileInfo(outputDirectory + generatedOutputUrl + @$"{Path.DirectorySeparatorChar}model{Path.DirectorySeparatorChar}TestType4.cs");
+            Assert.IsTrue(fileInfo.Exists, $"Expected: {fileInfo.FullName}. File was not found.");
+
+            IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
+            bool hasTestString = false;
+            string testString = "this.ODataType = \"microsoft.graph.testType4\";";
+            foreach (var line in lines)
+            {
+                if (line.Contains(testString))
+                {
+                    hasTestString = true;
+                    break;
+                }
+            }
+            Assert.True(hasTestString, $"The expected test token string, '{testString}', was not set in the generated test file. We didn't properly generate the cstor code.");
         }
 
         [Test]

--- a/test/Typewriter.Test/Resources/dirtyMetadata.xml
+++ b/test/Typewriter.Test/Resources/dirtyMetadata.xml
@@ -26,6 +26,7 @@
       
       <EntityType Name="testType2" BaseType="microsoft.graph.entity"></EntityType>
       <EntityType Name="testType3" BaseType="microsoft.graph.entity"></EntityType>
+      <EntityType Name="testType4" BaseType="microsoft.graph.testType3"></EntityType>
       <EntityType Name="testEntity" BaseType="microsoft.graph.entity">
         <NavigationProperty Name="testNav" Type="microsoft.graph.testType"/>
         <NavigationProperty Name="testInvalidNav" Type="microsoft.graph.testType2"/>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Call.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Call.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class Call : Entity
     {
     
-		///<summary>
-		/// The Call constructor
-		///</summary>
-        public Call()
-        {
-            this.ODataType = "microsoft.graph.call";
-        }
-	
         /// <summary>
         /// Gets or sets subject.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class CloudCommunications : Entity
     {
     
-		///<summary>
-		/// The CloudCommunications constructor
-		///</summary>
-        public CloudCommunications()
-        {
-            this.ODataType = "microsoft.graph.cloudCommunications";
-        }
-	
         /// <summary>
         /// Gets or sets calls.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/DirectoryObject.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/DirectoryObject.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph
     public partial class DirectoryObject : Entity
     {
     
-		///<summary>
-		/// The DirectoryObject constructor
-		///</summary>
-        public DirectoryObject()
-        {
-            this.ODataType = "microsoft.graph.directoryObject";
-        }
-	
         /// <summary>
         /// Gets or sets deleted date time.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyEntityTypeWithBaseType.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyEntityTypeWithBaseType.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Graph
     public partial class EmptyEntityTypeWithBaseType : Entity
     {
     
-		///<summary>
-		/// The internal EmptyEntityTypeWithBaseType constructor
-		///</summary>
+        ///<summary>
+        /// The internal EmptyEntityTypeWithBaseType constructor
+        ///</summary>
         protected internal EmptyEntityTypeWithBaseType()
         {
             // Don't allow initialization of abstract entity types

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Endpoint.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Endpoint.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class Endpoint : Entity
     {
     
-		///<summary>
-		/// The Endpoint constructor
-		///</summary>
-        public Endpoint()
-        {
-            this.ODataType = "microsoft.graph.endpoint";
-        }
-	
         /// <summary>
         /// Gets or sets property1.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Entity.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Entity.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Graph
     public partial class Entity
     {
     
-		///<summary>
-		/// The internal Entity constructor
-		///</summary>
+        ///<summary>
+        /// The internal Entity constructor
+        ///</summary>
         protected internal Entity()
         {
             // Don't allow initialization of abstract entity types

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EntityType2.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EntityType2.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class EntityType2 : Entity
     {
     
-		///<summary>
-		/// The EntityType2 constructor
-		///</summary>
-        public EntityType2()
-        {
-            this.ODataType = "microsoft.graph.entityType2";
-        }
-	
     }
 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EntityType3.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EntityType3.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph
     public partial class EntityType3 : Entity
     {
     
-		///<summary>
-		/// The EntityType3 constructor
-		///</summary>
-        public EntityType3()
-        {
-            this.ODataType = "microsoft.graph.entityType3";
-        }
-	
     }
 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Graph
     public partial class Group : DirectoryObject
     {
     
-		///<summary>
-		/// The Group constructor
-		///</summary>
+        ///<summary>
+        /// The Group constructor
+        ///</summary>
         public Group()
         {
             this.ODataType = "microsoft.graph.group";
         }
-	
+    
         /// <summary>
         /// Gets or sets members.
         /// Users and groups that are members of this Adminsitrative Unit. HTTP Methods: GET (list members), POST (add members), DELETE (remove members).

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Graph
         {
             this.ODataType = "microsoft.graph.group";
         }
-    
+
         /// <summary>
         /// Gets or sets members.
         /// Users and groups that are members of this Adminsitrative Unit. HTTP Methods: GET (list members), POST (add members), DELETE (remove members).

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Identity.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Identity.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter<Identity>))]
     public partial class Identity
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Identity"/> class.
-        /// </summary>
-        public Identity()
-        {
-            this.ODataType = "microsoft.graph.identity";
-        }
 
         /// <summary>
         /// Gets or sets displayName.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/IdentitySet.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/IdentitySet.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter<IdentitySet>))]
     public partial class IdentitySet
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IdentitySet"/> class.
-        /// </summary>
-        public IdentitySet()
-        {
-            this.ODataType = "microsoft.graph.identitySet";
-        }
 
         /// <summary>
         /// Gets or sets application.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/OnenotePage.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/OnenotePage.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class OnenotePage : Entity
     {
     
-		///<summary>
-		/// The OnenotePage constructor
-		///</summary>
-        public OnenotePage()
-        {
-            this.ODataType = "microsoft.graph.onenotePage";
-        }
-	
         /// <summary>
         /// Gets or sets content.
         /// The OneNotePage content.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/PlannerGroup.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/PlannerGroup.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class PlannerGroup : Entity
     {
     
-		///<summary>
-		/// The PlannerGroup constructor
-		///</summary>
-        public PlannerGroup()
-        {
-            this.ODataType = "microsoft.graph.plannerGroup";
-        }
-	
     }
 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Print.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Print.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph
     public partial class Print
     {
     
-		///<summary>
-		/// The Print constructor
-		///</summary>
-        public Print()
-        {
-            this.ODataType = "microsoft.graph.print";
-        }
-	
         /// <summary>
         /// Gets or sets settings.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Recipient.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Recipient.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter<Recipient>))]
     public partial class Recipient
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Recipient"/> class.
-        /// </summary>
-        public Recipient()
-        {
-            this.ODataType = "microsoft.graph.recipient";
-        }
 
         /// <summary>
         /// Gets or sets name.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/ResponseObject.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/ResponseObject.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -21,13 +21,6 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter<ResponseObject>))]
     public partial class ResponseObject
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ResponseObject"/> class.
-        /// </summary>
-        public ResponseObject()
-        {
-            this.ODataType = "microsoft.graph.responseObject";
-        }
 
         /// <summary>
         /// Gets or sets additional data.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class Schedule : Entity
     {
     
-		///<summary>
-		/// The Schedule constructor
-		///</summary>
-        public Schedule()
-        {
-            this.ODataType = "microsoft.graph.schedule";
-        }
-	
         /// <summary>
         /// Gets or sets enabled.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/SingletonEntity1.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/SingletonEntity1.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class SingletonEntity1 : Entity
     {
     
-		///<summary>
-		/// The SingletonEntity1 constructor
-		///</summary>
-        public SingletonEntity1()
-        {
-            this.ODataType = "microsoft.graph.singletonEntity1";
-        }
-	
         /// <summary>
         /// Gets or sets test single nav.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/SingletonEntity2.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/SingletonEntity2.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class SingletonEntity2 : Entity
     {
     
-		///<summary>
-		/// The SingletonEntity2 constructor
-		///</summary>
-        public SingletonEntity2()
-        {
-            this.ODataType = "microsoft.graph.singletonEntity2";
-        }
-	
         /// <summary>
         /// Gets or sets test single nav2.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TestEntity.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TestEntity.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class TestEntity : Entity
     {
     
-		///<summary>
-		/// The TestEntity constructor
-		///</summary>
-        public TestEntity()
-        {
-            this.ODataType = "microsoft.graph.testEntity";
-        }
-	
         /// <summary>
         /// Gets or sets test nav.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TestType.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TestType.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class TestType : Entity
     {
     
-		///<summary>
-		/// The TestType constructor
-		///</summary>
-        public TestType()
-        {
-            this.ODataType = "microsoft.graph.testType";
-        }
-	
         /// <summary>
         /// Gets or sets property alpha.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TimeOff.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TimeOff.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class TimeOff : Entity
     {
     
-		///<summary>
-		/// The TimeOff constructor
-		///</summary>
-        public TimeOff()
-        {
-            this.ODataType = "microsoft.graph.timeOff";
-        }
-	
         /// <summary>
         /// Gets or sets name.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TimeOffRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/TimeOffRequest.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class TimeOffRequestObject : Entity
     {
     
-		///<summary>
-		/// The TimeOffRequest constructor
-		///</summary>
-        public TimeOffRequestObject()
-        {
-            this.ODataType = "microsoft.graph.timeOffRequest";
-        }
-	
         /// <summary>
         /// Gets or sets name.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/UnifiedRoleEligibilityRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/UnifiedRoleEligibilityRequest.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph
     public partial class UnifiedRoleEligibilityRequestObject
     {
     
-		///<summary>
-		/// The UnifiedRoleEligibilityRequest constructor
-		///</summary>
-        public UnifiedRoleEligibilityRequestObject()
-        {
-            this.ODataType = "microsoft.graph.unifiedRoleEligibilityRequest";
-        }
-	
         /// <summary>
         /// Gets or sets action.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/User.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/User.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Graph
         {
             this.ODataType = "microsoft.graph.user";
         }
-    
+
         /// <summary>
         /// Gets or sets account enabled.
         /// true if the account is enabled; otherwise, false. This property is required when a user is created. Supports $filter.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/User.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/User.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,14 @@ namespace Microsoft.Graph
     public partial class User : DirectoryObject
     {
     
-		///<summary>
-		/// The User constructor
-		///</summary>
+        ///<summary>
+        /// The User constructor
+        ///</summary>
         public User()
         {
             this.ODataType = "microsoft.graph.user";
         }
-	
+    
         /// <summary>
         /// Gets or sets account enabled.
         /// true if the account is enabled; otherwise, false. This property is required when a user is created. Supports $filter.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/WorkbookChart.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/WorkbookChart.cs
@@ -20,14 +20,6 @@ namespace Microsoft.Graph
     public partial class WorkbookChart : Entity
     {
     
-		///<summary>
-		/// The WorkbookChart constructor
-		///</summary>
-        public WorkbookChart()
-        {
-            this.ODataType = "microsoft.graph.workbookChart";
-        }
-	
         /// <summary>
         /// Gets or sets height.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class CallRecord : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The CallRecord constructor
-		///</summary>
-        public CallRecord()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.callRecord";
-        }
-	
         /// <summary>
         /// Gets or sets version.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/DeviceInfo.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/DeviceInfo.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<DeviceInfo>))]
     public partial class DeviceInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DeviceInfo"/> class.
-        /// </summary>
-        public DeviceInfo()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.deviceInfo";
-        }
 
         /// <summary>
         /// Gets or sets captureDeviceName.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Endpoint.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Endpoint.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<Endpoint>))]
     public partial class Endpoint
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Endpoint"/> class.
-        /// </summary>
-        public Endpoint()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.endpoint";
-        }
 
         /// <summary>
         /// Gets or sets userAgent.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/FailureInfo.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/FailureInfo.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<FailureInfo>))]
     public partial class FailureInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FailureInfo"/> class.
-        /// </summary>
-        public FailureInfo()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.failureInfo";
-        }
 
         /// <summary>
         /// Gets or sets stage.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/FeedbackTokenSet.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/FeedbackTokenSet.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<FeedbackTokenSet>))]
     public partial class FeedbackTokenSet
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FeedbackTokenSet"/> class.
-        /// </summary>
-        public FeedbackTokenSet()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.feedbackTokenSet";
-        }
 
         /// <summary>
         /// Gets or sets additional data.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Media.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Media.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<Media>))]
     public partial class Media
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Media"/> class.
-        /// </summary>
-        public Media()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.media";
-        }
 
         /// <summary>
         /// Gets or sets label.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/MediaStream.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/MediaStream.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<MediaStream>))]
     public partial class MediaStream
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MediaStream"/> class.
-        /// </summary>
-        public MediaStream()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.mediaStream";
-        }
 
         /// <summary>
         /// Gets or sets streamId.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/NetworkInfo.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/NetworkInfo.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<NetworkInfo>))]
     public partial class NetworkInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NetworkInfo"/> class.
-        /// </summary>
-        public NetworkInfo()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.networkInfo";
-        }
 
         /// <summary>
         /// Gets or sets connectionType.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Option.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Option.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class Option : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The Option constructor
-		///</summary>
-        public Option()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.option";
-        }
-	
     }
 }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Photo.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Photo.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class Photo : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The Photo constructor
-		///</summary>
-        public Photo()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.photo";
-        }
-	
         /// <summary>
         /// Gets or sets failure info.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
@@ -20,14 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class Segment : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The Segment constructor
-		///</summary>
-        public Segment()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.segment";
-        }
-	
         /// <summary>
         /// Gets or sets start date time.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
@@ -21,14 +21,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class Session : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The Session constructor
-		///</summary>
-        public Session()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.session";
-        }
-	
         /// <summary>
         /// Gets or sets modalities.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/SingletonEntity1.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/SingletonEntity1.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -20,14 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     public partial class SingletonEntity1 : Microsoft.Graph.Entity
     {
     
-		///<summary>
-		/// The SingletonEntity1 constructor
-		///</summary>
-        public SingletonEntity1()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.singletonEntity1";
-        }
-	
         /// <summary>
         /// Gets or sets test single nav.
         /// </summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/UserFeedback.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/UserFeedback.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Graph2.CallRecords
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<UserFeedback>))]
     public partial class UserFeedback
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserFeedback"/> class.
-        /// </summary>
-        public UserFeedback()
-        {
-            this.ODataType = "microsoft.graph2.callRecords.userFeedback";
-        }
 
         /// <summary>
         /// Gets or sets text.

--- a/test/Typewriter.Test/Typewriter.Test.csproj
+++ b/test/Typewriter.Test/Typewriter.Test.csproj
@@ -40,7 +40,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Resources\dirtyMetadata.xml" />
+    <Content Include="Resources\dirtyMetadata.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">


### PR DESCRIPTION
## Summary
This PR closes https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/242

This PR updates the SDK code generator to set the odata.type under the following conditions for type disambiguation.

1. The type derives from an abstract type
2. One of its base types is referenced as the type for a property in another type (except if the base is entity).
3. One of its base types is referenced as the type in an odata action in another type (except if the base is entity).

This change therefore makes the setting of the type [unnecessary](https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/blob/master/src/Microsoft.Graph/Generated/requests/MessageAttachmentsCollectionRequest.cs#L57) when we try to post to abstract collections. This has therefore been removed as well. 

## Background/Related issues
- https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/36#issuecomment-529597352
- https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/312
- https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/586

## Generated code differences
V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/993
beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/296

## Related issues to be closed 

- [x] https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/67
- [x] https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/283
- [x] https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/226
- [x] https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/909
- [x] https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/560
- [x] https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/598
- [x] https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/566



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/534)