### PR TITLE
Exclude TS files in folder graphclient from deletion

### DIFF
--- a/scripts/clean-typescript-files.ps1
+++ b/scripts/clean-typescript-files.ps1
@@ -1,4 +1,4 @@
-$directories = Get-ChildItem -Path $env:MainDirectory  -Directory 
+$directories = Get-ChildItem -Path $env:MainDirectory  -Directory -Exclude @("graphclient")
 foreach ($directory in $directories) {
 	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
 }


### PR DESCRIPTION
## Summary

Exclude manually edited files for TS in directory `src\graphclient` from deletion

Resolves https://github.com/microsoftgraph/msgraph-sdk-typescript/issues/33

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/725)