### PR TITLE
adds a step to validate OpenAPI docs right before checkin

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -51,6 +51,11 @@ steps:
     pathToPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: ${{ parameters.cleanMetadataFolder }}
 
+- pwsh: |
+    ./scripts/run-openapi-validation.ps1 -repoDirectory (Get-Location).Path
+  displayName: ensure that OpenAPI docs can be parsed
+  workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+
 # Checkin clean metadata into metadata repo or make it an artifact.
 - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'
 


### PR DESCRIPTION
## Summary
- adds a step to validate OpenAPI docs right before checkin

## Generated code differences

N/A

## Command line arguments to run these changes

N/A

## Links to issues or work items this PR addresses
- fixes #782
- blocked on https://github.com/microsoftgraph/msgraph-metadata/pull/173

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/783)