### PR TITLE
- fixes a racing condition when publishing openapi descriptions

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -99,9 +99,6 @@ jobs:
 - job: publish_openapi
   dependsOn: convert_openapi
   displayName: Publish
-  variables:
-    targets: $[ dependencies.get_conversion_settings.outputs['setTargets.targets'] ]
-
   steps:
   # We only need the scripts
   - checkout: self

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -61,7 +61,6 @@ jobs:
     persistCredentials: true
 
   - template: checkout-metadata.yml
-  - template: set-user-config.yml
   - template: use-dotnet-sdk.yml
 
   - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
@@ -106,6 +105,8 @@ jobs:
     fetchDepth: 1
     persistCredentials: true
 
+  - template: checkout-metadata.yml
+  - template: set-user-config.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       path: $(Build.SourcesDirectory)/msgraph-metadata/openapi/${{ parameters.endpoint }}

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -45,9 +45,9 @@ jobs:
   - script: echo $(setTargets.targets)
     displayName: "Print settings"
 
-- job: publish_openapi
+- job: convert_openapi
   dependsOn: get_conversion_settings
-  displayName: Publish
+  displayName: Convert
   strategy:
     matrix: $[ dependencies.get_conversion_settings.outputs['setTargets.targets'] ]
   variables:
@@ -94,6 +94,25 @@ jobs:
       ./scripts/run-openapi-validation.ps1 -repoDirectory (Get-Location).Path -version "${{ parameters.endpoint }}" -platformName "$(Name)"
     displayName: ensure that OpenAPI docs can be parsed
     workingDirectory: $(Build.SourcesDirectory)/msgraph-metadata
+
+
+- job: publish_openapi
+  dependsOn: convert_openapi
+  displayName: Publish
+  variables:
+    targets: $[ dependencies.get_conversion_settings.outputs['setTargets.targets'] ]
+
+  steps:
+  # We only need the scripts
+  - checkout: self
+    displayName: checkout generator
+    fetchDepth: 1
+    persistCredentials: true
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      path: $(Build.SourcesDirectory)/msgraph-metadata/openapi/${{ parameters.endpoint }}
+      artifact: ${{ parameters.cleanMetadataFolder }}
 
   # Checkin clean metadata into metadata repo or make it an artifact.
   - pwsh: '$(scriptsDirectory)/git-push-cleanmetadata.ps1'


### PR DESCRIPTION
since we've added multiple open api convert settings and profiles, the conversion job often gets caught in a racing condition. This change commits all the files for a given version to reduce the likeliness of that happening. Ideally we'd do it for both versions at once but we'd lose the ability to generate for a single version at a time if we did that unless we seriously revamp the pipeline definition to use a matrix for versions for that aspect

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/995)