### PR TITLE
adds missing inherited content methods for java

### DIFF
--- a/Templates/templates/Java/requests/BaseEntityRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityRequestBuilder.java.tt
@@ -133,7 +133,7 @@ if (c.AsOdcmClass() != null)
 	{
 		var propName = prop.Name.ToCheckedCase();
 		var sanitizedName = propName;
-		if (c is OdcmMediaClass && propName == "Content") {
+		if (c.AsOdcmClass().IsStreamedEntity() && propName == "Content") {
 			 sanitizedName = prop.Type.GetReservedPrefix().ToCheckedCase() + prop.Name.ToCheckedCase();
 		} else {
 			sanitizedName = propName.SanitizePropertyName().ToLowerFirstChar();
@@ -154,7 +154,7 @@ if (c.AsOdcmClass() != null)
 	}
 #>
 <#
-    if (c is OdcmMediaClass)
+    if (c.AsOdcmClass().IsStreamedEntity())
     {
 #>
 

--- a/Templates/templates/Java/requests/BaseEntityStreamRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityStreamRequestBuilder.java.tt
@@ -111,7 +111,7 @@ if (c.AsOdcmClass() != null)
 #>
 
 <#
-    foreach (var prop in c.AsOdcmClass().Properties.Where(x => x.Projection.Type is OdcmMediaClass))
+    foreach (var prop in c.AsOdcmClass().Properties.Where(x => x.Projection.Type.AsOdcmClass().IsStreamedEntity()))
     {
         var propName = prop.Name.ToCheckedCase();
 #>

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -50,11 +50,15 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             var namespaces = GetOdcmNamespaces(model);
             return namespaces.SelectMany(@namespace => @namespace.Classes.Where(x => x is OdcmEntityClass || x is OdcmMediaClass));
         }
-
+        public static bool IsStreamedEntity(this OdcmClass odcmClass) {
+            if(odcmClass is OdcmMediaClass) return true;
+            else if (odcmClass?.Base == null) return false;
+            else return IsStreamedEntity(odcmClass.Base);
+        }
         public static IEnumerable<OdcmClass> GetMediaEntityTypes(this OdcmModel model)
         {
             var namespaces = GetOdcmNamespaces(model);
-            return namespaces.SelectMany(@namespace => @namespace.Classes.Where(x => x is OdcmMediaClass));
+            return namespaces.SelectMany(@namespace => @namespace.Classes.Where(x => x.IsStreamedEntity()));
         }
 
         public static IEnumerable<OdcmProperty> GetProperties(this OdcmModel model)


### PR DESCRIPTION
adds missing content methods for request builders of types that inherit types with has stream=true.

additional context https://github.com/microsoftgraph/msgraph-beta-sdk-java/issues/128
beta diff https://github.com/microsoftgraph/msgraph-beta-sdk-java/issues/130
v1 diff https://github.com/microsoftgraph/msgraph-sdk-java/pull/820

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/557)