### PR TITLE
updates dotnet cli tasks

### DIFF
--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -5,7 +5,7 @@ steps:
   displayName: checkout kiota
   fetchDepth: 1
 
-- pwsh: dotnet build --project $(Build.SourcesDirectory)/src/kiota/kiota.csproj --configuration $(buildConfiguration)
+- pwsh: dotnet build $(Build.SourcesDirectory)/src/kiota/kiota.csproj --configuration $(buildConfiguration)
   displayName: 'Build Kiota'
 
 - task: CopyFiles@2

--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -5,12 +5,8 @@ steps:
   displayName: checkout kiota
   fetchDepth: 1
 
-- task: DotNetCoreCLI@2
+- pwsh: dotnet build --project $(Build.SourcesDirectory)/src/kiota/kiota.csproj --configuration $(buildConfiguration)
   displayName: 'Build Kiota'
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)/src/kiota/kiota.csproj'
-    arguments: '--configuration $(buildConfiguration)'
 
 - task: CopyFiles@2
   inputs:

--- a/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
@@ -7,7 +7,7 @@ steps:
   submodules: recursive
   persistCredentials: true
 
-- pwsh: dotnet build --project $(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj --configuration $(buildConfiguration)
+- pwsh: dotnet build $(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj --configuration $(buildConfiguration)
   displayName: 'Build Typewriter'
 
 - task: CopyFiles@2

--- a/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
@@ -7,12 +7,8 @@ steps:
   submodules: recursive
   persistCredentials: true
 
-- task: DotNetCoreCLI@2
+- pwsh: dotnet build --project $(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj --configuration $(buildConfiguration)
   displayName: 'Build Typewriter'
-  inputs:
-    command: 'build'
-    projects: '$(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj'
-    arguments: '--configuration $(buildConfiguration)'
 
 - task: CopyFiles@2
   inputs:

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -116,16 +116,10 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
-- pwsh: '$(scriptsDirectory)/copy-dotnet-models.ps1'
-  displayName: update ${{ parameters.endpoint }} .NET models
-  env:
-    BuildConfiguration: $(buildConfiguration)
-    OutputFullPath: $(typewriterDirectory)/output
-    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
-
-# Smoke test that the generated files build for .NET
-- pwsh: dotnet build ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
-  displayName: smoke test - build dll for ${{ parameters.endpoint }}
+- template: dotnet.yml
+  parameters:
+    repoName: msgraph-sdk-dotnet
+    dllName: Microsoft.Graph.dll
 
 # Checkin clean metadata into metadata repo or make it an artifact.
 - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -97,11 +97,7 @@ steps:
 - template: use-dotnet-sdk.yml
 
 # verify that generated metadata is parsable as an Edm model
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'run'
-    projects: $(Build.SourcesDirectory)/msgraph-metadata/tools/MetadataParser/MetadataParser.csproj
-    arguments: ${{ parameters.cleanMetadataFile }}
+- pwsh: dotnet run --project $(Build.SourcesDirectory)/msgraph-metadata/tools/MetadataParser/MetadataParser.csproj -- ${{ parameters.cleanMetadataFile }}
   displayName: 'verify whether metadata is parsable as an Edm model'
 
 - pwsh: '$(scriptsDirectory)/run-typewriter.ps1'
@@ -128,12 +124,8 @@ steps:
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
 # Smoke test that the generated files build for .NET
-- task: DotNetCoreCLI@2
+- pwsh: dotnet build --project ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
   displayName: smoke test - build dll for ${{ parameters.endpoint }}
-  inputs:
-    command: 'build'
-    projects: ${{ parameters.repoName }}/**/*.csproj
-    arguments: '--configuration $(buildConfiguration)'
 
 # Checkin clean metadata into metadata repo or make it an artifact.
 - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -124,7 +124,7 @@ steps:
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
 # Smoke test that the generated files build for .NET
-- pwsh: dotnet build --project ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
+- pwsh: dotnet build ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
   displayName: smoke test - build dll for ${{ parameters.endpoint }}
 
 # Checkin clean metadata into metadata repo or make it an artifact.

--- a/.azure-pipelines/generation-templates/dotnet.yml
+++ b/.azure-pipelines/generation-templates/dotnet.yml
@@ -13,9 +13,5 @@ steps:
     OutputFullPath: $(typewriterDirectory)/output
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
-- task: DotNetCoreCLI@2
+- pwsh: dotnet build --project ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
   displayName: Build ${{ parameters.dllName }}
-  inputs:
-    command: 'build'
-    projects: ${{ parameters.repoName }}/**/*.csproj
-    arguments: '--configuration $(buildConfiguration)'

--- a/.azure-pipelines/generation-templates/dotnet.yml
+++ b/.azure-pipelines/generation-templates/dotnet.yml
@@ -7,11 +7,11 @@ parameters:
 
 steps:
 - pwsh: '$(scriptsDirectory)/copy-dotnet-models.ps1'
-  displayName: 'Update models'
+  displayName: 'Update .NET models - ${{ parameters.repoName }}'
   env:
     BuildConfiguration: $(buildConfiguration)
     OutputFullPath: $(typewriterDirectory)/output
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
-- pwsh: dotnet build ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
-  displayName: Build ${{ parameters.dllName }}
+- pwsh: dotnet build ${{ parameters.repoName }}/src/Microsoft.Graph/Microsoft.Graph.csproj --configuration $(buildConfiguration)
+  displayName: smoke test - build dll for ${{ parameters.dllName }}

--- a/.azure-pipelines/generation-templates/dotnet.yml
+++ b/.azure-pipelines/generation-templates/dotnet.yml
@@ -13,5 +13,5 @@ steps:
     OutputFullPath: $(typewriterDirectory)/output
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
-- pwsh: dotnet build --project ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
+- pwsh: dotnet build ${{ parameters.repoName }}/**/*.csproj --configuration $(buildConfiguration)
   displayName: Build ${{ parameters.dllName }}


### PR DESCRIPTION
All the dotnet cli tasks output these two messages during execution.

```
Info: .NET Core SDK/runtime 2.2 and 3.0 are now End of Life(EOL) and have been removed from all hosted agents. If you're using these SDK/runtimes on hosted agents, kindly upgrade to newer versions which are not EOL, or else use UseDotNet task to install the required version.
```

```
Info: Azure Pipelines hosted agents have been updated and now contain .Net 5.x SDK/Runtime along with the older .Net Core version which are currently lts. Unless you have locked down a SDK version for your project(s), 5.x SDK might be picked up which might have breaking behavior as compared to previous versions. You can learn more about the breaking changes here: https://docs.microsoft.com/en-us/dotnet/core/tools/ and https://docs.microsoft.com/en-us/dotnet/core/compatibility/ . To learn about more such changes and troubleshoot, refer here: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops#troubleshooting
```

It seems the task is locked to 3.0 for compatibility reasons, and our projects are now on dotnet 6.

This PR replaces dotnet CLI tasks with straight calls to the dotnet CLI (which will use the latest installed version) to make sure things are aligned and we don't get any undesired behaviour.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/678)