### PR TITLE
Fixes beta SDKs generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -198,7 +198,6 @@ stages:
         endpoint: 'v1.0'
         inputMetadata: $(rawMetadataFileV1)
         outputPath: $(cleanMetadataFileV1OutputPath)
-        repoName: "msgraph-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileV1)
         cleanMetadataFolder: $(cleanMetadataFolderV1)
         cleanMetadataFileWithAnnotations: $(cleanMetadataFileWithAnnotationsV1)
@@ -217,7 +216,6 @@ stages:
         endpoint: 'beta'
         inputMetadata: $(rawMetadataFileBeta)
         outputPath: $(cleanMetadataFileBetaOutputPath)
-        repoName: "msgraph-beta-sdk-dotnet"
         cleanMetadataFile: $(cleanMetadataFileBeta)
         cleanMetadataFolder: $(cleanMetadataFolderBeta)
         cleanMetadataFileWithAnnotations: $(cleanMetadataFileWithAnnotationsBeta)

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -14,9 +14,6 @@ parameters:
 - name: 'outputPath'
   type: string
   default: $(System.ArtifactsDirectory)
-- name: 'repoName'
-  type: string
-  default: "msgraph-sdk-dotnet"
 - name: 'cleanMetadataFile'
   type: string
   default: $(cleanMetadataFileV1)
@@ -133,16 +130,6 @@ steps:
     Language: 'CSharp'
     Endpoint:  ${{ parameters.endpoint }}
   displayName: 'generate ${{ parameters.endpoint }} files for .NET'
-
-- checkout: ${{ parameters.repoName }}
-  displayName: checkout dotnet ${{ parameters.endpoint }}
-  fetchDepth: 1
-  persistCredentials: true
-
-- template: dotnet.yml
-  parameters:
-    repoName: ${{ parameters.repoName }}
-    dllName: Microsoft.Graph.dll
 
 # Checkin clean metadata into metadata repo or make it an artifact.
 - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -120,17 +120,6 @@ steps:
 - pwsh: $(Build.SourcesDirectory)/msgraph-metadata/scripts/run-metadata-validation.ps1 -repoDirectory "$(Build.SourcesDirectory)/msgraph-metadata/" -version "${{ parameters.endpoint }}"
   displayName: 'verify whether metadata is parsable as an Edm model'
 
-- pwsh: '$(scriptsDirectory)/run-typewriter.ps1'
-  env:
-    BuildConfiguration: $(buildConfiguration)
-    OutputPath: output
-    CleanMetadataFile: ${{ parameters.cleanMetadataFile }}
-    TypewriterExecutable: $(typewriterExecutable)
-    TypewriterDirectory: $(typewriterDirectory)
-    Language: 'CSharp'
-    Endpoint:  ${{ parameters.endpoint }}
-  displayName: 'generate ${{ parameters.endpoint }} files for .NET'
-
 # Checkin clean metadata into metadata repo or make it an artifact.
 - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'
 

--- a/Templates/templates/CSharp/Model/EnumType.cs.tt
+++ b/Templates/templates/CSharp/Model/EnumType.cs.tt
@@ -11,7 +11,7 @@ var @namespace = enumT.Namespace.GetNamespaceName();
 
 namespace <#=enumT.Namespace.GetNamespaceName()#>
 {
-<# if (enumT.IsDeprecated) { #>
+<# if (enumT.IsDeprecated || enumT.Members.Any(static member => member.IsDeprecated)) { #>
     using System;
 <# } #>
     using System.Text.Json.Serialization;

--- a/test/Typewriter.Test/Metadata/MetadataMultipleNamespaces.xml
+++ b/test/Typewriter.Test/Metadata/MetadataMultipleNamespaces.xml
@@ -228,7 +228,21 @@
       </EntityType>
       <EnumType Name="roleEligibilityRequestFilterByCurrentUserOptions">
         <Member Name="principal" Value="1"/>
-        <Member Name="createdBy" Value="2"/>
+        <Member Name="createdBy" Value="2">
+          <Annotation Term="Org.OData.Core.V1.Revisions">
+            <Collection>
+              <Record>
+                <PropertyValue Date="2023-01-19" Property="Date" />
+                <PropertyValue Property="Description" String="The createdBy will be deprecated on April 30, 2023." />
+                <PropertyValue Property="Kind">
+                    <EnumMember>Org.OData.Core.V1.RevisionKind/Deprecated</EnumMember>
+                </PropertyValue>
+                <PropertyValue Date="2023-04-30" Property="RemovalDate" />
+                <PropertyValue Property="Version" String="2023-01/createdBy" />
+              </Record>
+            </Collection>
+          </Annotation>
+        </Member>
         <Member Name="approver" Value="3"/>
         <Member Name="unknownFutureValue" Value="4"/>
       </EnumType>

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/RoleEligibilityRequestFilterByCurrentUserOptions.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/model/RoleEligibilityRequestFilterByCurrentUserOptions.cs
@@ -10,6 +10,7 @@
 
 namespace Microsoft.Graph
 {
+    using System;
     using System.Text.Json.Serialization;
 
     /// <summary>
@@ -27,6 +28,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Created By
         /// </summary>
+        [Obsolete("The createdBy will be deprecated on April 30, 2023.")]
         CreatedBy = 2,
 	
         /// <summary>

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/RoleEligibilityRequestFilterByCurrentUserOptions.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/models/RoleEligibilityRequestFilterByCurrentUserOptions.java
@@ -17,7 +17,9 @@ public enum RoleEligibilityRequestFilterByCurrentUserOptions
     PRINCIPAL,
     /**
     * created By
+    * @deprecated The createdBy will be deprecated on April 30, 2023.
     */
+    @Deprecated
     CREATED_BY,
     /**
     * approver

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/RoleEligibilityRequestFilterByCurrentUserOptions.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/models/RoleEligibilityRequestFilterByCurrentUserOptions.java
@@ -17,7 +17,9 @@ public enum RoleEligibilityRequestFilterByCurrentUserOptions
     PRINCIPAL,
     /**
     * created By
+    * @deprecated The createdBy will be deprecated on April 30, 2023.
     */
+    @Deprecated
     CREATED_BY,
     /**
     * approver


### PR DESCRIPTION
This PR  unblock generation of beta SDKs in the current week,

In summary changes include.

- Remove smoke tests from metadata stages to prevent single point of failure for other SDKs
- Fixes dotnet generation to ensure the System namespace is included when Enum properties are deprecated.
- Updated test metadata to capture this scenario.

Sample run at https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=105923&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/936)