### PR TITLE
Exclude me endpoint from generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -736,6 +736,7 @@ stages:
         branchName: $(v1Branch)
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
+        customArguments: "-e '/me' -e '/me/**'" # Exclude me
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
         - template: generation-templates/python.yml
@@ -763,6 +764,7 @@ stages:
         branchName: $(betaBranch)
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
+        customArguments: "-e '/me' -e '/me/**'" # Exclude me
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/python.yml


### PR DESCRIPTION
## Summary
Skips generation of me endpoint to reduce SDK size


## Generated code differences

Pull requests that result in changes to generated code and/or directory structures should include example diffs of the resulting changes. This makes code review much easier.

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses
Part of https://github.com/microsoftgraph/msgraph-sdk-python/issues/150

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1001)