### PR TITLE
PHP Entity bug : Test never evaluates to true

### DIFF
--- a/Templates/templates/PHP/Model/EntityType.php.tt
+++ b/Templates/templates/PHP/Model/EntityType.php.tt
@@ -291,7 +291,7 @@ foreach(var property in entity.Properties.Where(prop => prop.Type.GetTypeString(
                 $serializableProperties[$property] = $val->format(\DateTime::RFC3339);
             } else if (is_a($val, "\Microsoft\Graph\Core\Enum")) {
                 $serializableProperties[$property] = $val->value();
-            } else if (is_a($val, "\Entity")) {
+            } else if (is_a($val, self::class)) {
                 $serializableProperties[$property] = $val->jsonSerialize();
             } else if (is_a($val, "\GuzzleHttp\Psr7\Stream")) {
                 $serializableProperties[$property] = (string) $val;


### PR DESCRIPTION
Targets PHP generated Entity model class.

Resolution of class `\Entity` is the problem.
Running `class_exists("\Entity")` returns `false` while `class_exists("\MicrosoftGraph\Core\Model\Entity")` is true. 
Because of beta api, the most simple fix is using `self::class`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/925)