### PR TITLE
Enable backing store during python generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -738,7 +738,7 @@ stages:
         branchName: $(v1Branch)
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
-        customArguments: "-e '/me' -e '/me/**'" # Exclude me
+        customArguments: "-b -e '/me' -e '/me/**'" # Enable backing store, Exclude me
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
         - template: generation-templates/python.yml
@@ -766,7 +766,7 @@ stages:
         branchName: $(betaBranch)
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "msgraph.generated"
-        customArguments: "-e '/me' -e '/me/**'" # Exclude me
+        customArguments: "-b -e '/me' -e '/me/**'" # Enable backing store, Exclude me
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/python.yml


### PR DESCRIPTION
## Summary

Enables the backing store by default for Python v1 and Beta.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1055&drop=dogfoodAlpha