### PR TITLE
Fix/delete typescript src recursive

### DIFF
--- a/scripts/clean-typescript-files.ps1
+++ b/scripts/clean-typescript-files.ps1
@@ -1,5 +1,23 @@
+function Delete-Folder-Recursive {
+    param (
+        $FolderName
+    )
 
-Rename-Item $env:MainDirectory "lib"
-New-Item $env:MainDirectory -ItemType Directory
+    $directories = Get-ChildItem -Path $FolderName -Directory
+    foreach ($directory in $directories) {
+    	Delete-Folder-Recursive $directory.FullName
+        Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
+    }
+
+    Write-Host "Deleting folder: $FolderName"
+}
+
+Delete-Folder-Recursive $env:MainDirectory
+
+$files = Get-ChildItem -Path $env:MainDirectory -File  -Filter "*.ts"
+foreach ($file in $files) {
+  Remove-Item -Path $file.FullName -Force
+}
+
 
 Write-Host "Removed the existing generated files in the repo's main directory: $env:MainDirectory" -ForegroundColor Green

--- a/scripts/clean-typescript-files.ps1
+++ b/scripts/clean-typescript-files.ps1
@@ -1,18 +1,7 @@
-function Delete-Folder-Recursive {
-    param (
-        $FolderName
-    )
-
-    $directories = Get-ChildItem -Path $FolderName -Directory
-    foreach ($directory in $directories) {
-    	Delete-Folder-Recursive $directory.FullName
-        Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
-    }
-
-    Write-Host "Deleting folder: $FolderName"
+$directories = Get-ChildItem -Path $env:MainDirectory  -Directory 
+foreach ($directory in $directories) {
+	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
 }
-
-Delete-Folder-Recursive $env:MainDirectory
 
 $files = Get-ChildItem -Path $env:MainDirectory -File  -Filter "*.ts"
 foreach ($file in $files) {

--- a/scripts/clean-typescript-files.ps1
+++ b/scripts/clean-typescript-files.ps1
@@ -1,6 +1,5 @@
-$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Filter *src*
-foreach ($directory in $directories) {
-	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
-}
+
+Rename-Item $env:MainDirectory "lib"
+New-Item $env:MainDirectory -ItemType Directory
 
 Write-Host "Removed the existing generated files in the repo's main directory: $env:MainDirectory" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Resolves issue deleting folders with depth > 2  in typescript `src` folder during code generation

## Generated code differences

```powershell
$directories = Get-ChildItem -Path $env:MainDirectory  -Directory 
foreach ($directory in $directories) {
	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
}

$files = Get-ChildItem -Path $env:MainDirectory -File  -Filter "*.ts"
foreach ($file in $files) {
  Remove-Item -Path $file.FullName -Force
}


Write-Host "Removed the existing generated files in the repo's main directory: $env:MainDirectory" -ForegroundColor Green
```

## Links to issues or work items this PR addresses
Res Run : https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=70873&view=logs&j=b56651c9-d0cc-5029-fad3-f9889cfa9c40&t=5a06b1a5-495c-591f-8543-a2257866fb3c

Test Run Log https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_apis/build/builds/70989/logs/81
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/709)