### PR TITLE
Update hidi transform command to include the endpoint version

### DIFF
--- a/scripts/generate-open-api.ps1
+++ b/scripts/generate-open-api.ps1
@@ -51,7 +51,7 @@ if(Test-Path $outputFile)
     Rename-Item $outputFile $oldFileName
 }
 
-$command = "hidi transform --csdl ""$inputFile"" --output ""$outputFile"" --settings-path ""$settings"" --version OpenApi3_0 --log-level Information --format yaml"
+$command = "hidi transform --csdl ""$inputFile"" --output ""$outputFile"" --settings-path ""$settings"" --version OpenApi3_0 --metadata-version ""$endpointVersion"" --log-level Information --format yaml"
 Write-Host $command
 
 try {


### PR DESCRIPTION
## Summary
Update OpenAPI generation script by adding a metadata version as a command-line argument during conversion

## Command line arguments to run these changes

`hidi transform --csdl ""$inputFile"" --output ""$outputFile"" --settings-path ""$settings"" --version OpenApi3_0 --metadata-version ""$endpointVersion"" --log-level Information --format yaml`
