### PR TITLE
Fix generation pipeline to use Hidi validation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -106,8 +106,7 @@ resources:
      endpoint: microsoftkiota
      name: microsoft/kiota
 
-pool:
-  vmImage: 'ubuntu-latest'
+pool: 1es-ubuntu-latest
 
 parameters:
   - name: v1BranchPrefix

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -120,7 +120,7 @@ steps:
     version: '6.x' # verify tool is NET6 app
 
 # verify that generated metadata is parsable as an Edm model
-- pwsh: dotnet run --project $(Build.SourcesDirectory)/msgraph-metadata/tools/MetadataParser/MetadataParser.csproj -- ${{ parameters.cleanMetadataFileWithAnnotations }}
+- pwsh: $(Build.SourcesDirectory)/msgraph-metadata/scripts/run-metadata-validation.ps1 -repoDirectory "$(Build.SourcesDirectory)/msgraph-metadata/" -version "${{ parameters.endpoint }}"
   displayName: 'verify whether metadata is parsable as an Edm model'
 
 - pwsh: '$(scriptsDirectory)/run-typewriter.ps1'

--- a/.azure-pipelines/generation-templates/dotnet-kiota.yml
+++ b/.azure-pipelines/generation-templates/dotnet-kiota.yml
@@ -14,6 +14,6 @@ steps:
   displayName: Restore dependencies for ${{ parameters.repoName }}
   workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}
 
-- pwsh: 'dotnet build --configuration $(buildConfiguration)'
+- pwsh: 'dotnet build --configuration $(buildConfiguration) -f netstandard2.0 --no-restore'
   displayName: Build dll for ${{ parameters.repoName }}
-  workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}
+  workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/


### PR DESCRIPTION
This PR fixes the generation pipeline to use the Hidi validation after changes made in https://github.com/microsoftgraph/msgraph-metadata/pull/257 make the pipeline point to non existing files.

Other changes include

- Updates pool to `1es-ubuntu-latest` to allow for more jobs to run in parallel.
- Updates the dotnet task to build the csproj directly.

Sample run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=105144&view=results



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/927)