### PR TITLE
Fix: conditionally generate OpenAPI documents

### DIFF
--- a/scripts/generate-open-api.ps1
+++ b/scripts/generate-open-api.ps1
@@ -24,7 +24,16 @@ param(
 $outputFile = Join-Path "./" "openapi" $endpointVersion "$platformName.yaml"
 $oldOutputFile = "$outputFile.old"
 $cleanVersion = $endpointVersion.Replace(".", "")
-$inputFile = Join-Path "./" "clean_$($cleanVersion)_metadata" "cleanMetadataWithDescriptionsAndAnnotationsAndErrors$endpointVersion.xml"
+
+# The clean metadata file name is different for openapi and other versions
+$baseFileName = "cleanMetadataWithDescriptionsAndAnnotations";
+if($platformName -eq "openapi")
+{
+    $baseFileName += "AndErrors";
+}
+$fileName = "$baseFileName$endpointVersion.xml";
+
+$inputFile = Join-Path "./" "clean_$($cleanVersion)_metadata" "$fileName"
 Write-Host "Settings: $settings"
 Write-Verbose "Generating OpenAPI description from $inputFile"
 Write-Verbose "Output file: $outputFile"


### PR DESCRIPTION
## Summary

The main OpenAPI document should generate from the document  with the Errors annotations while others do not need these files.

Fixes #980 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/983)