### PR TITLE
Rename target client

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -301,7 +301,7 @@ stages:
         repoName: 'msgraph-sdk-dotnet'
         baseBranchName : 'feature/5.0'
         branchName: 'kiota/$(v1Branch)'
-        targetClassName: "GraphServiceClient"
+        targetClassName: "BaseGraphServiceClient"
         targetNamespace: "MicrosoftGraphSdk"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
@@ -329,7 +329,7 @@ stages:
         repoName: 'msgraph-beta-sdk-dotnet'
         baseBranchName : 'feature/5.0'
         branchName: 'kiota/$(betaBranch)'
-        targetClassName: "GraphServiceClient"
+        targetClassName: "BaseGraphServiceClient"
         targetNamespace: "MicrosoftGraphSdk"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:


### PR DESCRIPTION
This PR renames the target kiota generated client to `BaseGraphServiceClient` for extensibility reasons

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/707)