### PR TITLE
Feature: generate multiple OpenAPI definitions

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -154,6 +154,7 @@ variables:
   kiotaDirectory: '$(Build.SourcesDirectory)/kiota'
   typewriterExecutable: '$(typewriterDirectory)/Typewriter'
   scriptsDirectory: '$(Build.SourcesDirectory)/MSGraph-SDK-Code-Generator/scripts'
+  conversionSettingsDirectory: '$(Build.SourcesDirectory)/MSGraph-SDK-Code-Generator/conversion-settings'
   transformScript: '$(Build.SourcesDirectory)/msgraph-metadata/transforms/csdl/preprocess_csdl.xsl'
   docsDirectory: '$(Build.SourcesDirectory)/microsoft-graph-docs'
 
@@ -224,25 +225,21 @@ stages:
   dependsOn: stage_v1_metadata
   condition: in(dependencies.stage_v1_metadata.result, 'Succeeded', 'Skipped')
   jobs:
-  - job: v1_openapi
-    steps:
-    - template: generation-templates/capture-openapi.yml
-      parameters:
-        endpoint: 'v1.0'
-        outputPath: $(cleanOpenAPIFileV1OutputPath)
-        cleanMetadataFolder: $(cleanOpenAPIFolderV1)
+  - template: generation-templates/capture-openapi.yml
+    parameters:
+      endpoint: 'v1.0'
+      outputPath: $(cleanOpenAPIFileV1OutputPath)
+      cleanMetadataFolder: $(cleanOpenAPIFolderV1)
 
 - stage: stage_beta_openapi
   dependsOn: stage_beta_metadata
   condition: in(dependencies.stage_beta_metadata.result, 'Succeeded', 'Skipped')
   jobs:
-  - job: beta_openapi
-    steps:
-    - template: generation-templates/capture-openapi.yml
-      parameters:
-        endpoint: 'beta'
-        outputPath: $(cleanOpenAPIFileBetaOutputPath)
-        cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
+  - template: generation-templates/capture-openapi.yml
+    parameters:
+      endpoint: 'v1.0'
+      outputPath: $(cleanOpenAPIFileV1OutputPath)
+      cleanMetadataFolder: $(cleanOpenAPIFolderV1)
 
 - stage: stage_csharp_v1
   dependsOn:

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -88,7 +88,7 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
 
   # Checkin clean metadata into metadata repo or make it an artifact.
-  - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1  -platformName "$(Name)"'
+  - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'
 
     displayName: push clean ${{ parameters.endpoint }} OpenAPI description to msgraph-metadata repo
     env:

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -13,55 +13,86 @@ parameters:
   default: $(System.ArtifactsDirectory)
 - name: 'cleanMetadataFolder'
   type: string
-steps:
 
-# We only need the scripts
-- checkout: self
-  displayName: checkout generator
-  fetchDepth: 1
-  persistCredentials: true
+jobs:
+- job: get_conversion_settings
+  displayName: "Get conversion settings"
+  steps:
+  - pwsh: |
+      $dirPath = "./conversion-settings"
+      $endpoint = "${{ parameters.endpoint }}"
+      Write-Host "endpoint: $endpoint"
+      Write-Host "directory path: $dirPath"
+      $jsonBase = @{}
+      foreach ($f in Get-ChildItem $dirPath -Recurse -Include *.json) {
+        $name = $f.Name.replace('.json','')
+        $data = @{"File"=$f.Name;"Name"=$name;}
+        $key = "$endpoint-$name"
+        $jsonBase.Add($key,$data)
+      }
+      $json = $jsonBase | ConvertTo-Json -Compress
+      Write-Host "##vso[task.setvariable variable=targets;isOutput=true]$json"
+    name: setTargets
 
-- template: checkout-metadata.yml
-- template: set-user-config.yml
-- template: use-dotnet-sdk.yml
+  - script: echo $(setTargets.targets)
+    displayName: "Print settings"
 
-- pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
-  displayName: install hidi
+- job: publish_openapi
+  dependsOn: get_conversion_settings
+  displayName: Publish
+  strategy:
+    matrix: $[ dependencies.get_conversion_settings.outputs['setTargets.targets'] ]
+  variables:
+    targets: $[ dependencies.get_conversion_settings.outputs['setTargets.targets'] ]
 
-- pwsh: |
-    git fetch origin master
-    git switch master
-  displayName: ensure the generation happens from master latest
-  workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+  steps:
+  # We only need the scripts
+  - checkout: self
+    displayName: checkout generator
+    fetchDepth: 1
+    persistCredentials: true
 
-- pwsh: '$(scriptsDirectory)/generate-open-api.ps1 -endpointVersion ${{ parameters.endpoint }}'
-  displayName: 'update ${{ parameters.endpoint }} open API description'
-  workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+  - template: checkout-metadata.yml
+  - template: set-user-config.yml
+  - template: use-dotnet-sdk.yml
 
-# publish metadata as an artifact
-- task: CopyFiles@2
-  inputs:
-    sourceFolder: ${{ parameters.outputPath }}
-    contents: '**/*'
-    targetFolder: '$(Build.ArtifactStagingDirectory)'
-  displayName: Copy generated metadata
+  - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
+    displayName: install hidi
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: '$(Build.ArtifactStagingDirectory)'
-    artifactName: ${{ parameters.cleanMetadataFolder }}
+  - pwsh: |
+      git fetch origin master
+      git switch master
+    displayName: ensure the generation happens from master latest
+    workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
 
-- pwsh: |
-    ./scripts/run-openapi-validation.ps1 -repoDirectory (Get-Location).Path -version "${{ parameters.endpoint }}"
-  displayName: ensure that OpenAPI docs can be parsed
-  workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+  - pwsh: '$(scriptsDirectory)/generate-open-api.ps1 -endpointVersion ${{ parameters.endpoint }} -settings "$(conversionSettingsDirectory)/$(File)" -platformName "$(Name)"'
+    displayName: 'update ${{ parameters.endpoint }} open API description'
+    workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
 
-# Checkin clean metadata into metadata repo or make it an artifact.
-- pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'
+  # publish metadata as an artifact
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: ${{ parameters.outputPath }}
+      contents: '**/*'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+    displayName: Copy generated metadata
 
-  displayName: push clean ${{ parameters.endpoint }} OpenAPI description to msgraph-metadata repo
-  env:
-    EndpointVersion: ${{ parameters.endpoint }}
-    PublishChanges: $(publishChanges)
-  workingDirectory: '$(Build.SourcesDirectory)/msgraph-metadata'
-  enabled: true
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: ${{ parameters.cleanMetadataFolder }}
+
+  - pwsh: |
+      ./scripts/run-openapi-validation.ps1 -repoDirectory (Get-Location).Path -version "${{ parameters.endpoint }}" -platformName "$(Name)"
+    displayName: ensure that OpenAPI docs can be parsed
+    workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+
+  # Checkin clean metadata into metadata repo or make it an artifact.
+  - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1  -platformName "$(Name)"'
+
+    displayName: push clean ${{ parameters.endpoint }} OpenAPI description to msgraph-metadata repo
+    env:
+      EndpointVersion: ${{ parameters.endpoint }}
+      PublishChanges: $(publishChanges)
+    workingDirectory: '$(Build.SourcesDirectory)/msgraph-metadata'
+    enabled: true

--- a/conversion-settings/graphexplorer.json
+++ b/conversion-settings/graphexplorer.json
@@ -1,0 +1,17 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "EnableDiscriminatorValue": false,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableKeyAsSegment": true,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "TagDepth": 2,
+    "ShowLinks": true,
+    "ShowRootPath": true
+  }
+}

--- a/conversion-settings/openapi.json
+++ b/conversion-settings/openapi.json
@@ -1,0 +1,22 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "DeclarePathParametersOnPathItem": true,
+    "EnableCount": true,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableDiscriminatorValue": true,
+    "EnableKeyAsSegment": true,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty": true,
+    "ErrorResponsesAsDefault": false,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "ShowLinks": false,
+    "ShowRootPath": false,
+    "TagDepth": 2,
+    "UseSuccessStatusCodeRange": true
+  }
+}

--- a/conversion-settings/powershell.json
+++ b/conversion-settings/powershell.json
@@ -1,0 +1,19 @@
+{
+  "OpenApiConvertSettings": {
+    "AddEnumDescriptionExtension": true,
+    "AddSingleQuotesForStringParameters": true,
+    "DeclarePathParametersOnPathItem": true,
+    "EnableDiscriminatorValue": false,
+    "EnableDerivedTypesReferencesForRequestBody": false,
+    "EnableDerivedTypesReferencesForResponses": false,
+    "EnableKeyAsSegment": true,
+    "EnableODataAnnotationReferencesForResponses": false,
+    "EnableOperationId": true,
+    "EnablePagination": true,
+    "ExpandDerivedTypesNavigationProperties": false,
+    "PrefixEntityTypeNameBeforeKey": true,
+    "TagDepth": 2,
+    "ShowRootPath": false,
+    "ShowLinks": false
+  }
+}


### PR DESCRIPTION
## Summary

The DevX API, when it receives a request, performs the conversion from CSDL to OpenAPI before returning the converted open api.  This is done in-process. Optimisations have been made to use caching however the conversion process takes time.

This work intends to do the conversion at source so that the DevX API's work is reduced to pure fetching of the document and fulfilling the requests made.

> Conversion settings

I've introduced a `conversion-settings` folder. It holds the OpenAPI conversion settings that will be used to override the default Hidi settings when performing the `publish openapi` build step. 
The pipeline reads through the folder and gets the filenames and spawns new jobs to perform the publish based on the azure pipelines matrix strategy. 
This is going to be useful when it comes to maintenance since the only changes to the generation process happen in this folder. Any new settings are immediately picked up. Deleted ones just reduce the eventually spawned jobs.


## Generated code differences

Once published the files are pushed to the `microsoftgraph/msgraph-metadata` repository and creates a folder structure that looks like this:

    openapi/
    ├── v1.0/
    └── beta/                    # Scoped to beta for brevity. The v1.0 folder should share the same folder structure
        ├── openapi.yml    
        ├── graphexplorer.yml         
        ├── powershell.yml 
        └── ...                # any other introduced platform
    

## Command line arguments to run these changes

No new command lines introduced

## Links to issues or work items this PR addresses