### PR TITLE
Make PHP beta migration test stage the official beta stage in PHP v2

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -300,35 +300,6 @@ stages:
 
 - stage: stage_php_beta
   dependsOn:
-  - stage_build_and_publish_typewriter
-  - stage_beta_metadata
-  condition: |
-    and
-    (
-      eq(dependencies.stage_build_and_publish_typewriter.result, 'Succeeded'),
-      in(dependencies.stage_beta_metadata.result, 'Succeeded', 'Skipped')
-    )
-  jobs:
-  - job: php_beta
-    steps:
-    - template: generation-templates/language-generation.yml
-      parameters:
-        language: 'PHP'
-        version: 'beta'
-        repoName: 'msgraph-sdk-php'
-        branchName: $(betaBranch)
-        cleanMetadataFile: $(cleanMetadataFileBeta)
-        cleanMetadataFolder: $(cleanMetadataFolderBeta)
-        languageSpecificSteps:
-        - template: generation-templates/php-beta.yml
-          parameters:
-             phpBetaGenerationDirectory: $(Build.SourcesDirectory)/msgraph-sdk-php/src/Beta/
-             repoName: 'msgraph-sdk-php'
-             migration: false
-             pathToCopy: '/com/Beta/*'
-
-- stage: stage_php_beta_migration
-  dependsOn:
     - stage_build_and_publish_typewriter
     - stage_beta_metadata
   condition: |


### PR DESCRIPTION
## Summary

Replaces current PHP beta stage that writes models to the v1 repo with the test PHP beta stage config that writes to the new Beta SDK repo

## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-php/issues/599

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/600)