### PR TITLE
Fixes length check before serializing an Enum collection

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -303,7 +303,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
                    foreach ($values as $propertyValue) {
                        $values []= $propertyValue->format(\DateTimeInterface::RFC3339);
                    }
-                } else if(count > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
+                } else if(count($val) > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
                     foreach ($values as $propertyValue) {
                        $values []= $propertyValue->value();
                    }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -128,7 +128,7 @@ class Entity implements \JsonSerializable
                    foreach ($values as $propertyValue) {
                        $values []= $propertyValue->format(\DateTimeInterface::RFC3339);
                    }
-                } else if(count > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
+                } else if(count($val) > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
                     foreach ($values as $propertyValue) {
                        $values []= $propertyValue->value();
                    }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -128,7 +128,7 @@ class GraphPrint implements \JsonSerializable
                    foreach ($values as $propertyValue) {
                        $values []= $propertyValue->format(\DateTimeInterface::RFC3339);
                    }
-                } else if(count > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
+                } else if(count($val) > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
                     foreach ($values as $propertyValue) {
                        $values []= $propertyValue->value();
                    }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -128,7 +128,7 @@ class Entity implements \JsonSerializable
                    foreach ($values as $propertyValue) {
                        $values []= $propertyValue->format(\DateTimeInterface::RFC3339);
                    }
-                } else if(count > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
+                } else if(count($val) > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
                     foreach ($values as $propertyValue) {
                        $values []= $propertyValue->value();
                    }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -128,7 +128,7 @@ class GraphPrint implements \JsonSerializable
                    foreach ($values as $propertyValue) {
                        $values []= $propertyValue->format(\DateTimeInterface::RFC3339);
                    }
-                } else if(count > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
+                } else if(count($val) > 0 && is_a($val[0], '\Microsoft\Graph\Core\Enum')) {
                     foreach ($values as $propertyValue) {
                        $values []= $propertyValue->value();
                    }


### PR DESCRIPTION
## Summary
Fixes length check before serializing Enum collection


## Generated code differences
![image](https://user-images.githubusercontent.com/10958912/134429993-2018ee12-685c-4ca6-a1cc-ef0e51dd75ff.png)


## Command line arguments to run these changes

None

## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-php/issues/599

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/598)