### PR TITLE
Changes target namespace

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -302,7 +302,7 @@ stages:
         baseBranchName : 'feature/5.0'
         branchName: 'kiota/$(v1Branch)'
         targetClassName: "BaseGraphServiceClient"
-        targetNamespace: "MicrosoftGraphSdk"
+        targetNamespace: "Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
         - template: generation-templates/dotnet-kiota.yml
@@ -330,7 +330,7 @@ stages:
         baseBranchName : 'feature/5.0'
         branchName: 'kiota/$(betaBranch)'
         targetClassName: "BaseGraphServiceClient"
-        targetNamespace: "MicrosoftGraphSdk"
+        targetNamespace: "Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/dotnet-kiota.yml


### PR DESCRIPTION
This PR changes the target namespace to `Microsoft.Graph` after fix applied in https://github.com/microsoft/kiota/pull/1489 

Generation run can be viewed at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=71662&view=results
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/717)