### PR TITLE
Remove beta updates to PHP beta SDK library until v2 is stable

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -327,35 +327,6 @@ stages:
              migration: false
              pathToCopy: '/com/Beta/*'
 
-- stage: stage_php_beta_migration
-  dependsOn:
-    - stage_build_and_publish_typewriter
-    - stage_beta_metadata
-  condition: |
-    and
-    (
-      eq(dependencies.stage_build_and_publish_typewriter.result, 'Succeeded'),
-      in(dependencies.stage_beta_metadata.result, 'Succeeded', 'Skipped')
-    )
-  jobs:
-    - job: php_beta_migration
-      steps:
-        - template: generation-templates/language-generation.yml
-          parameters:
-            language: 'PHP'
-            version: 'beta'
-            repoName: 'msgraph-beta-sdk-php'
-            branchName: $(betaBranch)
-            cleanMetadataFile: $(cleanMetadataFileBeta)
-            cleanMetadataFolder: $(cleanMetadataFolderBeta)
-            languageSpecificSteps:
-              - template: generation-templates/php-beta.yml
-                parameters:
-                  phpBetaGenerationDirectory: $(Build.SourcesDirectory)/msgraph-beta-sdk-php/src/
-                  repoName: 'msgraph-beta-sdk-php'
-                  migration: true
-                  pathToCopy: '/com/Beta/Microsoft/Graph/*'
-
 - stage: stage_typescript_v1
   dependsOn:
   - stage_build_and_publish_typewriter


### PR DESCRIPTION
## Summary

Removes the test Beta PHP stage used to push Beta model updates to the new Beta SDK repo.

The Beta SDK repo will be updated via manual runs of `support/php-2.x.x` to allow breaking model template changes currently on `support/php-2.x.x` to not be overwritten by weekly generation runs.

The removed test migration changes will be made the official beta stage in `support/php-2.x.x` which will later be merged to dev when v2 is stable. PR for that https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/600


## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-php/issues/599

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/601)