### PR TITLE
[Dotnet] Remove abstract modifier for complex types

### DIFF
--- a/Templates/templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/templates/CSharp/Model/ComplexType.cs.tt
@@ -28,7 +28,6 @@ if (complex.Base != null)
 }
 
 var isMethodResponse = complex.LongDescriptionContains("methodResponse");
-var classType = complex.IsAbstract ? "abstract partial class" : "partial class";
 
 var attributeStringBuilder = new StringBuilder();
 
@@ -70,10 +69,23 @@ if (attributeStringBuilder.Length > 0) {
 #>
     <#=attributeStringBuilder.ToString()#>
 <# } #>
-    public <#=classType#> <#=typeDeclaration#>
+    public partial class <#=typeDeclaration#>
     {
 <#
-        if (!complex.IsAbstract && isBaseTypeReferenced)
+        if (complex.IsAbstract)
+        {
+    #>
+
+        ///<summary>
+        /// The internal <#=complexTypeName#> constructor
+        ///</summary>
+        protected internal <#=cstorTypeDeclaration#>()
+        {
+            // Don't allow initialization of abstract complex types
+        }
+<#
+        }
+        else if (isBaseTypeReferenced)
         {
 #>        /// <summary>
         /// Initializes a new instance of the <see cref="<#=cstorTypeDeclaration#>"/> class.

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -370,14 +370,20 @@ namespace Typewriter.Test
 
             IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
             bool hasTestString = false;
-            string testString = "public abstract partial class EmptyBaseComplexTypeRequestObject";
+            string testString = "public partial class EmptyBaseComplexTypeRequestObject";
+            string constructorString = "protected internal EmptyBaseComplexTypeRequestObject";
 
             foreach (var line in lines)
             {
                 if (line.Contains(testString))
                 {
                     hasTestString = true;
-                    break;
+                    continue;
+                }
+                if (line.Contains(constructorString))
+                {
+                    hasTestString = true;
+                    continue;
                 }
             }
 

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyBaseComplexTypeRequest.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyBaseComplexTypeRequest.cs
@@ -19,8 +19,16 @@ namespace Microsoft.Graph
     /// </summary>
     [Obsolete("emptyBaseComplexTypeRequest is deprecated. Please use emptyBaseComplexTypeRequest2.")]
     [JsonConverter(typeof(DerivedTypeConverter<EmptyBaseComplexTypeRequestObject>))]
-    public abstract partial class EmptyBaseComplexTypeRequestObject
+    public partial class EmptyBaseComplexTypeRequestObject
     {
+
+        ///<summary>
+        /// The internal EmptyBaseComplexTypeRequest constructor
+        ///</summary>
+        protected internal EmptyBaseComplexTypeRequestObject()
+        {
+            // Don't allow initialization of abstract complex types
+        }
 
         /// <summary>
         /// Gets or sets additional data.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyComplexType.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyComplexType.cs
@@ -18,8 +18,16 @@ namespace Microsoft.Graph
     /// The type EmptyComplexType.
     /// </summary>
     [JsonConverter(typeof(DerivedTypeConverter<EmptyComplexType>))]
-    public abstract partial class EmptyComplexType
+    public partial class EmptyComplexType
     {
+
+        ///<summary>
+        /// The internal EmptyComplexType constructor
+        ///</summary>
+        protected internal EmptyComplexType()
+        {
+            // Don't allow initialization of abstract complex types
+        }
 
         /// <summary>
         /// Gets or sets additional data.

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyComplexTypeWithBaseType.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/EmptyComplexTypeWithBaseType.cs
@@ -18,8 +18,16 @@ namespace Microsoft.Graph
     /// The type EmptyComplexTypeWithBaseType.
     /// </summary>
     [JsonConverter(typeof(DerivedTypeConverter<EmptyComplexTypeWithBaseType>))]
-    public abstract partial class EmptyComplexTypeWithBaseType : Entity
+    public partial class EmptyComplexTypeWithBaseType : Entity
     {
+
+        ///<summary>
+        /// The internal EmptyComplexTypeWithBaseType constructor
+        ///</summary>
+        protected internal EmptyComplexTypeWithBaseType()
+        {
+            // Don't allow initialization of abstract complex types
+        }
 
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/UserAgent.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/model/UserAgent.cs
@@ -18,8 +18,16 @@ namespace Microsoft.Graph2.CallRecords
     /// The type UserAgent.
     /// </summary>
     [JsonConverter(typeof(Microsoft.Graph.DerivedTypeConverter<UserAgent>))]
-    public abstract partial class UserAgent
+    public partial class UserAgent
     {
+
+        ///<summary>
+        /// The internal UserAgent constructor
+        ///</summary>
+        protected internal UserAgent()
+        {
+            // Don't allow initialization of abstract complex types
+        }
 
         /// <summary>
         /// Gets or sets headerValue.


### PR DESCRIPTION
This PR is part of https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1328

It updates the Typewriter generator to behave consistently for both complex and abstract types by removing the abstract modifier on complex types.

This therefore unblocks instances where new derived types of abstract complex types are added to the metadata leading to the throwing of an exception. 

With this change, the derivedTypeConverter should be able to instantiate and return an instance of the base complex type in the event the user has not updated to a version where the derived type is not present in the metadata.

Generation PRs
V1 - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1340
Beta - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/pull/443

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/740)