### PR TITLE
Only publish the updated yaml file.

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -81,7 +81,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: ${{ parameters.outputPath }}
-      contents: '**/*'
+      contents: '**/$(Name).yaml'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
     displayName: Copy generated metadata
 


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1752#issuecomment-1477780228

The parallel stages for caputuring the openAPI files publish all the 4 yaml files but only update one of the files. This causes subsequent stages to potentially use unmodified/stale version as the publish stage end up publishing the same file used before. 

This PR updates the publishing of artifacts to only publish the file generated at the specified step to avoid the situation above. 

Sample generation run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=110760&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/977)