### PR TITLE
Generates PRs from ADO

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -265,6 +265,7 @@ stages:
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
         cleanMetadataFolder: $(cleanMetadataFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/dotnet.yml
           parameters:
@@ -292,6 +293,7 @@ stages:
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
         cleanMetadataFolder: $(cleanMetadataFolderBeta)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/dotnet.yml
           parameters:
@@ -322,6 +324,7 @@ stages:
         targetNamespace: "Microsoft.Graph"
         customArguments: "-b" # Enable the backing store
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/dotnet-kiota.yml
           parameters:
@@ -351,6 +354,7 @@ stages:
         targetNamespace: "Microsoft.Graph.Beta"
         customArguments: "-b" # Enable the backing store
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/dotnet-kiota.yml
           parameters:
@@ -598,6 +602,7 @@ stages:
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
         cleanMetadataFolder: $(cleanMetadataFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/php-v1.yml
           parameters:
@@ -624,6 +629,7 @@ stages:
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
         cleanMetadataFolder: $(cleanMetadataFolderBeta)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/php-beta.yml
           parameters:
@@ -655,6 +661,7 @@ stages:
             targetNamespace: 'Microsoft\\Graph\\Beta\\Generated'
             baseBranchName: 'dev'
             cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
+            generatePullRequest: true
             languageSpecificSteps:
               - template: generation-templates/php-kiota.yml
                 parameters:
@@ -683,6 +690,7 @@ stages:
             targetNamespace: 'Microsoft\\Graph\\Generated'
             baseBranchName: 'feat/kiota-preview'
             cleanMetadataFolder: $(cleanOpenAPIFolderV1)
+            generatePullRequest: true
             languageSpecificSteps:
               - template: generation-templates/php-kiota.yml
                 parameters:
@@ -709,6 +717,7 @@ stages:
         branchName: $(v1Branch)
         cleanMetadataFile: $(cleanMetadataFileV1)
         cleanMetadataFolder: $(cleanMetadataFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/typescript.yml
           parameters:
@@ -735,6 +744,7 @@ stages:
         branchName: $(betaBranch)
         cleanMetadataFile: $(cleanMetadataFileBeta)
         cleanMetadataFolder: $(cleanMetadataFolderBeta)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/typescript.yml
           parameters:
@@ -762,6 +772,7 @@ stages:
         targetClassName: "GraphBaseServiceClient"
         targetNamespace: "github.com/microsoftgraph/msgraph-sdk-typescript/"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/typescript-sdk.yml
           parameters:
@@ -789,6 +800,7 @@ stages:
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/python.yml
           parameters:
@@ -816,6 +828,7 @@ stages:
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
+        generatePullRequest: true
         languageSpecificSteps:
         - template: generation-templates/python.yml
           parameters:

--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -31,6 +31,11 @@ parameters:
   type: string
   default: ''
 
+- name: generatePullRequest
+  default: false
+  type: boolean
+  displayName: Generate PR after publish changes?
+
 - name: customArguments
   type: string
   default: ''
@@ -80,4 +85,14 @@ steps:
     BranchName: ${{ parameters.branchName }}
     PublishChanges: $(publishChanges)
     OverrideSkipCI: $(overrideSkipCI)
+  workingDirectory: ${{ parameters.repoName }}
+
+- pwsh: '$(scriptsDirectory)/create-pull-request.ps1'
+  displayName: 'Create Pull Request for the generated build'
+  env:
+    Version: ${{ parameters.version }}
+    BaseBranch: ${{ parameters.baseBranchName}}
+    OverrideSkipCI: $(overrideSkipCI)
+    GITHUB_TOKEN: $(GithubAuthToken)
+    GeneratePullRequest: ${{ parameters.generatePullRequest}}
   workingDirectory: ${{ parameters.repoName }}

--- a/.azure-pipelines/generation-templates/language-generation.yml
+++ b/.azure-pipelines/generation-templates/language-generation.yml
@@ -24,6 +24,15 @@ parameters:
 - name: cleanMetadataFolder
   type: string
 
+- name: baseBranchName
+  type: string
+  default: ''
+
+- name: generatePullRequest
+  default: false
+  type: boolean
+  displayName: Generate PR after publish changes?
+
 steps:
 - template: set-up-for-generation.yml
   parameters:
@@ -69,4 +78,14 @@ steps:
     BranchName: ${{ parameters.branchName }}
     PublishChanges: $(publishChanges)
     OverrideSkipCI: $(overrideSkipCI)
+  workingDirectory: ${{ parameters.repoName }}
+
+- pwsh: '$(scriptsDirectory)/create-pull-request.ps1'
+  displayName: 'Create Pull Request for the generated build'
+  env:
+    Version: ${{ parameters.version }}
+    BaseBranch: ${{ parameters.baseBranchName}}
+    OverrideSkipCI: $(overrideSkipCI)
+    GITHUB_TOKEN: $(GithubAuthToken)
+    GeneratePullRequest: ${{ parameters.generatePullRequest}}
   workingDirectory: ${{ parameters.repoName }}

--- a/scripts/create-pull-request.ps1
+++ b/scripts/create-pull-request.ps1
@@ -1,0 +1,26 @@
+if (($env:OverrideSkipCI -eq $False) -and ($env:BUILD_REASON -eq 'Manual')) # Skip CI if manually running this pipeline.
+{
+    Write-Host "Skipping pull request creation due Skip CI." -ForegroundColor Green
+    return;
+}
+
+if (($env:GeneratePullRequest -eq $False)) { # Skip CI if manually running this pipeline.
+    Write-Host "Skipping pull request creation due this repository being disabled" -ForegroundColor Green
+    return;
+}
+
+$version = $env:Version
+$title = "Generated $version models and request builders"
+$body = "This pull request was automatically created by Azure Pipelines. **Important** Check for unexpected deletions or changes in this PR."
+$baseBranchParameter = ""
+
+if (![string]::IsNullOrEmpty($env:BaseBranch))
+{
+    $baseBranchParameter = "-B $env:BaseBranch" # optionally pass the base branch if provided as the PR will target the default branch otherwise
+}
+
+ # No need to specify reviewers as code owners should be added automatically.
+Invoke-Expression "gh auth login" # login to GitHub
+Invoke-Expression "gh pr create -t ""$title"" -b ""$body"" $baseBranchParameter | Write-Host"
+
+Write-Host "Pull Request Created successfully." -ForegroundColor Green


### PR DESCRIPTION
This updates the generation pipeline to be able to generate PRs by adding a optional step to generate PR if skipCI conditions are met and can be enabled per repository.

Due to some repositories having working mechanisms at the moment such as Go, Ruby, Java this behaviour is disabled by default and is opt-in.

Sample run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=106646&view=logs&j=11f01158-f524-5966-40fd-acf3ebd4803b&t=7b03cdbb-a21e-5d67-a9fd-922bc6e7df2b

Sample PR - https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1652

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/946)