### PR TITLE
Allow stream upload to override content type

### DIFF
--- a/Templates/templates/CSharp/Requests/StreamRequest.cs.tt
+++ b/Templates/templates/CSharp/Requests/StreamRequest.cs.tt
@@ -103,7 +103,7 @@ namespace <#=@namespace#>
         /// <returns>The object returned by the PUT call.</returns>
         public System.Threading.Tasks.Task<T> PutAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>
         {
-            this.ContentType = <#=templateWriter.StreamContentType#>;
+            this.ContentType ??= <#=templateWriter.StreamContentType#>;
             this.Method = <#=templateWriter.PutMethod#>;
             return this.SendAsync<T>(<#=propName#>, cancellationToken, completionOption);
         }
@@ -118,7 +118,7 @@ namespace <#=@namespace#>
         /// <returns>The <see cref="GraphResponse"/> object returned by the PUT call.</returns>
         public System.Threading.Tasks.Task<GraphResponse<T>> PutResponseAsync<T>(Stream <#=propName#>, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead) where T : <#=propClass#>
         {
-            this.ContentType = <#=templateWriter.StreamContentType#>;
+            this.ContentType ??= <#=templateWriter.StreamContentType#>;
             this.Method = <#=templateWriter.PutMethod#>;
             return this.SendAsyncWithGraphResponse<T>(<#=propName#>, cancellationToken, completionOption);
         }
@@ -137,7 +137,7 @@ namespace <#=@namespace#>
         /// <returns>The updated stream.</returns>
         public System.Threading.Tasks.Task<Stream> PutAsync(Stream <#=propName#>, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
-            this.ContentType = <#=templateWriter.StreamContentType#>;
+            this.ContentType ??= <#=templateWriter.StreamContentType#>;
             this.Method = <#=templateWriter.PutMethod#>;
             return this.SendStreamRequestAsync(<#=propName#>, cancellationToken, completionOption);
         }
@@ -151,7 +151,7 @@ namespace <#=@namespace#>
         /// <returns>The <see cref="GraphResponse"/> object returned by the PUT call.</returns>
         public System.Threading.Tasks.Task<GraphResponse> PutResponseAsync(Stream <#=propName#>, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
-            this.ContentType = <#=templateWriter.StreamContentType#>;
+            this.ContentType ??= <#=templateWriter.StreamContentType#>;
             this.Method = <#=templateWriter.PutMethod#>;
             return this.SendAsyncWithGraphResponse(<#=propName#>, cancellationToken, completionOption);
         }


### PR DESCRIPTION
## Summary

Fixes an [issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1274)in C# SDK where logos cannot be uploaded since content type cannot be set.

## Generated code differences

E.g. [this file](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/ae32b5fda8bc456df7a56c0052008e60056fd190/src/Microsoft.Graph/Generated/requests/ApplicationLogoRequest.cs#L70):
```
this.ContentType = CoreConstants.MimeTypeNames.Application.Stream;
```
is changed to:
```
this.ContentType ??= CoreConstants.MimeTypeNames.Application.Stream;
```

## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1274