### PR TITLE
Fix type issues in PHPDocs.

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -40,12 +40,12 @@ if (String.IsNullOrEmpty(entityBaseName)) {
     * The array of properties available
     * to the model
     *
-    * @var array(string => string)
+    * @var array $_propDict
     */
     protected $_propDict;
     
     /**
-    * Construct a new <#=entityCheckedCase#>
+    * Construct a new <#=entityName.ToCheckedCase()#>
     *
     * @param array $propDict A list of properties to set
     */
@@ -114,7 +114,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     *
     * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entityCheckedCase#>
+    * @return <#=entityName.ToCheckedCase()#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
@@ -161,7 +161,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     *
     * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entityCheckedCase#>
+    * @return <#=entityName.ToCheckedCase()#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
@@ -218,7 +218,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     *
     * @param <#=propertyTypeReference#> $val The <#=propertyName#>
     *
-    * @return <#=entityCheckedCase#>
+    * @return <#=entityName.ToCheckedCase()#>
     */
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
@@ -263,9 +263,9 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     /**
     * Sets the ODataType
     *
-    * @param string The ODataType
+    * @param string $val The ODataType
     *
-    * @return Entity
+    * @return <#=entityName.ToCheckedCase()#>
     */
     public function setODataType($val)
     {

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -28,7 +28,7 @@ class Entity implements \JsonSerializable
     * The array of properties available
     * to the model
     *
-    * @var array(string => string)
+    * @var array $_propDict
     */
     protected $_propDict;
     
@@ -95,7 +95,7 @@ class Entity implements \JsonSerializable
     /**
     * Sets the ODataType
     *
-    * @param string The ODataType
+    * @param string $val The ODataType
     *
     * @return Entity
     */

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -28,12 +28,12 @@ class GraphPrint implements \JsonSerializable
     * The array of properties available
     * to the model
     *
-    * @var array(string => string)
+    * @var array $_propDict
     */
     protected $_propDict;
     
     /**
-    * Construct a new Print
+    * Construct a new GraphPrint
     *
     * @param array $propDict A list of properties to set
     */
@@ -74,7 +74,7 @@ class GraphPrint implements \JsonSerializable
     *
     * @param string $val The settings
     *
-    * @return Print
+    * @return GraphPrint
     */
     public function setSettings($val)
     {
@@ -95,9 +95,9 @@ class GraphPrint implements \JsonSerializable
     /**
     * Sets the ODataType
     *
-    * @param string The ODataType
+    * @param string $val The ODataType
     *
-    * @return Entity
+    * @return GraphPrint
     */
     public function setODataType($val)
     {

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -28,7 +28,7 @@ class Entity implements \JsonSerializable
     * The array of properties available
     * to the model
     *
-    * @var array(string => string)
+    * @var array $_propDict
     */
     protected $_propDict;
     
@@ -95,7 +95,7 @@ class Entity implements \JsonSerializable
     /**
     * Sets the ODataType
     *
-    * @param string The ODataType
+    * @param string $val The ODataType
     *
     * @return Entity
     */

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -28,12 +28,12 @@ class GraphPrint implements \JsonSerializable
     * The array of properties available
     * to the model
     *
-    * @var array(string => string)
+    * @var array $_propDict
     */
     protected $_propDict;
     
     /**
-    * Construct a new Print
+    * Construct a new GraphPrint
     *
     * @param array $propDict A list of properties to set
     */
@@ -74,7 +74,7 @@ class GraphPrint implements \JsonSerializable
     *
     * @param string $val The settings
     *
-    * @return Print
+    * @return GraphPrint
     */
     public function setSettings($val)
     {
@@ -95,9 +95,9 @@ class GraphPrint implements \JsonSerializable
     /**
     * Sets the ODataType
     *
-    * @param string The ODataType
+    * @param string $val The ODataType
     *
-    * @return Entity
+    * @return GraphPrint
     */
     public function setODataType($val)
     {


### PR DESCRIPTION
## Summary
PHPDocs of some setters set the return to a wrong class in the PHPDoc. This happens mostly when the class is also an inbuilt PHP type prefixed with `Graph`.
## Generated code differences
![Screenshot 2021-05-26 at 13 57 57](https://user-images.githubusercontent.com/11555354/119649035-d5cfc780-be2a-11eb-8a49-2c7d57fec5e1.png)

## Command line arguments to run these changes
N/A
## Links to issues or work items this PR addresses
Closes #521
#### Links to SDK PRs
[#493](https://github.com/microsoftgraph/msgraph-sdk-php/pull/493)
[#492](https://github.com/microsoftgraph/msgraph-sdk-php/pull/492)
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/535)