### PR TITLE
Fix PHP collection setter phpdocs

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -29,7 +29,7 @@ class <#=entityName.ToCheckedCase()#> implements \JsonSerializable
 } else {
 #>
 class <#=entityName.ToCheckedCase()#> extends <#=entityBaseName#>
-<# 
+<#
 }
 #>
 {
@@ -43,7 +43,7 @@ if (String.IsNullOrEmpty(entityBaseName)) {
     * @var array $_propDict
     */
     protected $_propDict;
-    
+
     /**
     * Construct a new <#=entityName.ToCheckedCase()#>
     *
@@ -66,7 +66,7 @@ if (String.IsNullOrEmpty(entityBaseName)) {
     {
         return $this->_propDict;
     }
-    
+
 <#
 }
 foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString() != "bytes")){
@@ -87,7 +87,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
         if (property.IsCollection()) {
 #>
 
-     /** 
+     /**
      * Gets the <#=propertyName#>
 <# if (property.LongDescription != null || property.Description != null) {
 #>
@@ -104,15 +104,15 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the <#=propertyName#>
 <# if (property.LongDescription != null || property.Description != null) {
 #>
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=propertyTypeReference#> $val The <#=propertyName#>
+    * @param <#=propertyTypeReference#>[] $val The <#=propertyName#>
     *
     * @return <#=entityName.ToCheckedCase()#>
     */
@@ -121,7 +121,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
         $this->_propDict["<#=camelCasePropertyName#>"] = $val;
         return $this;
     }
-    
+
 <#
    } else {
 #>
@@ -151,7 +151,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
         }
         return null;
     }
-    
+
     /**
     * Sets the <#=propertyName#>
 <# if (property.LongDescription != null || property.Description != null) {
@@ -176,7 +176,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 <# } #>
         return $this;
     }
-    
+
 <#
             }
         } else {
@@ -208,7 +208,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
             return null;
         }
     }
-    
+
     /**
     * Sets the <#=propertyName#>
 <# if (property.LongDescription != null || property.Description != null) {
@@ -225,7 +225,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 <#
     if (propertyTypeString == "\\DateTime") {
 #>
-        $this->_propDict["<#=camelCasePropertyName#>"] 
+        $this->_propDict["<#=camelCasePropertyName#>"]
             = $val->format(\DateTime::ISO8601) . "Z";
 <#
       } else {
@@ -244,7 +244,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
 #>
         return $this;
     }
-    
+
 <#
         }
     }
@@ -262,7 +262,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
         }
         return null;
     }
-    
+
     /**
     * Sets the ODataType
     *
@@ -275,7 +275,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
         $this->_propDict["@odata.type"] = $val;
         return $this;
     }
-    
+
     /**
     * Serializes the object by property array
     * Manually serialize DateTime into RFC3339 format

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallRecord.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/CallRecord.php
@@ -37,7 +37,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the version
     *
@@ -50,7 +50,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["version"] = intval($val);
         return $this;
     }
-    
+
     /**
     * Gets the type
     *
@@ -68,7 +68,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the type
     *
@@ -81,9 +81,9 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["type"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the modalities
      *
      * @return array|null The modalities
@@ -96,11 +96,11 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the modalities
     *
-    * @param Modality $val The modalities
+    * @param Modality[] $val The modalities
     *
     * @return CallRecord
     */
@@ -109,7 +109,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["modalities"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the lastModifiedDateTime
     *
@@ -127,7 +127,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the lastModifiedDateTime
     *
@@ -140,7 +140,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["lastModifiedDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the startDateTime
     *
@@ -158,7 +158,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -171,7 +171,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -189,7 +189,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -202,7 +202,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the organizer
     *
@@ -220,7 +220,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the organizer
     *
@@ -233,9 +233,9 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["organizer"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the participants
      *
      * @return array|null The participants
@@ -248,11 +248,11 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the participants
     *
-    * @param \Microsoft\Graph\Model\IdentitySet $val The participants
+    * @param \Microsoft\Graph\Model\IdentitySet[] $val The participants
     *
     * @return CallRecord
     */
@@ -261,7 +261,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["participants"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the joinWebUrl
     *
@@ -275,7 +275,7 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the joinWebUrl
     *
@@ -288,9 +288,9 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["joinWebUrl"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the sessions
      *
      * @return array|null The sessions
@@ -303,11 +303,11 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the sessions
     *
-    * @param Session $val The sessions
+    * @param Session[] $val The sessions
     *
     * @return CallRecord
     */
@@ -316,9 +316,9 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["sessions"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the recipients
      *
      * @return array|null The recipients
@@ -331,11 +331,11 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the recipients
     *
-    * @param \Microsoft\Graph\Model\EntityType2 $val The recipients
+    * @param \Microsoft\Graph\Model\EntityType2[] $val The recipients
     *
     * @return CallRecord
     */
@@ -344,5 +344,5 @@ class CallRecord extends \Microsoft\Graph\Model\Entity
         $this->_propDict["recipients"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Photo.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Photo.php
@@ -41,7 +41,7 @@ class Photo extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -54,7 +54,7 @@ class Photo extends \Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the option
     *
@@ -72,7 +72,7 @@ class Photo extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the option
     *
@@ -85,5 +85,5 @@ class Photo extends \Microsoft\Graph\Model\Entity
         $this->_propDict["option"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Segment.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Segment.php
@@ -41,7 +41,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -54,7 +54,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -72,7 +72,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -85,7 +85,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the caller
     *
@@ -103,7 +103,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the caller
     *
@@ -116,7 +116,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["caller"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the callee
     *
@@ -134,7 +134,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the callee
     *
@@ -147,7 +147,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["callee"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the failureInfo
     *
@@ -165,7 +165,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -178,9 +178,9 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the media
      *
      * @return array|null The media
@@ -193,11 +193,11 @@ class Segment extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the media
     *
-    * @param Media $val The media
+    * @param Media[] $val The media
     *
     * @return Segment
     */
@@ -206,9 +206,9 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["media"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the refTypes
      *
      * @return array|null The refTypes
@@ -221,11 +221,11 @@ class Segment extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the refTypes
     *
-    * @param \Microsoft\Graph\Model\EntityType3 $val The refTypes
+    * @param \Microsoft\Graph\Model\EntityType3[] $val The refTypes
     *
     * @return Segment
     */
@@ -234,7 +234,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["refTypes"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the refType
     *
@@ -252,7 +252,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the refType
     *
@@ -265,7 +265,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["refType"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the sessionRef
     *
@@ -283,7 +283,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the sessionRef
     *
@@ -296,7 +296,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["sessionRef"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the photo
     *
@@ -314,7 +314,7 @@ class Segment extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the photo
     *
@@ -327,5 +327,5 @@ class Segment extends \Microsoft\Graph\Model\Entity
         $this->_propDict["photo"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Session.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/Session.php
@@ -25,7 +25,7 @@ namespace Microsoft\Graph\CallRecords\Model;
 class Session extends \Microsoft\Graph\Model\Entity
 {
 
-     /** 
+     /**
      * Gets the modalities
      *
      * @return array|null The modalities
@@ -38,11 +38,11 @@ class Session extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the modalities
     *
-    * @param Modality $val The modalities
+    * @param Modality[] $val The modalities
     *
     * @return Session
     */
@@ -51,7 +51,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["modalities"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the startDateTime
     *
@@ -69,7 +69,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -82,7 +82,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -100,7 +100,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -113,7 +113,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the caller
     *
@@ -131,7 +131,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the caller
     *
@@ -144,7 +144,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["caller"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the callee
     *
@@ -162,7 +162,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the callee
     *
@@ -175,7 +175,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["callee"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the failureInfo
     *
@@ -193,7 +193,7 @@ class Session extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -206,9 +206,9 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the segments
      *
      * @return array|null The segments
@@ -221,11 +221,11 @@ class Session extends \Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the segments
     *
-    * @param Segment $val The segments
+    * @param Segment[] $val The segments
     *
     * @return Session
     */
@@ -234,5 +234,5 @@ class Session extends \Microsoft\Graph\Model\Entity
         $this->_propDict["segments"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
@@ -41,7 +41,7 @@ class SingletonEntity1 extends \Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav
     *
@@ -54,5 +54,5 @@ class SingletonEntity1 extends \Microsoft\Graph\Model\Entity
         $this->_propDict["testSingleNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Call.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Call.php
@@ -37,7 +37,7 @@ class Call extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the subject
     *
@@ -50,5 +50,5 @@ class Call extends Entity
         $this->_propDict["subject"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/CloudCommunications.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/CloudCommunications.php
@@ -25,7 +25,7 @@ namespace Microsoft\Graph\Model;
 class CloudCommunications extends Entity
 {
 
-     /** 
+     /**
      * Gets the calls
      *
      * @return array|null The calls
@@ -38,11 +38,11 @@ class CloudCommunications extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the calls
     *
-    * @param Call $val The calls
+    * @param Call[] $val The calls
     *
     * @return CloudCommunications
     */
@@ -51,9 +51,9 @@ class CloudCommunications extends Entity
         $this->_propDict["calls"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the callRecords
      *
      * @return array|null The callRecords
@@ -66,11 +66,11 @@ class CloudCommunications extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the callRecords
     *
-    * @param \Microsoft\Graph\CallRecords\Model\CallRecord $val The callRecords
+    * @param \Microsoft\Graph\CallRecords\Model\CallRecord[] $val The callRecords
     *
     * @return CloudCommunications
     */
@@ -79,5 +79,5 @@ class CloudCommunications extends Entity
         $this->_propDict["callRecords"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Endpoint.php
@@ -37,7 +37,7 @@ class Endpoint extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the property1
     *
@@ -50,5 +50,5 @@ class Endpoint extends Entity
         $this->_propDict["property1"] = intval($val);
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -31,7 +31,7 @@ class Entity implements \JsonSerializable
     * @var array $_propDict
     */
     protected $_propDict;
-    
+
     /**
     * Construct a new Entity
     *
@@ -54,7 +54,7 @@ class Entity implements \JsonSerializable
     {
         return $this->_propDict;
     }
-    
+
     /**
     * Gets the id
     *
@@ -68,7 +68,7 @@ class Entity implements \JsonSerializable
             return null;
         }
     }
-    
+
     /**
     * Sets the id
     *
@@ -81,7 +81,7 @@ class Entity implements \JsonSerializable
         $this->_propDict["id"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the ODataType
     *
@@ -94,7 +94,7 @@ class Entity implements \JsonSerializable
         }
         return null;
     }
-    
+
     /**
     * Sets the ODataType
     *
@@ -107,7 +107,7 @@ class Entity implements \JsonSerializable
         $this->_propDict["@odata.type"] = $val;
         return $this;
     }
-    
+
     /**
     * Serializes the object by property array
     * Manually serialize DateTime into RFC3339 format

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -31,7 +31,7 @@ class GraphPrint implements \JsonSerializable
     * @var array $_propDict
     */
     protected $_propDict;
-    
+
     /**
     * Construct a new GraphPrint
     *
@@ -54,7 +54,7 @@ class GraphPrint implements \JsonSerializable
     {
         return $this->_propDict;
     }
-    
+
     /**
     * Gets the settings
     *
@@ -68,7 +68,7 @@ class GraphPrint implements \JsonSerializable
             return null;
         }
     }
-    
+
     /**
     * Sets the settings
     *
@@ -81,7 +81,7 @@ class GraphPrint implements \JsonSerializable
         $this->_propDict["settings"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the ODataType
     *
@@ -94,7 +94,7 @@ class GraphPrint implements \JsonSerializable
         }
         return null;
     }
-    
+
     /**
     * Sets the ODataType
     *
@@ -107,7 +107,7 @@ class GraphPrint implements \JsonSerializable
         $this->_propDict["@odata.type"] = $val;
         return $this;
     }
-    
+
     /**
     * Serializes the object by property array
     * Manually serialize DateTime into RFC3339 format

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/OnenotePage.php
@@ -44,7 +44,7 @@ class OnenotePage extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the content
     * The OneNotePage content.
@@ -60,5 +60,5 @@ class OnenotePage extends Entity
         $this->_propDict["content"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Schedule.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Schedule.php
@@ -37,7 +37,7 @@ class Schedule extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the enabled
     *
@@ -50,9 +50,9 @@ class Schedule extends Entity
         $this->_propDict["enabled"] = boolval($val);
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the timesOff
      *
      * @return array|null The timesOff
@@ -65,11 +65,11 @@ class Schedule extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the timesOff
     *
-    * @param TimeOff $val The timesOff
+    * @param TimeOff[] $val The timesOff
     *
     * @return Schedule
     */
@@ -78,9 +78,9 @@ class Schedule extends Entity
         $this->_propDict["timesOff"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the timeOffRequests
      *
      * @return array|null The timeOffRequests
@@ -93,11 +93,11 @@ class Schedule extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the timeOffRequests
     *
-    * @param TimeOffRequest $val The timeOffRequests
+    * @param TimeOffRequest[] $val The timeOffRequests
     *
     * @return Schedule
     */
@@ -106,5 +106,5 @@ class Schedule extends Entity
         $this->_propDict["timeOffRequests"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity1.php
@@ -41,7 +41,7 @@ class SingletonEntity1 extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav
     *
@@ -54,5 +54,5 @@ class SingletonEntity1 extends Entity
         $this->_propDict["testSingleNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity2.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/SingletonEntity2.php
@@ -41,7 +41,7 @@ class SingletonEntity2 extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav2
     *
@@ -54,5 +54,5 @@ class SingletonEntity2 extends Entity
         $this->_propDict["testSingleNav2"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestEntity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestEntity.php
@@ -41,7 +41,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testNav
     *
@@ -54,7 +54,7 @@ class TestEntity extends Entity
         $this->_propDict["testNav"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the testInvalidNav
     *
@@ -72,7 +72,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testInvalidNav
     *
@@ -85,7 +85,7 @@ class TestEntity extends Entity
         $this->_propDict["testInvalidNav"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the testExplicitNav
     *
@@ -103,7 +103,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testExplicitNav
     *
@@ -116,5 +116,5 @@ class TestEntity extends Entity
         $this->_propDict["testExplicitNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
@@ -41,7 +41,7 @@ class TestType extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the propertyAlpha
     *
@@ -54,5 +54,5 @@ class TestType extends Entity
         $this->_propDict["propertyAlpha"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOff.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOff.php
@@ -37,7 +37,7 @@ class TimeOff extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the name
     *
@@ -50,5 +50,5 @@ class TimeOff extends Entity
         $this->_propDict["name"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOffRequest.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TimeOffRequest.php
@@ -37,7 +37,7 @@ class TimeOffRequest extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the name
     *
@@ -50,5 +50,5 @@ class TimeOffRequest extends Entity
         $this->_propDict["name"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallRecord.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/CallRecord.php
@@ -37,7 +37,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the version
     *
@@ -50,7 +50,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["version"] = intval($val);
         return $this;
     }
-    
+
     /**
     * Gets the type
     *
@@ -68,7 +68,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the type
     *
@@ -81,9 +81,9 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["type"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the modalities
      *
      * @return array|null The modalities
@@ -96,11 +96,11 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the modalities
     *
-    * @param Modality $val The modalities
+    * @param Modality[] $val The modalities
     *
     * @return CallRecord
     */
@@ -109,7 +109,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["modalities"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the lastModifiedDateTime
     *
@@ -127,7 +127,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the lastModifiedDateTime
     *
@@ -140,7 +140,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["lastModifiedDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the startDateTime
     *
@@ -158,7 +158,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -171,7 +171,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -189,7 +189,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -202,7 +202,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the organizer
     *
@@ -220,7 +220,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the organizer
     *
@@ -233,9 +233,9 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["organizer"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the participants
      *
      * @return array|null The participants
@@ -248,11 +248,11 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the participants
     *
-    * @param \Beta\Microsoft\Graph\Model\IdentitySet $val The participants
+    * @param \Beta\Microsoft\Graph\Model\IdentitySet[] $val The participants
     *
     * @return CallRecord
     */
@@ -261,7 +261,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["participants"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the joinWebUrl
     *
@@ -275,7 +275,7 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the joinWebUrl
     *
@@ -288,9 +288,9 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["joinWebUrl"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the sessions
      *
      * @return array|null The sessions
@@ -303,11 +303,11 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the sessions
     *
-    * @param Session $val The sessions
+    * @param Session[] $val The sessions
     *
     * @return CallRecord
     */
@@ -316,9 +316,9 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["sessions"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the recipients
      *
      * @return array|null The recipients
@@ -331,11 +331,11 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the recipients
     *
-    * @param \Beta\Microsoft\Graph\Model\EntityType2 $val The recipients
+    * @param \Beta\Microsoft\Graph\Model\EntityType2[] $val The recipients
     *
     * @return CallRecord
     */
@@ -344,5 +344,5 @@ class CallRecord extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["recipients"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Photo.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Photo.php
@@ -41,7 +41,7 @@ class Photo extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -54,7 +54,7 @@ class Photo extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the option
     *
@@ -72,7 +72,7 @@ class Photo extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the option
     *
@@ -85,5 +85,5 @@ class Photo extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["option"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Segment.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Segment.php
@@ -41,7 +41,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -54,7 +54,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -72,7 +72,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -85,7 +85,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the caller
     *
@@ -103,7 +103,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the caller
     *
@@ -116,7 +116,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["caller"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the callee
     *
@@ -134,7 +134,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the callee
     *
@@ -147,7 +147,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["callee"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the failureInfo
     *
@@ -165,7 +165,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -178,9 +178,9 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the media
      *
      * @return array|null The media
@@ -193,11 +193,11 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the media
     *
-    * @param Media $val The media
+    * @param Media[] $val The media
     *
     * @return Segment
     */
@@ -206,9 +206,9 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["media"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the refTypes
      *
      * @return array|null The refTypes
@@ -221,11 +221,11 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the refTypes
     *
-    * @param \Beta\Microsoft\Graph\Model\EntityType3 $val The refTypes
+    * @param \Beta\Microsoft\Graph\Model\EntityType3[] $val The refTypes
     *
     * @return Segment
     */
@@ -234,7 +234,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["refTypes"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the refType
     *
@@ -252,7 +252,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the refType
     *
@@ -265,7 +265,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["refType"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the sessionRef
     *
@@ -283,7 +283,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the sessionRef
     *
@@ -296,7 +296,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["sessionRef"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the photo
     *
@@ -314,7 +314,7 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the photo
     *
@@ -327,5 +327,5 @@ class Segment extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["photo"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Session.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/Session.php
@@ -25,7 +25,7 @@ namespace Beta\Microsoft\Graph\CallRecords\Model;
 class Session extends \Beta\Microsoft\Graph\Model\Entity
 {
 
-     /** 
+     /**
      * Gets the modalities
      *
      * @return array|null The modalities
@@ -38,11 +38,11 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the modalities
     *
-    * @param Modality $val The modalities
+    * @param Modality[] $val The modalities
     *
     * @return Session
     */
@@ -51,7 +51,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["modalities"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the startDateTime
     *
@@ -69,7 +69,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the startDateTime
     *
@@ -82,7 +82,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["startDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the endDateTime
     *
@@ -100,7 +100,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the endDateTime
     *
@@ -113,7 +113,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["endDateTime"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the caller
     *
@@ -131,7 +131,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the caller
     *
@@ -144,7 +144,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["caller"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the callee
     *
@@ -162,7 +162,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the callee
     *
@@ -175,7 +175,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["callee"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the failureInfo
     *
@@ -193,7 +193,7 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the failureInfo
     *
@@ -206,9 +206,9 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["failureInfo"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the segments
      *
      * @return array|null The segments
@@ -221,11 +221,11 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the segments
     *
-    * @param Segment $val The segments
+    * @param Segment[] $val The segments
     *
     * @return Session
     */
@@ -234,5 +234,5 @@ class Session extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["segments"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/CallRecords/Model/SingletonEntity1.php
@@ -41,7 +41,7 @@ class SingletonEntity1 extends \Beta\Microsoft\Graph\Model\Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav
     *
@@ -54,5 +54,5 @@ class SingletonEntity1 extends \Beta\Microsoft\Graph\Model\Entity
         $this->_propDict["testSingleNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Call.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Call.php
@@ -37,7 +37,7 @@ class Call extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the subject
     *
@@ -50,5 +50,5 @@ class Call extends Entity
         $this->_propDict["subject"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/CloudCommunications.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/CloudCommunications.php
@@ -25,7 +25,7 @@ namespace Beta\Microsoft\Graph\Model;
 class CloudCommunications extends Entity
 {
 
-     /** 
+     /**
      * Gets the calls
      *
      * @return array|null The calls
@@ -38,11 +38,11 @@ class CloudCommunications extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the calls
     *
-    * @param Call $val The calls
+    * @param Call[] $val The calls
     *
     * @return CloudCommunications
     */
@@ -51,9 +51,9 @@ class CloudCommunications extends Entity
         $this->_propDict["calls"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the callRecords
      *
      * @return array|null The callRecords
@@ -66,11 +66,11 @@ class CloudCommunications extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the callRecords
     *
-    * @param \Beta\Microsoft\Graph\CallRecords\Model\CallRecord $val The callRecords
+    * @param \Beta\Microsoft\Graph\CallRecords\Model\CallRecord[] $val The callRecords
     *
     * @return CloudCommunications
     */
@@ -79,5 +79,5 @@ class CloudCommunications extends Entity
         $this->_propDict["callRecords"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Endpoint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Endpoint.php
@@ -37,7 +37,7 @@ class Endpoint extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the property1
     *
@@ -50,5 +50,5 @@ class Endpoint extends Entity
         $this->_propDict["property1"] = intval($val);
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -31,7 +31,7 @@ class Entity implements \JsonSerializable
     * @var array $_propDict
     */
     protected $_propDict;
-    
+
     /**
     * Construct a new Entity
     *
@@ -54,7 +54,7 @@ class Entity implements \JsonSerializable
     {
         return $this->_propDict;
     }
-    
+
     /**
     * Gets the id
     *
@@ -68,7 +68,7 @@ class Entity implements \JsonSerializable
             return null;
         }
     }
-    
+
     /**
     * Sets the id
     *
@@ -81,7 +81,7 @@ class Entity implements \JsonSerializable
         $this->_propDict["id"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the ODataType
     *
@@ -94,7 +94,7 @@ class Entity implements \JsonSerializable
         }
         return null;
     }
-    
+
     /**
     * Sets the ODataType
     *
@@ -107,7 +107,7 @@ class Entity implements \JsonSerializable
         $this->_propDict["@odata.type"] = $val;
         return $this;
     }
-    
+
     /**
     * Serializes the object by property array
     * Manually serialize DateTime into RFC3339 format

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -31,7 +31,7 @@ class GraphPrint implements \JsonSerializable
     * @var array $_propDict
     */
     protected $_propDict;
-    
+
     /**
     * Construct a new GraphPrint
     *
@@ -54,7 +54,7 @@ class GraphPrint implements \JsonSerializable
     {
         return $this->_propDict;
     }
-    
+
     /**
     * Gets the settings
     *
@@ -68,7 +68,7 @@ class GraphPrint implements \JsonSerializable
             return null;
         }
     }
-    
+
     /**
     * Sets the settings
     *
@@ -81,7 +81,7 @@ class GraphPrint implements \JsonSerializable
         $this->_propDict["settings"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the ODataType
     *
@@ -94,7 +94,7 @@ class GraphPrint implements \JsonSerializable
         }
         return null;
     }
-    
+
     /**
     * Sets the ODataType
     *
@@ -107,7 +107,7 @@ class GraphPrint implements \JsonSerializable
         $this->_propDict["@odata.type"] = $val;
         return $this;
     }
-    
+
     /**
     * Serializes the object by property array
     * Manually serialize DateTime into RFC3339 format

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/OnenotePage.php
@@ -44,7 +44,7 @@ class OnenotePage extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the content
     * The OneNotePage content.
@@ -60,5 +60,5 @@ class OnenotePage extends Entity
         $this->_propDict["content"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Schedule.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Schedule.php
@@ -37,7 +37,7 @@ class Schedule extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the enabled
     *
@@ -50,9 +50,9 @@ class Schedule extends Entity
         $this->_propDict["enabled"] = boolval($val);
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the timesOff
      *
      * @return array|null The timesOff
@@ -65,11 +65,11 @@ class Schedule extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the timesOff
     *
-    * @param TimeOff $val The timesOff
+    * @param TimeOff[] $val The timesOff
     *
     * @return Schedule
     */
@@ -78,9 +78,9 @@ class Schedule extends Entity
         $this->_propDict["timesOff"] = $val;
         return $this;
     }
-    
 
-     /** 
+
+     /**
      * Gets the timeOffRequests
      *
      * @return array|null The timeOffRequests
@@ -93,11 +93,11 @@ class Schedule extends Entity
             return null;
         }
     }
-    
-    /** 
+
+    /**
     * Sets the timeOffRequests
     *
-    * @param TimeOffRequest $val The timeOffRequests
+    * @param TimeOffRequest[] $val The timeOffRequests
     *
     * @return Schedule
     */
@@ -106,5 +106,5 @@ class Schedule extends Entity
         $this->_propDict["timeOffRequests"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity1.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity1.php
@@ -41,7 +41,7 @@ class SingletonEntity1 extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav
     *
@@ -54,5 +54,5 @@ class SingletonEntity1 extends Entity
         $this->_propDict["testSingleNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity2.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/SingletonEntity2.php
@@ -41,7 +41,7 @@ class SingletonEntity2 extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testSingleNav2
     *
@@ -54,5 +54,5 @@ class SingletonEntity2 extends Entity
         $this->_propDict["testSingleNav2"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestEntity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestEntity.php
@@ -41,7 +41,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testNav
     *
@@ -54,7 +54,7 @@ class TestEntity extends Entity
         $this->_propDict["testNav"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the testInvalidNav
     *
@@ -72,7 +72,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testInvalidNav
     *
@@ -85,7 +85,7 @@ class TestEntity extends Entity
         $this->_propDict["testInvalidNav"] = $val;
         return $this;
     }
-    
+
     /**
     * Gets the testExplicitNav
     *
@@ -103,7 +103,7 @@ class TestEntity extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the testExplicitNav
     *
@@ -116,5 +116,5 @@ class TestEntity extends Entity
         $this->_propDict["testExplicitNav"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
@@ -41,7 +41,7 @@ class TestType extends Entity
         }
         return null;
     }
-    
+
     /**
     * Sets the propertyAlpha
     *
@@ -54,5 +54,5 @@ class TestType extends Entity
         $this->_propDict["propertyAlpha"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOff.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOff.php
@@ -37,7 +37,7 @@ class TimeOff extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the name
     *
@@ -50,5 +50,5 @@ class TimeOff extends Entity
         $this->_propDict["name"] = $val;
         return $this;
     }
-    
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOffRequest.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TimeOffRequest.php
@@ -37,7 +37,7 @@ class TimeOffRequest extends Entity
             return null;
         }
     }
-    
+
     /**
     * Sets the name
     *
@@ -50,5 +50,5 @@ class TimeOffRequest extends Entity
         $this->_propDict["name"] = $val;
         return $this;
     }
-    
+
 }


### PR DESCRIPTION
## Summary

- Updates PHPDocs for Entity setters that expect a collection of objects
Note that this does NOT strongly type the function argument (which would be a breaking change). It only gives a developer the correct type hint from their IDE.
See **Generated Code Differences** for more

- Contains expected whitespace changes caused by editorConfig trimming trailing whitespaces from the T4 templates which are passed on to the generated code.

## Generated code differences

![image](https://user-images.githubusercontent.com/10958912/142180949-652eb48e-a347-4976-8cf2-51d233e21976.png)

## Links to issues or work items this PR addresses
Fixes https://github.com/microsoftgraph/msgraph-sdk-php/issues/708

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/642)