### PR TITLE
Fix generation pipeline due to missing dotnet version

### DIFF
--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -54,6 +54,8 @@ steps:
 
 - template: download-typewriter.yml
 
+- template: use-dotnet-sdk.yml
+
 ## Only run if the previous step was successful
 - pwsh: '$(scriptsDirectory)/run-typewriter-clean-metadata.ps1'
   env:
@@ -114,6 +116,8 @@ steps:
 # Use the clean metadata from the last step to generate DotNet files.
 
 - template: use-dotnet-sdk.yml
+  parameters:
+    version: '6.x' # verify tool is NET6 app
 
 # verify that generated metadata is parsable as an Edm model
 - pwsh: dotnet run --project $(Build.SourcesDirectory)/msgraph-metadata/tools/MetadataParser/MetadataParser.csproj -- ${{ parameters.cleanMetadataFileWithAnnotations }}

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -24,6 +24,8 @@ steps:
 - template: checkout-metadata.yml
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
+  parameters:
+    version: '6.x' # Hidi is released as an NET6 app
 
 - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
   displayName: install hidi

--- a/.azure-pipelines/generation-templates/use-dotnet-sdk.yml
+++ b/.azure-pipelines/generation-templates/use-dotnet-sdk.yml
@@ -1,7 +1,12 @@
+parameters:
+- name: 'version'
+  type: string
+  default: "7.x"
+
 steps:
 - task: UseDotNet@2
   displayName: 'Use .NET SDK'
   inputs:
     packageType: sdk
-    version: 7.0.100
+    version: ${{ parameters.version }}
     installationPath: $(Agent.ToolsDirectory)/dotnet


### PR DESCRIPTION
This PR fixes some failing steps in generation pipeline due to some tools still using NET6.

In summary, changes include,
- Update `use-dotnet-sdk.yml` to take in the dotnet version as a param so that steps needing NET6 can choose the version. particularly Hidi.