### PR TITLE
[Dotnet] Remove package authentication

### DIFF
--- a/.azure-pipelines/generation-templates/dotnet-kiota.yml
+++ b/.azure-pipelines/generation-templates/dotnet-kiota.yml
@@ -10,11 +10,7 @@ steps:
     OutputFullPath: $(kiotaDirectory)/output/*
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
-- task: NuGetAuthenticate@0
-  inputs:
-    nuGetServiceConnections: 'ReadKiotaGithubPackages,ReadGithubPackages'
-
-- pwsh: 'dotnet restore --configfile Nuget.Config'
+- pwsh: 'dotnet restore'
   displayName: Restore dependencies for ${{ parameters.repoName }}
   workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}
 


### PR DESCRIPTION
This PR removes package authentication steps in the Kiota dotnet generation.

This is no longer needed as the packages are now public and causes the build to fail due to changed project structure to reflect this. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/713)