### PR TITLE
dev

### DIFF
--- a/scripts/generate-open-api.ps1
+++ b/scripts/generate-open-api.ps1
@@ -24,7 +24,16 @@ param(
 $outputFile = Join-Path "./" "openapi" $endpointVersion "$platformName.yaml"
 $oldOutputFile = "$outputFile.old"
 $cleanVersion = $endpointVersion.Replace(".", "")
-$inputFile = Join-Path "./" "clean_$($cleanVersion)_metadata" "cleanMetadataWithDescriptionsAndAnnotationsAndErrors$endpointVersion.xml"
+
+# The clean metadata file name is different for openapi and other versions
+$baseFileName = "cleanMetadataWithDescriptionsAndAnnotations";
+if($platformName -eq "openapi")
+{
+    $baseFileName += "AndErrors";
+}
+$fileName = "$baseFileName$endpointVersion.xml";
+
+$inputFile = Join-Path "./" "clean_$($cleanVersion)_metadata" "$fileName"
 Write-Host "Settings: $settings"
 Write-Verbose "Generating OpenAPI description from $inputFile"
 Write-Verbose "Output file: $outputFile"


### PR DESCRIPTION
- Bump apidoctor from `87e6174` to `f404708` (#991)
- Bump apidoctor from `f404708` to `ee2ce2d`
- Bump apidoctor from `ee2ce2d` to `ae3bab8`
- - fixes a racing condition when publishing openapi descriptions
- - cleans unecessary variable
- - adds missing steps to push open api descriptions
- Bump apidoctor from `ae3bab8` to `02368f3`
