### PR TITLE
Dotnet Beta generation fixes

### DIFF
--- a/Templates/templates/CSharp/Model/ComplexType.cs.tt
+++ b/Templates/templates/CSharp/Model/ComplexType.cs.tt
@@ -99,7 +99,7 @@ if (attributeStringBuilder.Length > 0) {
         foreach(var property in complex.Properties)
         {
 
-            var propertyTypeString = property.GetTypeString(complex.Namespace.GetNamespaceName());
+            var propertyTypeString = property.GetTypeString(complex.Namespace.GetNamespaceName()).DisambiguateTypeName();
             var propertyType = property.IsCollection ? string.Format("IEnumerable<{0}>", propertyTypeString) : propertyTypeString;
             var propertyName = isMethodResponse
                 ? property.Name.Substring(property.Name.IndexOf('.') + 1).ToCheckedCase()

--- a/Templates/templates/CSharp/Model/EntityType.cs.tt
+++ b/Templates/templates/CSharp/Model/EntityType.cs.tt
@@ -98,7 +98,7 @@ if (attributeStringBuilder.Length > 0) {
         }
         foreach(var property in entity.Properties)
         {
-            var propertyTypeString = property.GetTypeString(entity.Namespace.GetNamespaceName());
+            var propertyTypeString = property.GetTypeString(entity.Namespace.GetNamespaceName()).DisambiguateTypeName();
             var propertyType = property.IsTypeNullable() || property.IsCollection()
                     ? propertyTypeString
                     : propertyTypeString + "?";

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
         {
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                "Microsoft.Graph.Security"
+                "Microsoft.Graph.Security",
+                "Microsoft.Graph.IdentityGovernance"
             };
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/issues/814 and is related to https://github.com/microsoft/Vipr/pull/255

It fixes generation issues discovered in the beta staging metadata after the introduction of the `Microsoft.Graph.IdentityGovernance`

Changes include
- Adds `Microsoft.Graph.IdentityGovernance` to the reserved namespace list as it collides with the `Microsoft.Graph.IdentityGovernance` type
- Ensure the type names in properties in the models are disambiguated to avoid using reserved model names

Generation run - https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=83976&view=logs&j=59c05382-99ff-5215-87ed-89074293151a
Raptor Run - https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=83975&view=results
V1 Diff - https://github.com/microsoftgraph/msgraph-sdk-dotnet/commit/0231e1265cc5913aea3f0f9bd83ad140dee6bad9
Beta diff - https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/commit/3f3353b63fc7ba4f6885efd7a7e6f54a63ef2cf6

TODO
- [x] - Merge after updating submodule link to head of master in VIPR repo after https://github.com/microsoft/Vipr/pull/255 is merged

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/816)