### PR TITLE
Serialize stream properties in PHP models

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -293,6 +293,8 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
                 $serializableProperties[$property] = $val->value();
             } else if (is_a($val, "\Entity")) {
                 $serializableProperties[$property] = $val->jsonSerialize();
+            } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
+                $serializableProperties[$property] = (string) $val;
             }
         }
         return $serializableProperties;

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/Entity.php
@@ -125,6 +125,8 @@ class Entity implements \JsonSerializable
                 $serializableProperties[$property] = $val->value();
             } else if (is_a($val, "\Entity")) {
                 $serializableProperties[$property] = $val->jsonSerialize();
+            } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
+                $serializableProperties[$property] = (string) $val;
             }
         }
         return $serializableProperties;

--- a/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHP/com/Microsoft/Graph/Model/GraphPrint.php
@@ -125,6 +125,8 @@ class GraphPrint implements \JsonSerializable
                 $serializableProperties[$property] = $val->value();
             } else if (is_a($val, "\Entity")) {
                 $serializableProperties[$property] = $val->jsonSerialize();
+            } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
+                $serializableProperties[$property] = (string) $val;
             }
         }
         return $serializableProperties;

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/Entity.php
@@ -125,6 +125,8 @@ class Entity implements \JsonSerializable
                 $serializableProperties[$property] = $val->value();
             } else if (is_a($val, "\Entity")) {
                 $serializableProperties[$property] = $val->jsonSerialize();
+            } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
+                $serializableProperties[$property] = (string) $val;
             }
         }
         return $serializableProperties;

--- a/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
+++ b/test/Typewriter.Test/TestDataPHPBeta/com/Beta/Microsoft/Graph/Model/GraphPrint.php
@@ -125,6 +125,8 @@ class GraphPrint implements \JsonSerializable
                 $serializableProperties[$property] = $val->value();
             } else if (is_a($val, "\Entity")) {
                 $serializableProperties[$property] = $val->jsonSerialize();
+            } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
+                $serializableProperties[$property] = (string) $val;
             }
         }
         return $serializableProperties;


### PR DESCRIPTION
## Summary

Stream properties in models were NOT previously being serialized into the request payload.
This fix casts the streams to "string" which rewinds the stream & reads the stream's contents into a string

## Generated code differences

https://github.com/microsoftgraph/msgraph-sdk-php/pull/1055/files
https://github.com/microsoftgraph/msgraph-sdk-php/pull/1056/files

## Links to issues or work items this PR addresses
closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/1052

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/867)