### PR TITLE
Updates beta metadata source

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -158,7 +158,7 @@ variables:
   cleanMetadataFolderV1: 'clean_v10_metadata'
   cleanOpenAPIFolderBeta: 'clean_beta_openapi'
   cleanOpenAPIFolderV1: 'clean_v10_openapi'
-  rawMetadataFileBeta: 'https://graph.microsoft.com/beta/$metadata'
+  rawMetadataFileBeta: '$(Build.SourcesDirectory)/msgraph-metadata/schemas/beta-Prod.csdl'
   rawMetadataFileV1: 'https://graph.microsoft.com/v1.0/$metadata' # We want to run against the metadata we have captured.
   typewriterDirectory: '$(Build.SourcesDirectory)/typewriter'
   kiotaDirectory: '$(Build.SourcesDirectory)/kiota'

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -47,6 +47,7 @@ steps:
     errorOnNoChange: 1
     endpointVersion: ${{ parameters.endpoint }}
     targetBranch: 'master'
+    InputMetadataFile: ${{ parameters.inputMetadata }}
   enabled: true
 
 - template: download-typewriter.yml

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -47,7 +47,7 @@ steps:
     errorOnNoChange: 1
     endpointVersion: ${{ parameters.endpoint }}
     targetBranch: 'master'
-    InputMetadataFile: ${{ parameters.inputMetadata }}
+    inputMetadataFile: ${{ parameters.inputMetadata }}
   enabled: true
 
 - template: download-typewriter.yml

--- a/scripts/download-diff-metadata.ps1
+++ b/scripts/download-diff-metadata.ps1
@@ -49,7 +49,7 @@ if ($branch -ne $env:targetBranch) {
     git pull origin $env:targetBranch --ff-only | Write-Host
 }
 
-if ($env:inputMetadataFile.StartsWith("http")){    
+if ($env:inputMetadataFile.StartsWith("http", [StringComparison]::OrdinalIgnoreCase)){    
     # Download metadata from livesite.
     $url = "https://graph.microsoft.com/{0}/`$metadata" -f $env:endpointVersion
     $metadataFileName = "{0}_metadata.xml" -f $env:endpointVersion

--- a/scripts/download-diff-metadata.ps1
+++ b/scripts/download-diff-metadata.ps1
@@ -49,14 +49,8 @@ if ($branch -ne $env:targetBranch) {
     git pull origin $env:targetBranch --ff-only | Write-Host
 }
 
-if ($env:endpointVersion -eq "beta"){
-    # Retrieve the beta metadata from ./schemas folder in metadata repo
-    Write-Host "Retrieving metadata from $env:InputMetadataFile" -ForegroundColor DarkGreen
-    $content = Format-Xml (Get-Content $env:InputMetadataFile)
-    Write-Host "Retrieved metadata from $env:InputMetadataFile" -ForegroundColor DarkGreen
-}
-else{ 
-    # Download the v1.0 metadata from livesite.
+if ($env:inputMetadataFile.StartsWith("http")){    
+    # Download metadata from livesite.
     $url = "https://graph.microsoft.com/{0}/`$metadata" -f $env:endpointVersion
     $metadataFileName = "{0}_metadata.xml" -f $env:endpointVersion
     $pathToLiveMetadata = Join-Path -Path ($pwd).path -ChildPath $metadataFileName
@@ -70,6 +64,12 @@ else{
     $content = Format-Xml (Get-Content $pathToLiveMetadata)
     [IO.File]::WriteAllLines($pathToLiveMetadata, $content)
     Write-Host "Wrote $metadataFileName to disk. Now git will tell us whether there are changes." -ForegroundColor DarkGreen
+}
+else{
+    # Retrieve the metadata from ./schemas folder in the metadata repo.
+    Write-Host "Retrieving metadata from $env:inputMetadataFile" -ForegroundColor DarkGreen
+    $content = Format-Xml (Get-Content $env:inputMetadataFile)
+    Write-Host "Retrieved metadata from $env:inputMetadataFile" -ForegroundColor DarkGreen    
 }
 
 # Discover if there are changes between the downloaded file and what is in git.

--- a/scripts/download-diff-metadata.ps1
+++ b/scripts/download-diff-metadata.ps1
@@ -49,20 +49,28 @@ if ($branch -ne $env:targetBranch) {
     git pull origin $env:targetBranch --ff-only | Write-Host
 }
 
-# Download the metadata from livesite.
-$url = "https://graph.microsoft.com/{0}/`$metadata" -f $env:endpointVersion
-$metadataFileName = "{0}_metadata.xml" -f $env:endpointVersion
-$pathToLiveMetadata = Join-Path -Path ($pwd).path -ChildPath $metadataFileName
-$client = new-object System.Net.WebClient
-$client.Encoding = [System.Text.Encoding]::UTF8
-Write-Host "Attempting to downloaded metadata from $url to $pathToLiveMetadata" -ForegroundColor DarkGreen
-$client.DownloadFile($url, $pathToLiveMetadata)
-Write-Host "Downloaded metadata from $url to $pathToLiveMetadata" -ForegroundColor DarkGreen
+if ($env:endpointVersion -eq "beta"){
+    # Retrieve the beta metadata from ./schemas folder in metadata repo
+    Write-Host "Retrieving metadata from $env:InputMetadataFile" -ForegroundColor DarkGreen
+    $content = Format-Xml (Get-Content $env:InputMetadataFile)
+    Write-Host "Retrieved metadata from $env:InputMetadataFile" -ForegroundColor DarkGreen
+}
+else{ 
+    # Download the v1.0 metadata from livesite.
+    $url = "https://graph.microsoft.com/{0}/`$metadata" -f $env:endpointVersion
+    $metadataFileName = "{0}_metadata.xml" -f $env:endpointVersion
+    $pathToLiveMetadata = Join-Path -Path ($pwd).path -ChildPath $metadataFileName
+    $client = new-object System.Net.WebClient
+    $client.Encoding = [System.Text.Encoding]::UTF8
+    Write-Host "Attempting to download metadata from $url to $pathToLiveMetadata" -ForegroundColor DarkGreen
+    $client.DownloadFile($url, $pathToLiveMetadata)
+    Write-Host "Downloaded metadata from $url to $pathToLiveMetadata" -ForegroundColor DarkGreen
 
-# Format the metadata to make it easy for us hoomans to read and perform non-markup line based diffs.
-$content = Format-Xml (Get-Content $pathToLiveMetadata)
-[IO.File]::WriteAllLines($pathToLiveMetadata, $content)
-Write-Host "Wrote $metadataFileName to disk. Now git will tell us whether there are changes." -ForegroundColor DarkGreen
+    # Format the metadata to make it easy for us hoomans to read and perform non-markup line based diffs.
+    $content = Format-Xml (Get-Content $pathToLiveMetadata)
+    [IO.File]::WriteAllLines($pathToLiveMetadata, $content)
+    Write-Host "Wrote $metadataFileName to disk. Now git will tell us whether there are changes." -ForegroundColor DarkGreen
+}
 
 # Discover if there are changes between the downloaded file and what is in git.
 [array]$result = git status --porcelain


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-metadata/issues/203

Switches the source of beta metadata from the live site (https://graph.microsoft.com/beta/$metadata) to the CSDL files in the _./schema_ folder in the metadata repo. This file gets maintained by the Identity folks and it is an annotation-enriched version of the live site file.

We are validating and testing this move with the `beta` metadata first then switch over v1.0 later.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1113)