### PR TITLE
Fix for incorrect directory structure

### DIFF
--- a/scripts/copy-dotnet-models-kiota.ps1
+++ b/scripts/copy-dotnet-models-kiota.ps1
@@ -5,5 +5,7 @@ Remove-Item -Recurse $env:RepoModelsDir | Write-Host
 Write-Host "Removed the existing generated files in the repo." -ForegroundColor Green
 
 # copy new models
+# Create a dest folder explicitly https://github.com/PowerShell/PowerShell/issues/13352#issuecomment-669025179
+New-Item -ItemType directory -Path $env:RepoModelsDir
 Move-Item $env:OutputFullPath $env:RepoModelsDir
 Write-Host "Moved the models from $modelsDirectory into the local repo." -ForegroundColor Green

--- a/scripts/copy-java-models-kiota.ps1
+++ b/scripts/copy-java-models-kiota.ps1
@@ -2,5 +2,7 @@ Write-Host "Path of new models: $env:OutputFullPath"
 Write-Host "Path to repo models directory: $env:RepoModelsDir"
  
 #copy new modes
+# Create a dest folder explicitly https://github.com/PowerShell/PowerShell/issues/13352#issuecomment-669025179
+New-Item -ItemType directory -Path $env:RepoModelsDir
 Move-Item $env:OutputFullPath $env:RepoModelsDir -Force
 Write-Host "Moved the models from $env:OutputFullPath into the local repo $env:RepoModelsDir." -ForegroundColor Green

--- a/scripts/copy-php-kiota.ps1
+++ b/scripts/copy-php-kiota.ps1
@@ -5,5 +5,7 @@ Remove-Item -Recurse $env:RepoModelsDir | Write-Host
 Write-Host "Removed the existing generated files in the repo." -ForegroundColor Green
 
 # copy new generated files.
+# Create a dest folder explicitly https://github.com/PowerShell/PowerShell/issues/13352#issuecomment-669025179
+New-Item -ItemType directory -Path $env:RepoModelsDir
 Move-Item $env:OutputFullPath $env:RepoModelsDir
 Write-Host "Moved the models from $env:OutputFullPath into the local repo." -ForegroundColor Green


### PR DESCRIPTION
This PR closes https://github.com/PowerShell/PowerShell/issues/13352

It fixes an issue where generated code in the first folder would be placed in the incorrect folder due to an issue with the  powershell `Move-Item` cmdlet.

https://github.com/PowerShell/PowerShell/issues/13352

This PR fixes the issue by making sure the destination folder exists.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/773)