### PR TITLE
Typewriter: Load DocSet for specified version only

### DIFF
--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -110,12 +110,12 @@ namespace Typewriter
 
         private static DocSet GetDocSet(Options options, IssueLogger issues)
         {
-            Logger.Info("Opening documentation from {0}", options.DocsRoot);
             DocSet docSet;
+            string sourceFolderPath = Path.Join(options.DocsRoot, "api-reference", options.EndpointVersion);
+            Logger.Info("Opening documentation from {0}", sourceFolderPath);
 
             try
             {
-                string sourceFolderPath = Path.Join(options.DocsRoot, "api-reference", options.EndpointVersion);
                 docSet = new DocSet(sourceFolderPath);
             }
             catch (FileNotFoundException ex)

--- a/src/Typewriter/DocAnnotationWriter.cs
+++ b/src/Typewriter/DocAnnotationWriter.cs
@@ -111,11 +111,12 @@ namespace Typewriter
         private static DocSet GetDocSet(Options options, IssueLogger issues)
         {
             Logger.Info("Opening documentation from {0}", options.DocsRoot);
-            DocSet docSet = null;
+            DocSet docSet;
 
             try
             {
-                docSet = new DocSet(options.DocsRoot);
+                string sourceFolderPath = Path.Join(options.DocsRoot, "api-reference", options.EndpointVersion);
+                docSet = new DocSet(sourceFolderPath);
             }
             catch (FileNotFoundException ex)
             {


### PR DESCRIPTION
## Summary

When generating/enriching CSDL with annotations from documentation, the whole doc set, i.e. v1.0 and beta, is used despite a specific version having been set. This has led to links and descriptions annotation values from one version being mixed up in another version's CSDL.

This PR ensures we only use documentation from the specified version to generate annotations.

## Command line arguments to run these changes

`-v Info -m "\msgraph-metadata\v1.0_metadata.xml" -o \generated-metadata -g TransformWithDocs -t \msgraph-metadata\transforms\csdl\preprocess_csdl.xsl -d \microsoft-graph-docs -e v1.0 -r false -a true -f cleanMetadataWithDescriptionsAndAnnotationsAndErrors`

## Links to issues or work items this PR addresses
Fixes #790 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/789)