### PR TITLE
Include missing using statement in enum types

### DIFF
--- a/Templates/templates/CSharp/Model/EnumType.cs.tt
+++ b/Templates/templates/CSharp/Model/EnumType.cs.tt
@@ -11,6 +11,9 @@ var @namespace = enumT.Namespace.GetNamespaceName();
 
 namespace <#=enumT.Namespace.GetNamespaceName()#>
 {
+<# if (enumT.IsDeprecated) { #>
+    using System;
+<# } #>
     using System.Text.Json.Serialization;
 
     /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Enum1.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Enum1.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -10,6 +10,7 @@
 
 namespace Microsoft.Graph
 {
+    using System;
     using System.Text.Json.Serialization;
 
     /// <summary>


### PR DESCRIPTION
This PR implements a fix for the EnumType template where the `using System;` statement is needed in the event that the type is deprecated in order to prevent compilation issues with the [ObsoleteAttribute ](https://docs.microsoft.com/en-us/dotnet/api/system.obsoleteattribute?view=net-5.0) that could be potentially added to the class. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/565)