### PR TITLE
Rsh/java generation file paths

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -502,6 +502,7 @@ stages:
         - template: generation-templates/java-kiota.yml
           parameters:
             repoName: msgraph-sdk-java
+            pathToGeneratedModels: src/main/java/com/microsoft/graph/generated/ 
 
 - stage: stage_java_beta_kiota
   dependsOn:
@@ -524,13 +525,15 @@ stages:
         baseBranchName: 'feature/6.0'
         branchName: 'kiota/$(betaBranch)'
         targetClassName: "BaseGraphServiceClient"
-        targetNamespace: "com.Microsoft.Graph"
+        targetNamespace: "com.Microsoft.Graph.Beta"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         customArguments: "-b -e '/me' -e '/me/**'" # Exclude /me/** and enable backing store
         languageSpecificSteps:
         - template: generation-templates/java-kiota.yml
           parameters:
             repoName: msgraph-beta-sdk-java
+            pathToGeneratedModels: src/main/java/com/microsoft/graph/beta/generated/
+
 
 - stage: stage_php_beta_kiota
   dependsOn:

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -502,7 +502,7 @@ stages:
         - template: generation-templates/java-kiota.yml
           parameters:
             repoName: msgraph-sdk-java
-            pathToGeneratedModels: src/main/java/com/microsoft/graph/generated/ 
+            namespacePath: com/microsoft/graph
 
 - stage: stage_java_beta_kiota
   dependsOn:
@@ -532,7 +532,7 @@ stages:
         - template: generation-templates/java-kiota.yml
           parameters:
             repoName: msgraph-beta-sdk-java
-            pathToGeneratedModels: src/main/java/com/microsoft/graph/beta/generated/
+            namespacePath: com/microsoft/graph/beta
 
 
 - stage: stage_php_beta_kiota

--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -1,18 +1,18 @@
 parameters: 
 - name: repoName 
   type: string
-- name: pathToGeneratedModels
+- name: namespacePath
   type: string
 
 steps:
 - pwsh: '$(scriptsDirectory)/clean-java-files-kiota.ps1'
   displayName: 'Remove generated models and requests from the repo'
   env:
-    MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/${{ parameters.pathToGeneratedModels }}
+    MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/
 
 - pwsh: '$(scriptsDirectory)/copy-java-models-kiota.ps1'
   displayName: 'Update with new models'
   env: 
     BuildConfiguration: $(buildConfiguration) 
-    OutputFullPath: $(kiotaDirectory)/output/*
-    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/${{ parameters.pathToGeneratedModels }}
+    OutputFullPath: $(kiotaDirectory)/output/${{ parameters.namespacePath }}/*
+    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/

--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -1,16 +1,18 @@
 parameters: 
 - name: repoName 
   type: string
+- name: pathToGeneratedModels
+  type: string
 
 steps:
 - pwsh: '$(scriptsDirectory)/clean-java-files-kiota.ps1'
   displayName: 'Remove generated models and requests from the repo'
   env:
-    MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/com/microsoft/graph/
+    MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/${{ parameters.pathToGeneratedModels }}
 
 - pwsh: '$(scriptsDirectory)/copy-java-models-kiota.ps1'
   displayName: 'Update with new models'
   env: 
     BuildConfiguration: $(buildConfiguration) 
     OutputFullPath: $(kiotaDirectory)/output/*
-    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/
+    RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/${{ parameters.pathToGeneratedModels }}


### PR DESCRIPTION
Java-Kiota generated files will now live in following file paths:
v1:
src/main/java/com/microsoft/graph/generated/*
beta:
src/main/java/com/microsoft/graph/beta/generated/*

Generated pr's should put the generated code in the corresponding folders. 

Also, beta lib namespace/package name has changed to com.microsoft.graph.beta to disambiguate between v1 and beta. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1121)