### PR TITLE
Use distinct methods in collection request builders in java

### DIFF
--- a/Templates/templates/Java/requests/BaseEntityCollectionRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseEntityCollectionRequestBuilder.java.tt
@@ -13,7 +13,7 @@ import <#=mainNamespace#>.<#=TypeHelperJava.GetPrefixForRequests()#>.<#=c.TypeCo
 <#
 var currentTypeProjection = c.AsOdcmProperty().Projection.Type.AsOdcmClass();
 if (currentTypeProjection != null) {
-    foreach (var method in currentTypeProjection.MethodsAndOverloads()) {
+    foreach (var method in currentTypeProjection.MethodsAndOverloadsWithDistinctName()) {
         if (!method.IsBoundToCollection) {
             continue;
         }
@@ -68,7 +68,7 @@ import <#=method#>;
 
 <#
 if (currentTypeProjection != null) {
-    foreach (var method in currentTypeProjection.MethodsAndOverloads()) {
+    foreach (var method in currentTypeProjection.MethodsAndOverloadsWithDistinctName()) {
 
         if (!method.IsBoundToCollection) {
             continue;


### PR DESCRIPTION
This PR partially addresses the failure at https://github.com/microsoftgraph/msgraph-beta-sdk-java/actions/runs/4296032145/jobs/7487243083

It ensures the collection request builder picks up the unique methods and does not regenerate inherited methods if there's one already declared.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/966)