### PR TITLE
Fix/go filter change notification

### DIFF
--- a/scripts/clean-go-files.ps1
+++ b/scripts/clean-go-files.ps1
@@ -1,6 +1,6 @@
 $directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", ".github" , "tests")
 foreach ($directory in $directories) {
-	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose
+	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose -Exclude *change_notification*, "change_type.go", "lifecycle_event_type.go", "resource_data.go", "resource_permission.go" , "resource_permission_collection_response.go"
 }
 Remove-Item -Path $env:MainDirectory -Filter "*.go" -Exclude "graph_request_adapter.go", "graph_service_client.go" -Verbose
 


### PR DESCRIPTION
## Summary

Retains change notification models  in Go SDK as these are no longer generated by kiota, as a result of a change to generate models only directly used in builders e.t.c, but are required in actual usecases by devs i.e resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/481

## Generated code differences

Retains the models added in PR https://github.com/microsoftgraph/msgraph-sdk-go/pull/509 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1028)