### PR TITLE
Fix failing generation of v1.0 models for PHP

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -295,6 +295,8 @@ stages:
         cleanMetadataFolder: $(cleanMetadataFolderV1)
         languageSpecificSteps:
         - template: generation-templates/php-v1.yml
+          parameters:
+             repoName: 'msgraph-sdk-php'
 
 - stage: stage_php_beta
   dependsOn:

--- a/.azure-pipelines/generation-templates/php-v1.yml
+++ b/.azure-pipelines/generation-templates/php-v1.yml
@@ -7,3 +7,5 @@ steps:
     RepoModelsDir: $(Build.SourcesDirectory)/msgraph-sdk-php/src/
 
 - template: php-run-tests.yml
+  parameters:
+    repoName: ${{ parameters.repoName }}


### PR DESCRIPTION
## Summary

The `v1.0` model generation for PHP is failing due an issue with PATH that I introduced in a #554.

## Generated code differences
N/A

## Command line arguments to run these changes
N/A

## Links to issues or work items this PR addresses

Closes #559 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/560)