### PR TITLE
Adds a base client for go generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -358,7 +358,7 @@ stages:
         version: ''
         repoName: 'msgraph-sdk-go'
         branchName: $(v1Branch)
-        targetClassName: "GraphServiceClient"
+        targetClassName: "GraphBaseServiceClient"
         targetNamespace: "github.com/microsoftgraph/msgraph-sdk-go/"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
@@ -385,7 +385,7 @@ stages:
         version: 'beta'
         repoName: 'msgraph-beta-sdk-go'
         branchName: $(betaBranch)
-        targetClassName: "GraphServiceClient"
+        targetClassName: "GraphBaseServiceClient"
         targetNamespace: "github.com/microsoftgraph/msgraph-beta-sdk-go/"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:

--- a/scripts/clean-go-files.ps1
+++ b/scripts/clean-go-files.ps1
@@ -1,7 +1,7 @@
-$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", ".github")
+$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", ".github" , "tests")
 foreach ($directory in $directories) {
 	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
 }
-Get-ChildItem -Path $env:MainDirectory -Filter graph_base_service_client.go -Recurse | Remove-Item
+Remove-Item -Path $env:MainDirectory -Filter "*.go" -Exclude "graph_request_adapter.go", "graph_service_client.go" -Verbose
 
 Write-Host "Removed the existing generated files in the repo's main directory: $env:MainDirectory" -ForegroundColor Green

--- a/scripts/clean-go-files.ps1
+++ b/scripts/clean-go-files.ps1
@@ -2,6 +2,6 @@ $directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("cor
 foreach ($directory in $directories) {
 	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
 }
-Remove-Item -Path $env:MainDirectory -Filter "*.go" -Exclude "graph_request_adapter.go" -Verbose
+Get-ChildItem -Path $env:MainDirectory -Filter graph_base_service_client.go -Recurse | Remove-Item
 
 Write-Host "Removed the existing generated files in the repo's main directory: $env:MainDirectory" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Renames default client generated by go from `GraphServiceClient` to `GraphBaseServiceClient`. This should allow adding manually edited files later.

Partially addresses https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/88

###
Blocked by 
https://github.com/microsoftgraph/msgraph-sdk-go/pull/277
https://github.com/microsoftgraph/msgraph-beta-sdk-go/pull/155

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/835)