### PR TITLE
Disable writing PHP model file to test context

### DIFF
--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -64,8 +64,6 @@ namespace Typewriter.Test
 
             // Check that the namespace applied at the CLI was added to the document.
             IEnumerable<string> lines = File.ReadLines(fileInfo.FullName);
-            TestContext.Out.WriteLine("Entity.php result");
-            TestContext.Out.Write(lines.Aggregate((x, y) => $"{x}{TestContext.Out.NewLine}{y}"));
             bool isExpectedNamespaceSet = false;
             foreach (var line in lines)
             {


### PR DESCRIPTION
`Entity.php` is always written to console during test runs making it confusing to trace issues with failed builds
e.g. https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/actions/runs/3907997316/jobs/6677759915

This PR disables writing Entity.php to the test context.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/913)