### PR TITLE
Fix wrong Security namespace in PHP models

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/PHP/TypeHelperPHP.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
             }
         }
 
+        private static readonly HashSet<string> ReservedNamespaces =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Microsoft.Graph.Security"
+            };
+
         private static readonly ICollection<string> SimpleTypes =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -209,7 +215,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.PHP
                 namespacePrefix = settings.Properties["php.namespacePrefix"];
             }
 
-            var @namespace = currentType.Namespace.Name;
+            var @namespace = ReservedNamespaces.Contains(currentType.Namespace.Name) ? $"{currentType.Namespace.Name}Namespace" : currentType.Namespace.Name;
             if (@namespace.Equals("edm", StringComparison.OrdinalIgnoreCase))
             {
                 // for edm types that we generate for (e.g. TimeOfDay)

--- a/test/Typewriter.Test/Metadata/MetadataWithSubNamespaces.xml
+++ b/test/Typewriter.Test/Metadata/MetadataWithSubNamespaces.xml
@@ -295,5 +295,14 @@
                 <ReturnType Type="microsoft.graph.callRecords.callRecord" />
             </Function>
         </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph.security">
+            <EnumType Name="alertClassification" UnderlyingType="Edm.Byte">
+                <Member Name="unknown" Value="0"/>
+                <Member Name="falsePositive" Value="10"/>
+                <Member Name="truePositive" Value="20"/>
+                <Member Name="informationalExpectedActivity" Value="30"/>
+                <Member Name="unknownFutureValue" Value="39"/>
+            </EnumType>
+        </Schema>
     </edmx:DataServices>
 </edmx:Edmx>

--- a/test/Typewriter.Test/TestDataObjC/Models/MSGraphClientModels.h
+++ b/test/Typewriter.Test/TestDataObjC/Models/MSGraphClientModels.h
@@ -17,6 +17,7 @@
 #import "MSGraphCallRecordsWifiBand.h"
 #import "MSGraphCallRecordsWifiRadioType.h"
 #import "MSGraphCallRecordsModality.h"
+#import "MSGraphSecurityAlertClassification.h"
 #import "MSGraphEmptyBaseComplexTypeRequest.h"
 #import "MSGraphDerivedComplexTypeRequest.h"
 #import "MSGraphResponseObject.h"

--- a/test/Typewriter.Test/TestDataObjC/Models/MSGraphSecurityNamespaceAlertClassification.h
+++ b/test/Typewriter.Test/TestDataObjC/Models/MSGraphSecurityNamespaceAlertClassification.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+
+
+#include <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, MSGraphSecurityAlertClassificationValue){
+
+	MSGraphSecurityAlertClassificationUnknown = 0,
+	MSGraphSecurityAlertClassificationFalsePositive = 10,
+	MSGraphSecurityAlertClassificationTruePositive = 20,
+	MSGraphSecurityAlertClassificationInformationalExpectedActivity = 30,
+	MSGraphSecurityAlertClassificationUnknownFutureValue = 39,
+    MSGraphSecurityAlertClassificationEndOfEnum
+};
+
+@interface MSGraphSecurityAlertClassification : NSObject
+
++(MSGraphSecurityAlertClassification*) unknown;
++(MSGraphSecurityAlertClassification*) falsePositive;
++(MSGraphSecurityAlertClassification*) truePositive;
++(MSGraphSecurityAlertClassification*) informationalExpectedActivity;
++(MSGraphSecurityAlertClassification*) unknownFutureValue;
+
++(MSGraphSecurityAlertClassification*) UnknownEnumValue;
+
++(MSGraphSecurityAlertClassification*) alertClassificationWithEnumValue:(MSGraphSecurityAlertClassificationValue)val;
+-(NSString*) ms_toString;
+
+@property (nonatomic, readonly) MSGraphSecurityAlertClassificationValue enumValue;
+
+@end
+
+
+@interface NSString (MSGraphSecurityAlertClassification)
+
+- (MSGraphSecurityAlertClassification*) toMSGraphSecurityAlertClassification;
+
+@end

--- a/test/Typewriter.Test/TestDataObjC/Models/MSGraphSecurityNamespaceAlertClassification.m
+++ b/test/Typewriter.Test/TestDataObjC/Models/MSGraphSecurityNamespaceAlertClassification.m
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+
+
+
+#import "MSGraphSecurityAlertClassification.h"
+
+@interface MSGraphSecurityAlertClassification () {
+    MSGraphSecurityAlertClassificationValue _enumValue;
+}
+@property (nonatomic, readwrite) MSGraphSecurityAlertClassificationValue enumValue;
+@end
+
+@implementation MSGraphSecurityAlertClassification
+
++ (MSGraphSecurityAlertClassification*) unknown {
+    static MSGraphSecurityAlertClassification *_unknown;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _unknown = [[MSGraphSecurityAlertClassification alloc] init];
+        _unknown.enumValue = MSGraphSecurityAlertClassificationUnknown;
+    });
+    return _unknown;
+}
++ (MSGraphSecurityAlertClassification*) falsePositive {
+    static MSGraphSecurityAlertClassification *_falsePositive;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _falsePositive = [[MSGraphSecurityAlertClassification alloc] init];
+        _falsePositive.enumValue = MSGraphSecurityAlertClassificationFalsePositive;
+    });
+    return _falsePositive;
+}
++ (MSGraphSecurityAlertClassification*) truePositive {
+    static MSGraphSecurityAlertClassification *_truePositive;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _truePositive = [[MSGraphSecurityAlertClassification alloc] init];
+        _truePositive.enumValue = MSGraphSecurityAlertClassificationTruePositive;
+    });
+    return _truePositive;
+}
++ (MSGraphSecurityAlertClassification*) informationalExpectedActivity {
+    static MSGraphSecurityAlertClassification *_informationalExpectedActivity;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _informationalExpectedActivity = [[MSGraphSecurityAlertClassification alloc] init];
+        _informationalExpectedActivity.enumValue = MSGraphSecurityAlertClassificationInformationalExpectedActivity;
+    });
+    return _informationalExpectedActivity;
+}
++ (MSGraphSecurityAlertClassification*) unknownFutureValue {
+    static MSGraphSecurityAlertClassification *_unknownFutureValue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _unknownFutureValue = [[MSGraphSecurityAlertClassification alloc] init];
+        _unknownFutureValue.enumValue = MSGraphSecurityAlertClassificationUnknownFutureValue;
+    });
+    return _unknownFutureValue;
+}
+
++ (MSGraphSecurityAlertClassification*) UnknownEnumValue {
+    static MSGraphSecurityAlertClassification *_unknownValue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _unknownValue = [[MSGraphSecurityAlertClassification alloc] init];
+        _unknownValue.enumValue = MSGraphSecurityAlertClassificationEndOfEnum;
+    });
+    return _unknownValue;
+}
+
+
++ (MSGraphSecurityAlertClassification*) alertClassificationWithEnumValue:(MSGraphSecurityAlertClassificationValue)val {
+
+    switch(val)
+    {
+        case MSGraphSecurityAlertClassificationUnknown:
+            return [MSGraphSecurityAlertClassification unknown];
+        case MSGraphSecurityAlertClassificationFalsePositive:
+            return [MSGraphSecurityAlertClassification falsePositive];
+        case MSGraphSecurityAlertClassificationTruePositive:
+            return [MSGraphSecurityAlertClassification truePositive];
+        case MSGraphSecurityAlertClassificationInformationalExpectedActivity:
+            return [MSGraphSecurityAlertClassification informationalExpectedActivity];
+        case MSGraphSecurityAlertClassificationUnknownFutureValue:
+            return [MSGraphSecurityAlertClassification unknownFutureValue];
+        case MSGraphSecurityAlertClassificationEndOfEnum:
+        default:
+            return [MSGraphSecurityAlertClassification UnknownEnumValue];
+    }
+
+    return nil;
+}
+
+- (NSString*) ms_toString {
+
+    switch(self.enumValue)
+    {
+        case MSGraphSecurityAlertClassificationUnknown:
+            return @"unknown";
+        case MSGraphSecurityAlertClassificationFalsePositive:
+            return @"falsePositive";
+        case MSGraphSecurityAlertClassificationTruePositive:
+            return @"truePositive";
+        case MSGraphSecurityAlertClassificationInformationalExpectedActivity:
+            return @"informationalExpectedActivity";
+        case MSGraphSecurityAlertClassificationUnknownFutureValue:
+            return @"unknownFutureValue";
+        case MSGraphSecurityAlertClassificationEndOfEnum:
+        default:
+            return nil;
+    }
+
+    return nil;
+}
+
+- (MSGraphSecurityAlertClassificationValue) enumValue {
+    return _enumValue;
+}
+
+@end
+
+@implementation NSString (MSGraphSecurityAlertClassification)
+
+- (MSGraphSecurityAlertClassification*) toMSGraphSecurityAlertClassification{
+
+    if([self isEqualToString:@"unknown"])
+    {
+          return [MSGraphSecurityAlertClassification unknown];
+    }
+    else if([self isEqualToString:@"falsePositive"])
+    {
+          return [MSGraphSecurityAlertClassification falsePositive];
+    }
+    else if([self isEqualToString:@"truePositive"])
+    {
+          return [MSGraphSecurityAlertClassification truePositive];
+    }
+    else if([self isEqualToString:@"informationalExpectedActivity"])
+    {
+          return [MSGraphSecurityAlertClassification informationalExpectedActivity];
+    }
+    else if([self isEqualToString:@"unknownFutureValue"])
+    {
+          return [MSGraphSecurityAlertClassification unknownFutureValue];
+    }
+    else {
+        return [MSGraphSecurityAlertClassification UnknownEnumValue];
+    }
+}
+
+@end

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/SecurityNamespace/Model/AlertClassification.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/SecurityNamespace/Model/AlertClassification.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* AlertClassification File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright (c) Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Microsoft\Graph\SecurityNamespace\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* AlertClassification class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright (c) Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class AlertClassification extends Enum
+{
+    /**
+    * The Enum AlertClassification
+    */
+    const UNKNOWN = "unknown";
+    const FALSE_POSITIVE = "falsePositive";
+    const TRUE_POSITIVE = "truePositive";
+    const INFORMATIONAL_EXPECTED_ACTIVITY = "informationalExpectedActivity";
+    const UNKNOWN_FUTURE_VALUE = "unknownFutureValue";
+}

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/SecurityNamespace/Model/AlertClassification.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/SecurityNamespace/Model/AlertClassification.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+* 
+* AlertClassification File
+* PHP version 7
+*
+* @category  Library
+* @package   Microsoft.Graph
+* @copyright (c) Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+namespace Beta\Microsoft\Graph\SecurityNamespace\Model;
+
+use Microsoft\Graph\Core\Enum;
+
+/**
+* AlertClassification class
+*
+* @category  Model
+* @package   Microsoft.Graph
+* @copyright (c) Microsoft Corporation. All rights reserved.
+* @license   https://opensource.org/licenses/MIT MIT License
+* @link      https://graph.microsoft.com
+*/
+class AlertClassification extends Enum
+{
+    /**
+    * The Enum AlertClassification
+    */
+    const UNKNOWN = "unknown";
+    const FALSE_POSITIVE = "falsePositive";
+    const TRUE_POSITIVE = "truePositive";
+    const INFORMATIONAL_EXPECTED_ACTIVITY = "informationalExpectedActivity";
+    const UNKNOWN_FUTURE_VALUE = "unknownFutureValue";
+}

--- a/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -213,3 +213,11 @@ export namespace CallRecords {
         priority?: number;
     }
 }
+export namespace SecurityNamespace {
+    type AlertClassification =
+        | "unknown"
+        | "falsePositive"
+        | "truePositive"
+        | "informationalExpectedActivity"
+        | "unknownFutureValue";
+}

--- a/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -212,3 +212,11 @@ export namespace CallRecords {
         priority?: number;
     }
 }
+export namespace SecurityNamespace {
+    type AlertClassification =
+        | "unknown"
+        | "falsePositive"
+        | "truePositive"
+        | "informationalExpectedActivity"
+        | "unknownFutureValue";
+}


### PR DESCRIPTION
## Summary

PHP `Microsoft.Graph.Security` models are currently generated under the folder structure `src/Beta/Microsoft/Graph/SecurityNamespace/Model/*.php` but the namespace definition is still `Beta\Microsoft\Graph\Security\Model` (missing "Namespace").

This causes warnings to be thrown when installing the SDK as reported in https://github.com/microsoftgraph/msgraph-sdk-php/issues/791.

This PR:
- Appends "Namespace" to security namespace models
- Adds security namespace metadata to the test metadata (MetadataWithSubNamespaces) and updates affected test data for PHP, TypeScript and ObjC 

## Generated code differences
https://github.com/microsoftgraph/msgraph-sdk-php/pull/883/files#diff-f782c8960d071232e78fb07169c816febd464bed54d20f395a8a5394c17f1b49

## Links to issues or work items this PR addresses
Fixes https://github.com/microsoftgraph/msgraph-sdk-php/issues/791

Related to https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/666