### PR TITLE
Fixes namespace resolution for odata function/actions

### DIFF
--- a/Templates/templates/CSharp/Base/IRequestBuilder.Base.template.tt
+++ b/Templates/templates/CSharp/Base/IRequestBuilder.Base.template.tt
@@ -88,7 +88,7 @@ public string GetRequestMethodWithOptions(string requestTypeName, string @namesp
 
 
 // Creates the set of property definitions for OData method properties on the entity
-public string GetMethodProperties(OdcmClass entity, bool isCollection)
+public string GetMethodProperties(OdcmClass entity, bool isCollection, string namespaceContext)
 {
     var allMethods = new List<OdcmMethod>();
     foreach (var method in entity.Methods)
@@ -102,7 +102,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
     {
 		if (method.IsBoundToCollection != isCollection)
 		{
-			continue; 
+			continue;
 		}
 
         var methodName = this.GetMethodName(method);
@@ -120,8 +120,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             foreach (var param in requiredParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
-                var paramTypeString = param.Type.GetTypeString(entity.GetNamespaceName()).DisambiguateTypeName();
-
+                var paramTypeString = param.Type.GetTypeString(namespaceContext).DisambiguateTypeName();
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -135,7 +134,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             foreach (var param in optionalParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
-                var paramTypeString = param.Type.GetTypeString().DisambiguateTypeName();
+                var paramTypeString = param.Type.GetTypeString(namespaceContext).DisambiguateTypeName();
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -160,11 +159,16 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             methodPropertiesStringBuilder.Append("        ");
         }
 
+        var namespacePrefix = namespaceContext.Equals(entity.GetNamespaceName(),StringComparison.OrdinalIgnoreCase) ?
+                                                        string.Empty:
+                                                        entity.GetNamespaceName() + ".";
+
         methodPropertiesStringBuilder.Append(
             this.GetMethodRequestBuilderMethod(
                 methodName,
                 baseName,
-                paramStringBuilder.ToString()));
+                paramStringBuilder.ToString(),
+                namespacePrefix));
     }
 
     return methodPropertiesStringBuilder.ToString();
@@ -176,9 +180,10 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
 public string GetMethodRequestBuilderMethod(
     string methodName,
     string requestBuilderBaseString,
-    string methodParamaterString)
+    string methodParamaterString,
+    string namespaceContext)
 {
-    var requestBuilderTypeName = this.GetRequestBuilderString(requestBuilderBaseString);
+    var requestBuilderTypeName = namespaceContext + this.GetRequestBuilderString(requestBuilderBaseString);
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append("/// <summary>");

--- a/Templates/templates/CSharp/Base/RequestBuilder.Base.template.tt
+++ b/Templates/templates/CSharp/Base/RequestBuilder.Base.template.tt
@@ -132,7 +132,7 @@ public string GetRequestMethodWithOptions(string requestTypeName, string @namesp
 }
 
 // Creates the set of property definitions for OData method properties on the entity
-public string GetMethodProperties(OdcmClass entity, bool isCollection)
+public string GetMethodProperties(OdcmClass entity, bool isCollection, string namespaceContext)
 {
     var allMethods = new List<OdcmMethod>();
     foreach (var method in entity.Methods)
@@ -146,7 +146,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
     {
 		if (method.IsBoundToCollection != isCollection)
 		{
-			continue; 
+			continue;
 		}
 
         var methodName = this.GetMethodName(method);
@@ -172,7 +172,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             foreach (var param in requiredParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
-                var paramTypeString = param.Type.GetTypeString(entity.GetNamespaceName()).DisambiguateTypeName();
+                var paramTypeString = param.Type.GetTypeString(namespaceContext).DisambiguateTypeName();
 
                 if (param.IsCollection)
                 {
@@ -191,7 +191,7 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             foreach (var param in optionalParameters)
             {
                 var paramVariableName = param.Name.GetSanitizedParameterName();
-                var paramTypeString = param.Type.GetTypeString().DisambiguateTypeName();
+                var paramTypeString = param.Type.GetTypeString(namespaceContext).DisambiguateTypeName();
                 if (param.IsCollection)
                 {
                     paramTypeString = string.Format("IEnumerable<{0}>", paramTypeString);
@@ -222,12 +222,17 @@ public string GetMethodProperties(OdcmClass entity, bool isCollection)
             methodPropertiesStringBuilder.Append("        ");
         }
 
+        var namespacePrefix = namespaceContext.Equals(entity.GetNamespaceName(),StringComparison.OrdinalIgnoreCase) ?
+                                                string.Empty:
+                                                entity.GetNamespaceName() + ".";
+
         methodPropertiesStringBuilder.Append(
             this.GetMethodRequestBuilderMethod(
                 methodName,
                 baseName,
                 paramStringBuilder.ToString(),
-                builderInitializerStringBuilder.ToString()));
+                builderInitializerStringBuilder.ToString(),
+                namespacePrefix));
     }
 
     return methodPropertiesStringBuilder.ToString();
@@ -240,9 +245,10 @@ public string GetMethodRequestBuilderMethod(
     string methodName,
     string requestBuilderBaseString,
     string methodParamaterString,
-    string requestBuilderInitializerString)
+    string requestBuilderInitializerString,
+    string namespacePrefix)
 {
-    var requestBuilderTypeName = this.GetRequestBuilderString(requestBuilderBaseString);
+    var requestBuilderTypeName = namespacePrefix + this.GetRequestBuilderString(requestBuilderBaseString);
     var stringBuilder = new StringBuilder();
 
     stringBuilder.Append("/// <summary>");

--- a/Templates/templates/CSharp/Requests/EntityCollectionRequestBuilder.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityCollectionRequestBuilder.cs.tt
@@ -11,7 +11,6 @@ var collectionRequestBuilderConstructor = this.GetCollectionRequestBuilderConstr
 var collectionRequestMethod = this.GetCollectionRequestMethod(prop);
 var collectionRequestMethodWithOptions = this.GetCollectionRequestMethodWithOptions(prop);
 var collectionIndexRequestBuilder = this.GetCollectionIndexRequestBuilder(prop);
-var methodProperties = this.GetMethodProperties(prop.Projection.Type.AsOdcmClass(), true);
 
 #>
 namespace <#=@namespace#>
@@ -29,6 +28,6 @@ namespace <#=@namespace#>
 
         <#=this.GetCollectionIndexRequestBuilder(prop)#>
 
-        <#=this.GetMethodProperties(prop.Projection.Type.AsOdcmClass(), true) #>
+        <#=this.GetMethodProperties(prop.Projection.Type.AsOdcmClass(), true, @namespace) #>
     }
 }

--- a/Templates/templates/CSharp/Requests/EntityRequestBuilder.cs.tt
+++ b/Templates/templates/CSharp/Requests/EntityRequestBuilder.cs.tt
@@ -43,7 +43,7 @@ namespace <#=@namespace#>
     {
     #>
 
-        <#=this.GetMethodProperties(entity, false)#>
+        <#=this.GetMethodProperties(entity, false, @namespace)#>
     <#
     }
     #>

--- a/Templates/templates/CSharp/Requests/IEntityCollectionRequestBuilder.cs.tt
+++ b/Templates/templates/CSharp/Requests/IEntityCollectionRequestBuilder.cs.tt
@@ -20,6 +20,6 @@ namespace <#=@namespace#>
 
         <#=this.GetCollectionIndexRequestBuilder(prop)#>
 
-        <#=this.GetMethodProperties(prop.Projection.Type.AsOdcmClass(), true) #>
+        <#=this.GetMethodProperties(prop.Projection.Type.AsOdcmClass(), true, @namespace) #>
     }
 }

--- a/Templates/templates/CSharp/Requests/IEntityRequestBuilder.cs.tt
+++ b/Templates/templates/CSharp/Requests/IEntityRequestBuilder.cs.tt
@@ -43,7 +43,7 @@ namespace <#=@namespace#>
     {
     #>
 
-        <#=this.GetMethodProperties(entity, false)#>
+        <#=this.GetMethodProperties(entity, false,@namespace)#>
     <#
     }
     #>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/CloudCommunicationsCallRecordsCollectionRequestBuilder.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the request builder for CallRecordItem.
         /// </summary>
-        /// <returns>The <see cref="ICallRecordItemRequestBuilder"/>.</returns>
-        public ICallRecordItemRequestBuilder Item(
+        /// <returns>The <see cref="Microsoft.Graph2.CallRecords.ICallRecordItemRequestBuilder"/>.</returns>
+        public Microsoft.Graph2.CallRecords.ICallRecordItemRequestBuilder Item(
             string name = null)
         {
-            return new CallRecordItemRequestBuilder(
+            return new Microsoft.Graph2.CallRecords.CallRecordItemRequestBuilder(
                 this.AppendSegmentToRequestUrl("microsoft.graph2.callRecords.item"),
                 this.Client,
                 name);

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ICloudCommunicationsCallRecordsCollectionRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/ICloudCommunicationsCallRecordsCollectionRequestBuilder.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the request builder for CallRecordItem.
         /// </summary>
-        /// <returns>The <see cref="ICallRecordItemRequestBuilder"/>.</returns>
-        ICallRecordItemRequestBuilder Item(
+        /// <returns>The <see cref="Microsoft.Graph2.CallRecords.ICallRecordItemRequestBuilder"/>.</returns>
+        Microsoft.Graph2.CallRecords.ICallRecordItemRequestBuilder Item(
             string name = null);
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/ISegmentRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/ISegmentRequestBuilder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         /// <returns>The <see cref="ISegmentTestActionRequestBuilder"/>.</returns>
         ISegmentTestActionRequestBuilder TestAction(
-            IdentitySet value = null);
+            Microsoft.Graph.IdentitySet value = null);
     
     }
 }

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph2/callrecords/requests/SegmentRequestBuilder.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Graph2.CallRecords
         /// </summary>
         /// <returns>The <see cref="ISegmentTestActionRequestBuilder"/>.</returns>
         public ISegmentTestActionRequestBuilder TestAction(
-            IdentitySet value = null)
+            Microsoft.Graph.IdentitySet value = null)
         {
             return new SegmentTestActionRequestBuilder(
                 this.AppendSegmentToRequestUrl("microsoft.graph2.callRecords.testAction"),


### PR DESCRIPTION
This PR fixes a bug where return types and parameters for request builders odata methods would not be aware of namespace context causing build issues on smoke tests. 



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/920)