### PR TITLE
Fix pipeline paths after dotnet 6 update

### DIFF
--- a/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
@@ -16,7 +16,7 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/src/Typewriter/bin/$(BuildConfiguration)/net5.0'
+    sourceFolder: '$(Build.SourcesDirectory)/src/Typewriter/bin/$(BuildConfiguration)/net6.0'
     contents: '**/*'
     targetFolder: '$(Build.ArtifactStagingDirectory)'
   displayName: Copy Typewriter executable

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,16 +30,16 @@ jobs:
       if: ${{ failure() }}
       with:
         name: languages-test-output
-        path: 'test/Typewriter.Test/bin/Debug/net5.0/OutputDirectory*/**'
+        path: 'test/Typewriter.Test/bin/Debug/net6.0/OutputDirectory*/**'
     - name: Upload unit test output on failure
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: unit-test-output
-        path: test/Typewriter.Test/bin/Debug/net5.0/output/
+        path: test/Typewriter.Test/bin/Debug/net6.0/output/
     - name: Upload unit test java output on failure
       uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: unit-test-output-java
-        path: test/Typewriter.Test/bin/Debug/net5.0/outputJava/
+        path: test/Typewriter.Test/bin/Debug/net6.0/outputJava/


### PR DESCRIPTION
This PR is part of the work from https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/672

It fixes some paths left out in the pipelines that are broken after the upgrade to net6.0 in the typewriter project.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/676)