### PR TITLE
Fix null reference exception when method return type is an odata primitive.

### DIFF
--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -730,10 +730,10 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
                 throw new InvalidOperationException("This extension method is intended " +
                                                     "to only be called on a composable function.");
 
-            return (odcmMethod.ReturnType as OdcmClass).Properties
+            return (odcmMethod.ReturnType as OdcmClass)?.Properties
                                                        .Where(p => p.IsLink)
                                                        .OrderBy(p => p.Name)
-                                                       .ToList();
+                                                       .ToList() ?? new List<OdcmProperty>();
         }
 
         /// <summary>

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             return (odcmMethod.ReturnType as OdcmClass)?.Properties
                                                        .Where(p => p.IsLink)
                                                        .OrderBy(p => p.Name)
-                                                       .ToList() ?? new List<OdcmProperty>();
+                                                       .ToList() ?? new List<OdcmProperty>(); // default to empty list
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes a null reference exception in the `GetComposableFunctionReturnTypeNavigations` due to a failed cast.

Related to changes made in https://github.com/microsoftgraph/msgraph-metadata/pull/213

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/854)