### PR TITLE
Fix conflicting type and namespace due to new Microsoft.Graph.DeviceManagement namespace

### DIFF
--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -125,7 +125,8 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "Microsoft.Graph.Security",
-                "Microsoft.Graph.IdentityGovernance"
+                "Microsoft.Graph.IdentityGovernance",
+                "Microsoft.Graph.DeviceManagement"
             };
         }
 


### PR DESCRIPTION
This PR fixes the broken beta staging raptor pipeline due to the newly introduced `Microsoft.Graph.DeviceManagement` namespace which conflicts with the `DeviceManagement` type in the `Microsoft.Graph` namespace in dotnet.

Successful run after change can be found at the link below

https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=85497&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=6278c56e-b9dd-5471-9c3c-f3062039459c

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/827)