### PR TITLE
Use full name for lookup of reference types

### DIFF
--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -92,7 +92,9 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             var referenceEntityTypes = new List<OdcmClass>();
             foreach (var referencePropertyType in referencePropertyTypes)
             {
-                var entityType = entityTypes.FirstOrDefault(entity => entity.Name == referencePropertyType.Name);
+                // use the FullName to match the types as there could be multiple types of the same name but in different namespaces
+                // e.g microsoft.graph.group and microsoft.graph.termstore.group
+                var entityType = entityTypes.FirstOrDefault(entity => entity.FullName == referencePropertyType.FullName);
 
                 if (entityType != null)
                 {


### PR DESCRIPTION
This PR closes #735 

Generation failure was caused by the existence of multiple types with the same name across multiple namespaces (`microsoft.graph.ediscovery.datasource` and `microsoft.graph.security.datasource`). 
Due to the current lookup only using the name, some request builders would fail to generate as the type found during the lookup was always the first type in the list and would thus not generate the request builders for the second item with a similar name.

This PR therefore updates the lookup to use the full name to ensure the type found is the expected type.

Generation run  :
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=73776&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/736)