### PR TITLE
Fix an issue with missing OData types.

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -223,7 +223,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     public function set<#=propertyName.ToCheckedCase()#>($val)
     {
 <#
-    if (propertyTypeString == "\\DateTime") {
+    if (propertyTypeString == "\\DateTime" || propertyTypeString == "\\Microsoft\\Graph\\Core\\Models\\TimeOfDay" || propertyTypeString == "\\Microsoft\\Graph\\Core\\Models\\Date" ) {
 #>
         $this->_propDict["<#=camelCasePropertyName#>"] 
             = $val->format(\DateTime::ISO8601) . "Z";
@@ -286,7 +286,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {
-            if (is_a($val, "\DateTime")) {
+            if (get_class((object)$val) === "\DateTime")) {
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -67,11 +67,12 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 case "Int32":
                 case "Int64":
                     return "int";
+                case "Decimal":
                 case "Double":
                 case "Single":
                     return "float";
                 case "DateTimeOffset":
-                case "Date":
+                case "DateTime":
                     return "\\DateTime";
                 case "Duration":
                     return "\\DateInterval";
@@ -80,6 +81,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 case "Binary":
                 case "Stream":
                     return "\\GuzzleHttp\\Psr7\\Stream";
+                case "Date" or "TimeOfDay" or "Byte":
+                    return $"\\Microsoft\\Graph\\Core\\Models\\{@type.Name}";
                 default:
                     return @type.Name.ToUpperFirstChar();
             }
@@ -266,7 +269,6 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                     {
                         return $"\\{settings.Properties["php.namespacePrefix"]}\\Microsoft\\Graph\\Model\\Entity";
                     }
-
                     return "\\Microsoft\\Graph\\Model\\Entity";
             }
         }

--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 case "Single":
                     return "float";
                 case "DateTimeOffset":
-                case "DateTime":
                     return "\\DateTime";
                 case "Duration":
                     return "\\DateInterval";
@@ -81,7 +80,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 case "Binary":
                 case "Stream":
                     return "\\GuzzleHttp\\Psr7\\Stream";
-                case "Date" or "TimeOfDay" or "Byte":
+                case "Date":
+                case "TimeOfDay":
+                case "Byte":
                     return $"\\Microsoft\\Graph\\Core\\Models\\{@type.Name}";
                 default:
                     return @type.Name.ToUpperFirstChar();

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -118,7 +118,7 @@ class Entity implements \JsonSerializable
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {
-            if (is_a($val, "\DateTime")) {
+            if (get_class((object)$val) === "\DateTime")) {
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -118,7 +118,7 @@ class GraphPrint implements \JsonSerializable
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {
-            if (is_a($val, "\DateTime")) {
+            if (get_class((object)$val) === "\DateTime")) {
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -118,7 +118,7 @@ class Entity implements \JsonSerializable
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {
-            if (is_a($val, "\DateTime")) {
+            if (get_class((object)$val) === "\DateTime")) {
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -118,7 +118,7 @@ class GraphPrint implements \JsonSerializable
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {
-            if (is_a($val, "\DateTime")) {
+            if (get_class((object)$val) === "\DateTime")) {
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();


### PR DESCRIPTION
## Summary
This PR replaces references for missing Odata types with Custom types on the [microsoft-graph-php-core](https://github.com/microsoftgraph/microsoft-graph-php-core) repo
## Generated code differences

See [#712](https://github.com/microsoftgraph/msgraph-sdk-php/pull/712) for detailed diff.

## Command line arguments to run these changes

N/A

## Links to issues or work items this PR addresses
Fixes #524 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/644)