### PR TITLE
Fix generation pipeline to depend on stage_build_and_publish_kiota stage

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -160,7 +160,9 @@ stages:
 # metadata through the cleaning and documentation processes before validating
 # the results with generated and built .NET code files as a smoke test.
 - stage: stage_v1_metadata
-  dependsOn: stage_build_and_publish_typewriter
+  dependsOn:
+    - stage_build_and_publish_typewriter
+    - stage_build_and_publish_kiota
   condition: |
     and(succeeded('stage_build_and_publish_typewriter'),
         succeeded('stage_build_and_publish_kiota'),
@@ -179,7 +181,9 @@ stages:
 
 # Same description as stage_v1_metadata
 - stage: stage_beta_metadata
-  dependsOn: stage_build_and_publish_typewriter
+  dependsOn:
+    - stage_build_and_publish_typewriter
+    - stage_build_and_publish_kiota
   condition: |
     and(succeeded('stage_build_and_publish_typewriter'),
         succeeded('stage_build_and_publish_kiota'),

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -160,12 +160,9 @@ stages:
 # metadata through the cleaning and documentation processes before validating
 # the results with generated and built .NET code files as a smoke test.
 - stage: stage_v1_metadata
-  dependsOn:
-    - stage_build_and_publish_typewriter
-    - stage_build_and_publish_kiota
+  dependsOn: stage_build_and_publish_typewriter
   condition: |
     and(succeeded('stage_build_and_publish_typewriter'),
-        succeeded('stage_build_and_publish_kiota'),
         eq( ${{ parameters.skipMetadataCaptureAndClean }}, false))
   jobs:
   - job: v1_metadata
@@ -181,12 +178,9 @@ stages:
 
 # Same description as stage_v1_metadata
 - stage: stage_beta_metadata
-  dependsOn:
-    - stage_build_and_publish_typewriter
-    - stage_build_and_publish_kiota
+  dependsOn: stage_build_and_publish_typewriter
   condition: |
     and(succeeded('stage_build_and_publish_typewriter'),
-        succeeded('stage_build_and_publish_kiota'),
         eq( ${{ parameters.skipMetadataCaptureAndClean }}, false))
   jobs:
   - job: beta_metadata


### PR DESCRIPTION
This PR fixes the generation pipeline to ensure the capture metadata stages wait for the `stage_build_and_publish_kiota` stage to complete in order to ensure the step is not skipped (the conditions for the stage rely on the completion of the `stage_build_and_publish_kiota`  stage). 

This caused the generation pipeline to skip capture metadata stages and thus the later generation stages failed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/634)