### PR TITLE
namespace java kiota

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -466,7 +466,7 @@ stages:
         baseBranchName: 'feature/6.0'
         branchName: 'kiota/$(v1Branch)'
         targetClassName: "BaseGraphServiceClient"
-        targetNamespace: "Microsoft.Graph"
+        targetNamespace: "com.Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
         - template: generation-templates/java-kiota.yml

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -494,7 +494,7 @@ stages:
         baseBranchName: 'feature/6.0'
         branchName: 'kiota/$(betaBranch)'
         targetClassName: "BaseGraphServiceClient"
-        targetNamespace: "Microsoft.Graph"
+        targetNamespace: "com.Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/java-kiota.yml

--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -13,4 +13,4 @@ steps:
   env: 
     BuildConfiguration: $(buildConfiguration) 
     OutputFullPath: $(kiotaDirectory)/output/*
-    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/com/
+    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/


### PR DESCRIPTION
Change the namespace for the Kiota generated java files from Microsoft.Graph to Com.Microsoft.Graph. This fixes the issue of entities and classes not being able to find certain classes due to a truncated namespace.  

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/818)