### PR TITLE
Set Hidi version to 1.0.0-preview1

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -25,7 +25,7 @@ steps:
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
 
-- pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
+- pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --version 1.0.0-preview1
   displayName: install hidi
 
 - pwsh: |


### PR DESCRIPTION
This PR provides a temporary fix to unblock openApi generation for Kiota based SDKs

It sets the hidi version to `1.0.0-preview1` pending the resolution of https://github.com/microsoft/OpenAPI.NET/issues/866

Once the issue has been resolved, we can do a simple reverting of this PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/756)