### PR TITLE
Fix Hidi dotnet version

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -24,8 +24,6 @@ steps:
 - template: checkout-metadata.yml
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
-  parameters:
-    version: '6.x' # Hidi is released as an NET6 app
 
 - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
   displayName: install hidi


### PR DESCRIPTION
This PR fixes the openAPI generation step that fails as Hidi is now an .NET 7 app

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/885)