### PR TITLE
Revert "Replace `GuzzleHttp\Psr7\stream_for()` with `GuzzleHttp\Psr7\Utils::streamFor()`"

### DIFF
--- a/Templates/templates/PHP/Model/ComplexType.php.tt
+++ b/Templates/templates/PHP/Model/ComplexType.php.tt
@@ -142,7 +142,7 @@ foreach(var property in complex.Properties.Where(prop => prop.Type.GetTypeString
                 return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
 <# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
-                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\Utils::streamFor($this->_propDict["<#=camelCasePropertyName#>"]);
+                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
                 $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeReference#>($this->_propDict["<#=camelCasePropertyName#>"]);

--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -141,7 +141,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
                 return $this->_propDict["<#=camelCasePropertyName#>"];
             } else {
 <# if (propertyTypeString == "\\GuzzleHttp\\Psr7\\Stream") { #>
-                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\Utils::streamFor($this->_propDict["<#=camelCasePropertyName#>"]);
+                $this->_propDict["<#=camelCasePropertyName#>"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["<#=camelCasePropertyName#>"]);
                 return $this->_propDict["<#=camelCasePropertyName#>"];
 <# } else { #>
                 $this->_propDict["<#=camelCasePropertyName#>"] = new <#=propertyTypeReference#>($this->_propDict["<#=camelCasePropertyName#>"]);

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
@@ -38,7 +38,7 @@ class OnenotePage extends Entity
             if (is_a($this->_propDict["content"], "\GuzzleHttp\Psr7\Stream") || is_null($this->_propDict["content"])) {
                 return $this->_propDict["content"];
             } else {
-                $this->_propDict["content"] = \GuzzleHttp\Psr7\Utils::streamFor($this->_propDict["content"]);
+                $this->_propDict["content"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["content"]);
                 return $this->_propDict["content"];
             }
         }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
@@ -38,7 +38,7 @@ class OnenotePage extends Entity
             if (is_a($this->_propDict["content"], "\GuzzleHttp\Psr7\Stream") || is_null($this->_propDict["content"])) {
                 return $this->_propDict["content"];
             } else {
-                $this->_propDict["content"] = \GuzzleHttp\Psr7\Utils::streamFor($this->_propDict["content"]);
+                $this->_propDict["content"] = \GuzzleHttp\Psr7\stream_for($this->_propDict["content"]);
                 return $this->_propDict["content"];
             }
         }


### PR DESCRIPTION
Reverts microsoftgraph/MSGraph-SDK-Code-Generator#555 to maintain backward compatibility.

Change will be valid after we do a major upgrade of the SDK.

More info https://github.com/microsoftgraph/msgraph-sdk-php/pull/561

Fixes https://github.com/microsoftgraph/msgraph-sdk-php/issues/560

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/567)