### PR TITLE
Fix for missing AddAsync methods for collection references

### DIFF
--- a/GraphODataTemplateWriter.Test/ContainmentTests.cs
+++ b/GraphODataTemplateWriter.Test/ContainmentTests.cs
@@ -62,6 +62,22 @@ namespace GraphODataTemplateWriter.Test
             Assert.AreEqual(singleton.Name, result.Name);
         }
 
+        /// <summary>
+        /// Test an implicit entity set is found for a given navigation property without 
+        /// containment or an explicit entity set but exists nested in a singleton navigation property chain
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("testChainedNav", true)] // we can navigate to the type using /GraphService/testSingleton2/testSingleNav3/containedNestedTestNav/oneLevelContainedNestedTestNav
+        [DataRow("testNav", true)] // we can navigate to the type using /GraphService/testSingleton/testSingleNav/
+        [DataRow("testInvalidNav", false)] // we cant navigate to this by following a chain of contained nav properties from the root service object
+        public void TestIsPropertyChainedToContainedServiceNavigationPropertyt(string propertyName, bool expectedResult)
+        {
+            var type = model.GetEntityTypes().First(t => t.Name == "testEntity");
+            var prop = type.Properties.First(p => p.Name == propertyName);
+            bool result = prop.IsPropertyChainedToContainedServiceNavigationProperty(model);
+            Assert.AreEqual(expectedResult, result);
+        }
+
         [TestMethod]
         public void GetDeprecation()
         {

--- a/GraphODataTemplateWriter.Test/Edmx/Containment.xml
+++ b/GraphODataTemplateWriter.Test/Edmx/Containment.xml
@@ -11,16 +11,25 @@
       <EntityType Name="testType"></EntityType>
       <EntityType Name="testType2"></EntityType>
       <EntityType Name="testType3"></EntityType>
+      <EntityType Name="testType4">
+        <NavigationProperty Name="containedNestedTestNav" Type="graph.testType5" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="testType5">
+        <NavigationProperty Name="oneLevelContainedNestedTestNav" Type="graph.testType6" ContainsTarget="true" />
+      </EntityType>
+      <EntityType Name="testType6"></EntityType>
       <EntityType Name="testEntity">
         <NavigationProperty Name="testNav" Type="graph.testType"/>
         <NavigationProperty Name="testInvalidNav" Type="graph.testType2"/>
         <NavigationProperty Name="testExplicitNav" Type="graph.testType3"/>
+        <NavigationProperty Name="testChainedNav" Type="graph.testType6"/>
       </EntityType>
       <EntityType Name="testSingleton">
         <NavigationProperty Name="testSingleNav" Type="graph.testType" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="testSingleton2">
         <NavigationProperty Name="testSingleNav2" Type="graph.testType3" ContainsTarget="true" />
+        <NavigationProperty Name="testSingleNav3" Type="graph.testType4" ContainsTarget="true" />
       </EntityType>
       <EntityContainer Name="GraphService">
         <Singleton Name="testSingleton" Type="graph.testSingleton"/>

--- a/Templates/templates/CSharp/Base/CollectionRequest.Base.template.tt
+++ b/Templates/templates/CSharp/Base/CollectionRequest.Base.template.tt
@@ -141,17 +141,24 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty, 
 
     var templateWriterHost = (CustomT4Host)Host;
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
+    var useCustomReferenceRequestBody = false;
 
     var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType(((CustomT4Host)Host).CurrentModel);
-	if (serviceNavigationProperty == null)
-		return string.Empty;
+    if (serviceNavigationProperty == null && odcmProperty.IsPropertyChainedToContainedServiceNavigationProperty(((CustomT4Host)Host).CurrentModel))
+    {
+        useCustomReferenceRequestBody = true;
+        propertyType = referenceRequestBodyTypeName;
+        sanitizedPropertyName = String.Concat(sanitizedPropertyName, "Reference");
+    }
+    else if(serviceNavigationProperty == null)
+        return string.Empty;
 
 	var implicitNavigationProperty = string.Empty;
 
 	// If the odcmProperty is a part of Singleton, then we need to determine whether there is a
 	// NavigationPropertyBinding generation hint. If there is, then we need to use it for
 	// creating the URL of a reference entity in a POST body.
-	if (serviceNavigationProperty.GetType() == typeof(OdcmSingleton))
+	if (serviceNavigationProperty?.GetType() == typeof(OdcmSingleton))
 	    implicitNavigationProperty = "/" + odcmProperty.GetImplicitPropertyName((OdcmSingleton)serviceNavigationProperty);
 
     var stringBuilder = new StringBuilder();
@@ -177,7 +184,14 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty, 
     stringBuilder.AppendFormat("            this.Method = {0};", templateWriter.PostMethod);
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("            if (string.IsNullOrEmpty({0}.Id))", sanitizedPropertyName);
+    if(useCustomReferenceRequestBody)
+    {
+        stringBuilder.AppendFormat("            if (string.IsNullOrEmpty({0}.ODataId))", sanitizedPropertyName);
+    }
+    else
+    {
+        stringBuilder.AppendFormat("            if (string.IsNullOrEmpty({0}.Id))", sanitizedPropertyName);
+    }
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("            {");
     stringBuilder.Append(Environment.NewLine);
@@ -185,16 +199,21 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty, 
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("            }");
     stringBuilder.Append(Environment.NewLine);
-    stringBuilder.Append(Environment.NewLine);
-    stringBuilder.AppendFormat("            var requestBody = new {0} {{ ODataId = string.Format(\"{{0}}/{1}{2}/{{1}}\", this.Client.BaseUrl, {3}.Id) }};", referenceRequestBodyTypeName, serviceNavigationProperty.Name, implicitNavigationProperty, sanitizedPropertyName);
+    var sendVariable = sanitizedPropertyName;
+    if(!useCustomReferenceRequestBody)
+    {
+        stringBuilder.Append(Environment.NewLine);
+        stringBuilder.AppendFormat("            var requestBody = new {0} {{ ODataId = string.Format(\"{{0}}/{1}{2}/{{1}}\", this.Client.BaseUrl, {3}.Id) }};", referenceRequestBodyTypeName, serviceNavigationProperty?.Name, implicitNavigationProperty, sanitizedPropertyName);
+        sendVariable = "requestBody";
+    }
     stringBuilder.Append(Environment.NewLine);
     if (isGraphResponseMethod)
     {
-        stringBuilder.AppendFormat("            return this.SendAsyncWithGraphResponse(requestBody, cancellationToken);");
+        stringBuilder.AppendFormat("            return this.SendAsyncWithGraphResponse({0}, cancellationToken);",sendVariable);
     }
     else
     {
-        stringBuilder.AppendFormat("            return this.SendAsync(requestBody, cancellationToken);");
+        stringBuilder.AppendFormat("            return this.SendAsync({0}, cancellationToken);",sendVariable);
     }
     stringBuilder.Append(Environment.NewLine);
     stringBuilder.Append("        }");

--- a/Templates/templates/CSharp/Base/ICollectionRequest.Base.template.tt
+++ b/Templates/templates/CSharp/Base/ICollectionRequest.Base.template.tt
@@ -98,7 +98,12 @@ public string GetPostAsyncMethodForReferencesRequest(OdcmProperty odcmProperty, 
     var templateWriter = (CodeWriterCSharp)templateWriterHost.CodeWriter;
 
     var serviceNavigationProperty = odcmProperty.GetServiceCollectionNavigationPropertyForPropertyType(((CustomT4Host)Host).CurrentModel);
-    if (serviceNavigationProperty == null)
+    if (serviceNavigationProperty == null && odcmProperty.IsPropertyChainedToContainedServiceNavigationProperty(((CustomT4Host)Host).CurrentModel))
+    {
+        propertyType = @namespace.GetCoreLibraryType("ReferenceRequestBody");
+        sanitizedPropertyName = String.Concat(sanitizedPropertyName, "Reference");
+    }
+    else if(serviceNavigationProperty == null)
         return string.Empty;
 
     var stringBuilder = new StringBuilder();

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
         private static bool IsPropertyTypeChainedContainedNavigationProperty(this OdcmProperty odcmRootProperty, OdcmProperty testProperty, HashSet<string> navigatedTypes, string route)
         {
             // check if the property already matches the type.
-            if (odcmRootProperty.Type.FullName.Equals(testProperty.Type.FullName))
+            if (odcmRootProperty.Type.FullName.Equals(testProperty.Type.FullName, StringComparison.OrdinalIgnoreCase))
             {
                 logger.Info("Property \"{0}\" matches self contained navigation property \"{1}\" of type \"{2}\"", testProperty.Name, odcmRootProperty.Name, odcmRootProperty.Type.FullName);
                 logger.Info("Possible route from service class is: {0}{1}{1}",route,Environment.NewLine);

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+﻿// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 namespace Microsoft.Graph.ODataTemplateWriter.Extensions
 {
@@ -352,9 +352,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             }
 
             // check if the base class is referenced instead.
-            if (odcmRootProperty.Type.FullName.Equals(testProperty.BaseClass()?.FullName))
+            if (odcmRootProperty.AsOdcmClass()?.IsAncestorOfType(testProperty.AsOdcmClass() ?? null) ?? false)
             {
-                logger.Info("Property \"{0}\" matches self contained navigation property \"{1}\" of Base type \"{2}\"", testProperty.Name, odcmRootProperty.Name, testProperty.BaseClass()?.FullName);
+                logger.Info("Property \"{0}\" of type \"{1}\" matches self contained navigation property \"{2}\" of Base type \"{3}\"", testProperty.Name, testProperty.Type.FullName, odcmRootProperty.Name, odcmRootProperty.Type.FullName);
                 logger.Info("Possible route from service class is: {0}{1}{1}", route, Environment.NewLine);
                 return true;
             }
@@ -371,6 +371,24 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             );
 
             return matchingProperty != null;
+        }
+
+        /// <summary>
+        /// This method tries to determine if a certain class is an ancestor of the other class.
+        /// </summary>
+        /// <param name="odcmClass"></param>
+        /// <param name="testClass"></param>
+        /// <returns></returns>
+        private static bool IsAncestorOfType(this OdcmClass odcmClass, OdcmClass testClass)
+        {
+            if (testClass?.Base == null || testClass == null)
+            {
+                return false; // no base type. end of the road
+            }
+
+            // check if the base is a match. Otherwise keep going up by trying the test class' base
+            return odcmClass.FullName.Equals(testClass.Base.FullName, StringComparison.OrdinalIgnoreCase) ||
+                   odcmClass.IsAncestorOfType(testClass.Base);
         }
 
         public static string GetImplicitPropertyName(this OdcmProperty property, OdcmSingleton singleton)

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -231,7 +231,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
         /// 3. If a navigation property does not have a defined EntitySet but there is a Singleton which has 
         ///    a self-contained reference to the given type, we can make a relationship to the implied EntitySet of 
         ///    the singleton. Generate a reference path to the item (ie "singleton/item/$ref").
-        /// 4. If none of the above pertain to the navigation property, it should be treated as a metadata error.
+        /// 4. If none of the above pertain. Try to call <see cref="IsPropertyChainedToContainedServiceNavigationProperty"/> to ascertain if this is a metadata error as
+        ///    the relationship could be more than one level deep. (The nav property we are looking for could be a navigation property of another navigation property :) ).
+        /// 5. If none of the above pertain to the navigation property, it should be treated as a metadata error.
         /// </summary>
         public static OdcmProperty GetServiceCollectionNavigationPropertyForPropertyType(this OdcmProperty odcmProperty, OdcmModel model)
         {
@@ -345,7 +347,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             if (odcmRootProperty.Type.FullName.Equals(testProperty.Type.FullName))
             {
                 logger.Info("Property \"{0}\" matches self contained navigation property \"{1}\" of type \"{2}\"", testProperty.Name, odcmRootProperty.Name, odcmRootProperty.Type.FullName);
-                logger.Info("Route from service class is: {0}",route);
+                logger.Info("Possible route from service class is: {0}{1}{1}",route,Environment.NewLine);
                 return true;
             }
 
@@ -353,7 +355,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             if (odcmRootProperty.Type.FullName.Equals(testProperty.BaseClass()?.FullName))
             {
                 logger.Info("Property \"{0}\" matches self contained navigation property \"{1}\" of Base type \"{2}\"", testProperty.Name, odcmRootProperty.Name, testProperty.BaseClass()?.FullName);
-                logger.Info("Route from service class is: {0}",route);
+                logger.Info("Possible route from service class is: {0}{1}{1}", route, Environment.NewLine);
                 return true;
             }
 


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/336

This PR fixes the blocked generation of POST(Add) request builders for some objects due to the expectation in the generator that posts $ref segments should have the following expectations

```cs
  /// 1. If a navigation property specifies "ContainsTarget='true'", it is self-contained. 
  ///    Generate a direct path to the item (ie "parent/child").
  /// 2. If a navigation property does not specify ContainsTarget but there is a defined EntitySet 
  ///    of the given type, it is a reference relationship. Generate a reference path to the item (ie "item/$ref").
  /// 3. If a navigation property does not have a defined EntitySet but there is a Singleton which has 
  ///    a self-contained reference to the given type, we can make a relationship to the implied EntitySet of 
  ///    the singleton. Generate a reference path to the item (ie "singleton/item/$ref").
  /// 4. If none of the above pertain to the navigation property, it should be treated as a metadata error.
```

However, the example [here](https://docs.microsoft.com/en-us/graph/api/ediscovery-sourcecollection-post-custodiansources?view=graph-rest-beta&tabs=http#request) shows that the navigation property containing the reference could be chained through several levels of contained navigation properties from the entityContainer.

This PR therefore adds a new method that can deduce if a given property is navigable from the entityContainer through a chain of navigationProperties with ContainsTarget=true. This is then used after we confirm that the four checks above are not true to avoid altering any functionality.

**Notes**
- There is the possibility of several routes (and multiple id insertions) from the entityContainer, therefore generation has been updated to let the user create the `ReferenceRequestBody` instance for themselves in the event this is exposed.

**Generations changes**
Generation Beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/346
Generation V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1142

**Todo**
- [x] Validate the validity of newly exposed methods (validations added to PR descriptions in service libraries)
- [x] Update snippet generation (Resolved via https://github.com/microsoftgraph/microsoft-graph-devx-api/pull/714)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/596)