### PR TITLE
Enable backing store for next version of Java generation

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -497,7 +497,7 @@ stages:
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "com.Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
-        customArguments: "-e '/me' -e '/me/**'" # Exclude /me
+        customArguments: "-b -e '/me' -e '/me/**'" # Exclude /me/** and enable backing store
         languageSpecificSteps:
         - template: generation-templates/java-kiota.yml
           parameters:
@@ -526,7 +526,7 @@ stages:
         targetClassName: "BaseGraphServiceClient"
         targetNamespace: "com.Microsoft.Graph"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
-        customArguments: "-e '/me' -e '/me/**'" # Exclude /me
+        customArguments: "-b -e '/me' -e '/me/**'" # Exclude /me/** and enable backing store
         languageSpecificSteps:
         - template: generation-templates/java-kiota.yml
           parameters:


### PR DESCRIPTION
In preparation for the release candidate of the next version of the Java SDK we must enable the backing store. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1088)