### PR TITLE
PHP - Fix representation of collections of primitive types

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -188,7 +188,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @return <#=propertyTypeReference#>|null The <#=propertyName#>
+    * @return <#=(property.IsCollection()) ? "array" : propertyTypeReference#>|null The <#=propertyName#>
     */
     public function get<#=propertyName.ToCheckedCase()#>()
     {
@@ -216,7 +216,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
     * <#=property.GetSanitizedLongDescription()#>
 <# } #>
     *
-    * @param <#=propertyTypeReference#> $val The <#=propertyName#>
+    * @param <#=(property.IsCollection()) ? $"{propertyTypeReference}[]" : propertyTypeReference#> $val The <#=propertyName#>
     *
     * @return <#=entityName.ToCheckedCase()#>
     */

--- a/test/Typewriter.Test/Metadata/MetadataWithSubNamespaces.xml
+++ b/test/Typewriter.Test/Metadata/MetadataWithSubNamespaces.xml
@@ -10,6 +10,7 @@
             </EntityType>
             <EntityType Name="testType" BaseType="graph.entity">
                 <Property Name="propertyAlpha" Type="graph.derivedComplexTypeRequest" />
+                <Property Name="primitiveCollection" Type="Collection(Edm.String)" />
             </EntityType>
             <EnumType Name="enum1">
                 <Member Name="value0" Value="0" />

--- a/test/Typewriter.Test/TestDataObjC/Models/MSGraphTestType.h
+++ b/test/Typewriter.Test/TestDataObjC/Models/MSGraphTestType.h
@@ -9,5 +9,6 @@
 @interface MSGraphTestType : MSGraphEntity
 
   @property (nullable, nonatomic, setter=setPropertyAlpha:, getter=propertyAlpha) MSGraphDerivedComplexTypeRequest* propertyAlpha;
+    @property (nullable, nonatomic, setter=setPrimitiveCollection:, getter=primitiveCollection) NSArray* primitiveCollection;
   
 @end

--- a/test/Typewriter.Test/TestDataObjC/Models/MSGraphTestType.m
+++ b/test/Typewriter.Test/TestDataObjC/Models/MSGraphTestType.m
@@ -15,6 +15,7 @@
 @interface MSGraphTestType()
 {
     MSGraphDerivedComplexTypeRequest* _propertyAlpha;
+    NSArray* _primitiveCollection;
 }
 @end
 
@@ -39,6 +40,20 @@
 {
     _propertyAlpha = val;
     self.dictionary[@"propertyAlpha"] = val;
+}
+
+- (NSArray*) primitiveCollection
+{
+    if([[NSNull null] isEqual:self.dictionary[@"primitiveCollection"]])
+    {
+        return nil;
+    }   
+    return self.dictionary[@"primitiveCollection"];
+}
+
+- (void) setPrimitiveCollection: (NSArray*) val
+{
+    self.dictionary[@"primitiveCollection"] = val;
 }
 
 

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/TestType.php
@@ -55,4 +55,31 @@ class TestType extends Entity
         return $this;
     }
 
+    /**
+    * Gets the primitiveCollection
+    *
+    * @return array|null The primitiveCollection
+    */
+    public function getPrimitiveCollection()
+    {
+        if (array_key_exists("primitiveCollection", $this->_propDict)) {
+            return $this->_propDict["primitiveCollection"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the primitiveCollection
+    *
+    * @param string[] $val The primitiveCollection
+    *
+    * @return TestType
+    */
+    public function setPrimitiveCollection($val)
+    {
+        $this->_propDict["primitiveCollection"] = $val;
+        return $this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/TestType.php
@@ -55,4 +55,31 @@ class TestType extends Entity
         return $this;
     }
 
+    /**
+    * Gets the primitiveCollection
+    *
+    * @return array|null The primitiveCollection
+    */
+    public function getPrimitiveCollection()
+    {
+        if (array_key_exists("primitiveCollection", $this->_propDict)) {
+            return $this->_propDict["primitiveCollection"];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Sets the primitiveCollection
+    *
+    * @param string[] $val The primitiveCollection
+    *
+    * @return TestType
+    */
+    public function setPrimitiveCollection($val)
+    {
+        $this->_propDict["primitiveCollection"] = $val;
+        return $this;
+    }
+
 }

--- a/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScript/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -18,6 +18,7 @@ export interface Entity {
 }
 export interface TestType extends Entity {
     propertyAlpha?: NullableOption<DerivedComplexTypeRequest>;
+    primitiveCollection?: NullableOption<string[]>;
 }
 export interface Print {
     settings?: NullableOption<string>;

--- a/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
+++ b/test/Typewriter.Test/TestDataTypeScriptBeta/com/microsoft/graph/src/Microsoft-graph.d.ts
@@ -17,6 +17,7 @@ export interface Entity {
 }
 export interface TestType extends Entity {
     propertyAlpha?: NullableOption<DerivedComplexTypeRequest>;
+    primitiveCollection?: NullableOption<string[]>;
 }
 export interface Print {
     settings?: NullableOption<string>;


### PR DESCRIPTION
## Summary

Ensure's primitive collection types are properly represented in documentation of model getters & setters.

## Generated code differences
https://github.com/microsoftgraph/msgraph-sdk-php/pull/1022
https://github.com/microsoftgraph/msgraph-sdk-php/pull/1023

## Links to issues or work items this PR addresses
https://github.com/microsoftgraph/msgraph-sdk-php/issues/1024

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/847)