### PR TITLE
NextLink initialization using the NextLinkConverter

### DIFF
--- a/Templates/templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/templates/CSharp/Model/EntityType.cs.tt
@@ -157,6 +157,7 @@ if (attributeStringBuilder.Length > 0) {
         /// Gets or sets <#=collectionPropertyName.ToLowerFirstChar()#>NextLink.
         /// </summary>
         [JsonPropertyName("<#=collectionPropertyName.ToLowerFirstChar()#>@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string <#=collectionPropertyName#>NextLink { get; set; }
     <#
                     }

--- a/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -40,6 +40,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionResponse.cs.tt
@@ -22,12 +22,6 @@ namespace <#=@namespace#>
     /// <summary>
     /// The type <#=collectionResponse#>.
     /// </summary>
-<# 
-// We only want to add the derived type converter to the classes at the top of the inheritance hierarchy
-if (prop.Class.Derived != null && prop.Class.Base == null)
-{ #>
-    [JsonConverter(typeof(<#=derivedTypeConverterTypeName#><<#=collectionResponse#>>))]
-<# } #>
     public class <#=collectionResponse#>
     {
         /// <summary>

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -40,6 +40,7 @@ if (prop.Class.Derived != null && prop.Class.Base == null)
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionWithReferencesResponse.cs.tt
@@ -22,12 +22,6 @@ namespace <#=@namespace#>
     /// <summary>
     /// The type <#=collectionResponse#>.
     /// </summary>
-<# 
-// We only want to add the derived type converter to the classes at the top of the inheritance hierarchy
-if (prop.Class.Derived != null && prop.Class.Base == null)
-{ #>
-    [JsonConverter(typeof(<#=derivedTypeConverterTypeName#><<#=collectionResponse#>>))]
-<# } #>
     public class <#=collectionResponse#>
     {
         /// <summary>

--- a/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
+++ b/Templates/templates/CSharp/Requests/MethodCollectionResponse.cs.tt
@@ -55,6 +55,7 @@ namespace <#=@namespace#>
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/CloudCommunications.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Graph
         /// Gets or sets callsNextLink.
         /// </summary>
         [JsonPropertyName("calls@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string CallsNextLink { get; set; }
     
         /// <summary>
@@ -42,6 +43,7 @@ namespace Microsoft.Graph
         /// Gets or sets callRecordsNextLink.
         /// </summary>
         [JsonPropertyName("callRecords@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string CallRecordsNextLink { get; set; }
     
     }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Group.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Graph
         /// Gets or sets membersNextLink.
         /// </summary>
         [JsonPropertyName("members@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string MembersNextLink { get; set; }
     
     }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/Schedule.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Graph
         /// Gets or sets timesOffNextLink.
         /// </summary>
         [JsonPropertyName("timesOff@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string TimesOffNextLink { get; set; }
     
         /// <summary>
@@ -48,6 +49,7 @@ namespace Microsoft.Graph
         /// Gets or sets timeOffRequestsNextLink.
         /// </summary>
         [JsonPropertyName("timeOffRequests@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string TimeOffRequestsNextLink { get; set; }
     
     }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GraphServiceTestTypesCollectionResponse.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type GraphServiceTestTypesCollectionResponse.
     /// </summary>
-    [JsonConverter(typeof(DerivedTypeConverter<GraphServiceTestTypesCollectionResponse>))]
     public class GraphServiceTestTypesCollectionResponse
     {
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/GroupMembersCollectionWithReferencesResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimeOffRequestsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ScheduleTimesOffCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/TestTypeQueryCollectionResponse.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UnifiedRoleEligibilityRequestFilterByCurrentUserCollectionResponse.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Graph
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/CallRecord.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets sessionsNextLink.
         /// </summary>
         [JsonPropertyName("sessions@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string SessionsNextLink { get; set; }
     
         /// <summary>
@@ -97,6 +98,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets recipientsNextLink.
         /// </summary>
         [JsonPropertyName("recipients@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string RecipientsNextLink { get; set; }
     
     }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Segment.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets refTypesNextLink.
         /// </summary>
         [JsonPropertyName("refTypes@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string RefTypesNextLink { get; set; }
     
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/Session.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets segmentsNextLink.
         /// </summary>
         [JsonPropertyName("segments@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string SegmentsNextLink { get; set; }
     
     }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordRecipientsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/CallRecordSessionsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRefTypesCollectionWithReferencesResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentTestActionCollectionResponse.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SessionSegmentsCollectionResponse.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Graph2.CallRecords
         /// Gets or sets the nextLink string value.
         /// </summary>
         [JsonPropertyName("@odata.nextLink")]
+        [JsonConverter(typeof(NextLinkConverter))]
         public string NextLink { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This PR is related to https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/299

It adds the `[JsonConverter(typeof(NextLinkConverter))]` attribute to the relevant `@odata.nextLink` properties so that urls may be decoded first to prevent issues with paging brought about by encoding done by the SDK. 

It also removes the DerivedTypeConverter attribute from `*CollectionResponse` objects as they do not have parents/children. This will enable them to use the native converters to improve performance of deserialization.

This PR should be merged in after https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/299

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/570)