### PR TITLE
Make properties of GraphServiceClient virtual

### DIFF
--- a/Templates/templates/CSharp/Requests/EntityClient.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityClient.cs.tt
@@ -90,7 +90,7 @@ namespace <#=@namespace#>
 <# if (prop.IsDeprecated) { #>
         <#=prop.GetDeprecationString()#>
 <# } #>
-        public I<#=collectionRequestBuilder#> <#=sanitizedPropName#>
+        public virtual I<#=collectionRequestBuilder#> <#=sanitizedPropName#>
         {
             get
             {
@@ -111,7 +111,7 @@ namespace <#=@namespace#>
 <# if (prop.IsDeprecated) { #>
         <#=prop.GetDeprecationString()#>
 <# } #>
-        public <#=iRequestBuilder#> <#=sanitizedPropName#>
+        public virtual <#=iRequestBuilder#> <#=sanitizedPropName#>
         {
             get
             {

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceClient.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceClient.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Graph
         /// Gets the GraphServiceTestTypes request builder.
         /// </summary>
         [Obsolete("entityType3 is deprecated. Please use singletonEntity1.")]
-        public IGraphServiceTestTypesCollectionRequestBuilder TestTypes
+        public virtual IGraphServiceTestTypesCollectionRequestBuilder TestTypes
         {
             get
             {
@@ -87,7 +87,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSingletonProperty1 request builder.
         /// </summary>
-        public ISingletonEntity1RequestBuilder SingletonProperty1
+        public virtual ISingletonEntity1RequestBuilder SingletonProperty1
         {
             get
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSingletonProperty2 request builder.
         /// </summary>
-        public ISingletonEntity2RequestBuilder SingletonProperty2
+        public virtual ISingletonEntity2RequestBuilder SingletonProperty2
         {
             get
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSingletonProperty3 request builder.
         /// </summary>
-        public Microsoft.Graph2.CallRecords.ISingletonEntity1RequestBuilder SingletonProperty3
+        public virtual Microsoft.Graph2.CallRecords.ISingletonEntity1RequestBuilder SingletonProperty3
         {
             get
             {


### PR DESCRIPTION
This PR makes the properties of GraphServiceClient virtual to enable the use of mocking frameworks such as Moq to be able to override the implementations provided in the class after the dropping of the IGraphServiceClient interface.

V1 generation
https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1040

beta generation
https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/312

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/547)