### PR TITLE
Fixes multiple constrcutors in java

### DIFF
--- a/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
+++ b/Templates/templates/Java/requests/BaseMethodRequestBuilder.java.tt
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 <#if(c.AsOdcmMethod().WithOverloadsOfDistinctName().Any(x => x.MethodHasParameters()) && isAction) { #>
     private <#=c.AsOdcmMethod().TypeParameterSet() #> body;
 <# } #>
-<# foreach(var method in c.AsOdcmMethod().WithOverloadsOfDistinctName()) { #>
+<# foreach(var method in c.AsOdcmMethod().WithOverloadsOfDistinctNameIgnoringCollectionBinding()) { #>
     /**
      * The request builder for this <#=c.TypeName()#>
      *

--- a/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
+++ b/src/GraphODataTemplateWriter/Extensions/OdcmModelExtensions.cs
@@ -704,6 +704,12 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
             CompareParametersCount = false,
             CompareHasParameters = true
         };
+        private static readonly OdcmMethodEqualityComparer methodNameAndParametersCountAndIgnoreCollectionBindingComparer = new OdcmMethodEqualityComparer {
+            CompareParameters = false,
+            CompareParametersCount = false,
+            CompareHasParameters = true,
+            CompareBoundToCollection = false
+        };
         public static IEnumerable<OdcmMethod> MethodsAndOverloadsWithDistinctName(this OdcmClass odcmClass)
         {
             return odcmClass
@@ -715,6 +721,11 @@ namespace Microsoft.Graph.ODataTemplateWriter.Extensions
         public static IEnumerable<OdcmMethod> WithOverloadsOfDistinctName(this OdcmMethod m)
         {
             return m?.WithOverloads()?.Distinct(methodNameAndParametersCountComparer) ?? Enumerable.Empty<OdcmMethod>();
+        }
+        
+        public static IEnumerable<OdcmMethod> WithOverloadsOfDistinctNameIgnoringCollectionBinding(this OdcmMethod m)
+        {
+            return m?.WithOverloads()?.Distinct(methodNameAndParametersCountAndIgnoreCollectionBindingComparer) ?? Enumerable.Empty<OdcmMethod>();
         }
 
         /// <summary>

--- a/src/GraphODataTemplateWriter/OdcmMethodEqualityComparer.cs
+++ b/src/GraphODataTemplateWriter/OdcmMethodEqualityComparer.cs
@@ -19,10 +19,15 @@ namespace Microsoft.Graph.ODataTemplateWriter
         {
             get; set;
         } = false;
+        public bool CompareBoundToCollection
+        {
+            get; set;
+        } = true;
         private static readonly OdcmParameterCollectionEqualityComparer paramComparer = new OdcmParameterCollectionEqualityComparer();
         public bool Equals(OdcmMethod x, OdcmMethod y)
         {
-            return x.FullName == y.FullName && x.IsBoundToCollection == y.IsBoundToCollection &&
+            return x.FullName == y.FullName && 
+                 (!CompareBoundToCollection || x.IsBoundToCollection == y.IsBoundToCollection) &&
                 (!CompareParameters || paramComparer.Equals(y?.Parameters, x?.Parameters)) &&
                 (!CompareParametersCount || y?.Parameters?.Count == x?.Parameters?.Count) &&
                 (!CompareHasParameters || y?.Parameters?.Any() == x?.Parameters?.Any());

--- a/test/Typewriter.Test/Metadata/MetadataMultipleNamespaces.xml
+++ b/test/Typewriter.Test/Metadata/MetadataMultipleNamespaces.xml
@@ -244,6 +244,11 @@
         <Parameter Name="mailNickname" Type="Edm.String" Unicode="false" />
         <Parameter Name="onBehalfOfUserId" Type="Edm.Guid" />
       </Action>
+      <Action Name="validateProperties" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(graph.user)" Nullable="false" />
+        <Parameter Name="displayName" Type="Edm.String" Unicode="false" />
+        <Parameter Name="mailNickname" Type="Edm.String" Unicode="false" />
+      </Action>
       <Action Name="validateProperties" IsBound="true" EntitySetPath="bindingParameter">
         <Parameter Name="bindingParameter" Type="Collection(graph.directoryObject)" Nullable="false" />
         <Parameter Name="entityType" Type="Edm.String" Unicode="false" />

--- a/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UserValidatePropertiesRequestBuilder.cs
+++ b/test/Typewriter.Test/TestDataCSharp/com/microsoft/graph/requests/UserValidatePropertiesRequestBuilder.cs
@@ -40,6 +40,24 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
+        /// Constructs a new <see cref="UserValidatePropertiesRequestBuilder"/>.
+        /// </summary>
+        /// <param name="requestUrl">The URL for the request.</param>
+        /// <param name="client">The <see cref="IBaseClient"/> for handling requests.</param>
+        /// <param name="displayName">A displayName parameter for the OData method call.</param>
+        /// <param name="mailNickname">A mailNickname parameter for the OData method call.</param>
+        public UserValidatePropertiesRequestBuilder(
+            string requestUrl,
+            IBaseClient client,
+            string displayName,
+            string mailNickname)
+            : base(requestUrl, client)
+        {
+            this.SetParameter("displayName", displayName, true);
+            this.SetParameter("mailNickname", mailNickname, true);
+        }
+
+        /// <summary>
         /// A method used by the base class to construct a request class instance.
         /// </summary>
         /// <param name="functionUrl">The request URL to </param>

--- a/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJava/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import com.microsoft.graph.requests.UserCollectionRequestBuilder;
 import com.microsoft.graph.requests.UserRequestBuilder;
 import com.microsoft.graph.requests.UserCollectionRequest;
-import com.microsoft.graph.requests.DirectoryObjectValidatePropertiesRequestBuilder;
+import com.microsoft.graph.requests.UserValidatePropertiesRequestBuilder;
 import com.microsoft.graph.http.BaseCollectionRequestBuilder;
 import com.microsoft.graph.core.IBaseClient;
 import com.microsoft.graph.http.PrimitiveRequestBuilder;
@@ -52,8 +52,8 @@ public class UserCollectionRequestBuilder extends BaseCollectionRequestBuilder<U
      * @param parameters the parameters for the service method
      */
     @Nonnull
-    public DirectoryObjectValidatePropertiesRequestBuilder validateProperties(@Nonnull final DirectoryObjectValidatePropertiesParameterSet parameters) {
-        return new DirectoryObjectValidatePropertiesRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.validateProperties"), getClient(), null, parameters);
+    public UserValidatePropertiesRequestBuilder validateProperties(@Nonnull final UserValidatePropertiesParameterSet parameters) {
+        return new UserValidatePropertiesRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.validateProperties"), getClient(), null, parameters);
     }
 
     /**

--- a/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
+++ b/test/Typewriter.Test/TestDataJavaBeta/com/microsoft/graph/requests/UserCollectionRequestBuilder.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import com.microsoft.graph.requests.UserCollectionRequestBuilder;
 import com.microsoft.graph.requests.UserRequestBuilder;
 import com.microsoft.graph.requests.UserCollectionRequest;
-import com.microsoft.graph.requests.DirectoryObjectValidatePropertiesRequestBuilder;
+import com.microsoft.graph.requests.UserValidatePropertiesRequestBuilder;
 import com.microsoft.graph.http.BaseCollectionRequestBuilder;
 import com.microsoft.graph.core.IBaseClient;
 import com.microsoft.graph.http.PrimitiveRequestBuilder;
@@ -52,8 +52,8 @@ public class UserCollectionRequestBuilder extends BaseCollectionRequestBuilder<U
      * @param parameters the parameters for the service method
      */
     @Nonnull
-    public DirectoryObjectValidatePropertiesRequestBuilder validateProperties(@Nonnull final DirectoryObjectValidatePropertiesParameterSet parameters) {
-        return new DirectoryObjectValidatePropertiesRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.validateProperties"), getClient(), null, parameters);
+    public UserValidatePropertiesRequestBuilder validateProperties(@Nonnull final UserValidatePropertiesParameterSet parameters) {
+        return new UserValidatePropertiesRequestBuilder(getRequestUrlWithAdditionalSegment("microsoft.graph.validateProperties"), getClient(), null, parameters);
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/532

Fixes the incorrect generation of multiple constructors when an action/function is both bound to a type and a collection of the type.

This is done by adding a method comparer that can ignore checking if the method is bound to a collection.

Test metadata has been updated to capture this and updated generation at https://github.com/microsoftgraph/msgraph-beta-sdk-java/pull/534

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/973)