### PR TITLE
fixes a bug for java with composable function and collection navigation properties

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.Java
 
         public static string TypeRequest(this OdcmObject c)
         {
-            if (c is OdcmProperty && c.AsOdcmProperty().IsReference())
+            if (c is OdcmProperty p && p.IsReference())
             {
                 return c.TypeWithReferencesRequest();
             }
@@ -369,7 +369,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.Java
 
         public static string TypeCollectionRequest(this OdcmObject c)
         {
-            if (c is OdcmProperty && c.AsOdcmProperty().IsReference())
+            if (c is OdcmProperty p && p.IsReference())
             {
                 return c.TypeCollectionWithReferencesRequest();
             }
@@ -699,8 +699,13 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.Java
                     var returnTypeNamespace = returnTypeClass.Namespace.Name.AddPrefix();
                     returnTypeClass
                         .NavigationProperties(true)
-                        .Where(x => !x.GetPropertyNamespace().Equals(returnTypeNamespace))
-                        .Select(x => $"import {x.GetPropertyNamespace()}.{GetPrefixForRequests()}.{x.Projection.Type.TypeRequestBuilder()};\n")
+                        .Select(x => new Tuple<string, string>(x.GetPropertyNamespace(), 
+                                                                x.IsCollection ? 
+                                                                    x.Projection.Type.TypeCollectionRequestBuilder() :
+                                                                    x.Projection.Type.TypeRequestBuilder()))
+                        .Where(x => !x.Item1.Equals(returnTypeNamespace))
+                        .Select(x => $"import {x.Item1}.{GetPrefixForRequests()}.{x.Item2};\n")
+                        .Distinct()
                         .ToList()
                         .ForEach(x => sb.Append(x));
                 }

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.graph2.callrecords.requests;
 import com.microsoft.graph2.callrecords.requests.CallRecordItemRequest;
-import com.microsoft.graph.requests.EntityType2RequestBuilder;
+import com.microsoft.graph.requests.EntityType2CollectionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecord;
 import com.microsoft.graph.http.BaseFunctionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecordItemParameterSet;

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph2/callrecords/requests/CallRecordItemRequestBuilder.java
@@ -5,7 +5,7 @@
 
 package com.microsoft.graph2.callrecords.requests;
 import com.microsoft.graph2.callrecords.requests.CallRecordItemRequest;
-import com.microsoft.graph.requests.EntityType2RequestBuilder;
+import com.microsoft.graph.requests.EntityType2CollectionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecord;
 import com.microsoft.graph.http.BaseFunctionRequestBuilder;
 import com.microsoft.graph2.callrecords.models.CallRecordItemParameterSet;


### PR DESCRIPTION
- fixes a bug where imports for navigation property of collection for composable methods would be incorrect in java
- updates java test data

related to
https://github.com/microsoftgraph/msgraph-sdk-java/pull/848

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/578)