### PR TITLE
- switches api doctor module reference to upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = master
 [submodule "apidoctor"]
 	path = apidoctor
-	url = https://github.com/microsoftgraph/apidoctor.git
+	url = https://github.com/OneDrive/apidoctor.git
 	branch = master


### PR DESCRIPTION
## Summary

This PR switches the submodule reference from our fork under microsoftgraph to the upstream in OneDrive in an effort to avoid code duplication and confusion.

If you have this repo cloned locally, you'll need to update the submodule after pulling those changes:

```shell
git submodule deinit apidoctor
rm -r .\.git\modules\apidoctor\ -Force
git submodule init apidoctor
git submodule update --remote --merge
```

## Generated code differences

No impact on code generation.

## Links to issues or work items this PR addresses

Related
https://github.com/OneDrive/apidoctor/pull/102
https://github.com/microsoftgraph/apidoctor/pull/34

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/646)