### PR TITLE
PHP - Add ReturnTypeWillChange attribute to jsonSerialize()

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -282,7 +282,8 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     *
     * @return array The list of properties
     */
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -114,7 +114,8 @@ class Entity implements \JsonSerializable
     *
     * @return array The list of properties
     */
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -114,7 +114,8 @@ class GraphPrint implements \JsonSerializable
     *
     * @return array The list of properties
     */
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -114,7 +114,8 @@ class Entity implements \JsonSerializable
     *
     * @return array The list of properties
     */
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -114,7 +114,8 @@ class GraphPrint implements \JsonSerializable
     *
     * @return array The list of properties
     */
-    public function jsonSerialize(): array
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         $serializableProperties = $this->getProperties();
         foreach ($serializableProperties as $property => $val) {


### PR DESCRIPTION
## Summary

Reverts a previous change where we explicitly defined the `jsonSerialize()`  return type to `array` to prevent [this warning on PHP 8.1](https://github.com/microsoftgraph/msgraph-sdk-php/issues/753). See [this](https://php.watch/versions/8.1/internal-method-return-types) for more context on the warning.

Explicitly defining the return type didn't seem like a breaking change since the method always returned an array. However we missed the case that a developer may have extended the model leading to https://github.com/microsoftgraph/msgraph-sdk-php/issues/919 being reported.

This PR uses the `#[\ReturnTypeWillChange]` attribute instead to prevent the PHP 8.1 warning from being emitted without breaking BC.

## Generated code differences
[v1 diff](https://github.com/microsoftgraph/msgraph-sdk-php/compare/v1.0/pipelinebuild/77831?expand=1)
[beta diff](https://github.com/microsoftgraph/msgraph-sdk-php/compare/v1.0/pipelinebuild/77831?expand=1)

## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-php/issues/919

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/772)