### PR TITLE
Update pipeline to align to latest Hidi  options

### DIFF
--- a/scripts/generate-open-api.ps1
+++ b/scripts/generate-open-api.ps1
@@ -34,7 +34,7 @@ if(Test-Path $outputFile)
 }
 
 try {
-    Invoke-Expression "hidi transform --csdl ""$inputFile"" --output ""$outputFile"" --version OpenApi3_0 --loglevel Information --format yaml"
+    Invoke-Expression "hidi transform --csdl ""$inputFile"" --output ""$outputFile"" --version OpenApi3_0 --log-level Information --format yaml"
     # temporary fix for the server url https://github.com/microsoftgraph/msgraph-metadata/issues/124
     $content = get-content $outputFile
     $updatedContent = $content -replace "http://localhost", "https://graph.microsoft.com/$endpointVersion"


### PR DESCRIPTION
This PR fixes the generation pipeline to align to the latest hidi options.

Before the log level was set as `--loglevel` but is now set as `--log-level`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/767)