### PR TITLE
add funcOptions to requestOptions

### DIFF
--- a/Templates/templates/Java/requests/BaseMethodRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequest.java.tt
@@ -30,7 +30,7 @@ import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.AsOdcmMethod().TypePara
     }
 
 <# if (c.AsOdcmMethod().IsAction()) { #>
-<# if(c.AsOdcmMethod().MethodHasParameters()) { #>
+<# if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters())) { #>
 	/** The body for the method */
     @Nullable
     public <#=c.TypeParameterSet()#> body;

--- a/Templates/templates/Java/requests/BaseMethodRequest.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequest.java.tt
@@ -13,7 +13,7 @@ import <#=importNamespace#>.http.HttpMethod;
 import <#=importNamespace#>.core.ClientException;
 import <#=importNamespace#>.core.IBaseClient;
 <# var mainNamespace = host.CurrentNamespace(); #>
-<#if(c.AsOdcmMethod().MethodHasParameters()) { #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters())) { #>
 import <#=mainNamespace#>.<#=c.GetPackagePrefix()#>.<#=c.AsOdcmMethod().TypeParameterSet()#>;
 <# } #>
 

--- a/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
@@ -85,7 +85,7 @@ import javax.annotation.Nonnull;
                 getRequestUrl(),
                 getClient(),
                 requestOptions);
-<#if(c.AsOdcmMethod().MethodHasParameters()) { #>
+<#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters())) { #>
 <# if (isAction) { #>
         request.body = this.body;
 <# } else { #>


### PR DESCRIPTION
https://github.com/microsoftgraph/msgraph-sdk-java/issues/1063
As noted in this issue, we are not adding function options to our request options on all methods which include parameters. The issue is due to the fact that we do not check the method overloads for whether they have parameters or not when we generate the BuildRequest() methods. In some cases the topmost Ocdm method of the class does not have parameters and in such cases, we fail to add these parameters to the request options. By checking all instances of the method, and whether any overloads include parameters, we can cover scenarios where some overloads have parameters and others don't.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/857)