### PR TITLE
Rsh/correct stream property name space

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/Java/TypeHelperJava.cs
@@ -996,7 +996,7 @@ import javax.annotation.Nonnull;";
             switch (host.CurrentType)
             {
                 case OdcmProperty p:
-                    @namespace = p.Type.Namespace.Name.AddPrefix();
+                    @namespace = p.GetTypeString().Contains("Stream", StringComparison.OrdinalIgnoreCase) ? p.Class.Namespace.Name.AddPrefix() : p.Type.Namespace.Name.AddPrefix();
                     if (p.Class.GetTypeString() != graphServiceEntityName)
                         methodImports.Add(string.Format(importFormat, p.Class.Namespace.Name.AddPrefix(), p.Class.GetPackagePrefix(), p.Class.GetTypeString()));
                     if (!(p.Projection.Type is OdcmPrimitiveType))

--- a/src/GraphODataTemplateWriter/TemplateProcessor/TemplateProcessor.cs
+++ b/src/GraphODataTemplateWriter/TemplateProcessor/TemplateProcessor.cs
@@ -384,7 +384,14 @@ namespace Microsoft.Graph.ODataTemplateWriter.TemplateProcessor
                         @namespace = p.Type.Namespace.Name;
                         if (@namespace == "Edm")
                         {
-                            @namespace = "Microsoft.Graph";
+                            if (p.Type.Name.Equals("Stream", StringComparison.OrdinalIgnoreCase))
+                            {
+                                @namespace = p.Class.Namespace.Name;
+                            }
+                            else
+                            {
+                                @namespace = "Microsoft.Graph";
+                            }
                         }
                     }
                     else


### PR DESCRIPTION
Places stream properties in the correct package/folder as the entity that contains it. 
Writes the correct package definition in these stream properties' requests and requestBuilders. 
https://github.com/microsoftgraph/msgraph-beta-sdk-java/compare/beta/pipelinebuild/74322..beta/pipelinebuild/74554