### PR TITLE
Revert "Switches `v1.0` metadata source from livesite to local CSDL file in metadata repo."

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -159,7 +159,7 @@ variables:
   cleanOpenAPIFolderBeta: 'clean_beta_openapi'
   cleanOpenAPIFolderV1: 'clean_v10_openapi'
   rawMetadataFileBeta: '$(Build.SourcesDirectory)/msgraph-metadata/schemas/beta-Prod.csdl'
-  rawMetadataFileV1: '$(Build.SourcesDirectory)/msgraph-metadata/schemas/v1.0-Prod.csdl'
+  rawMetadataFileV1: 'https://graph.microsoft.com/v1.0/$metadata' # We want to run against the metadata we have captured.
   typewriterDirectory: '$(Build.SourcesDirectory)/typewriter'
   kiotaDirectory: '$(Build.SourcesDirectory)/kiota'
   typewriterExecutable: '$(typewriterDirectory)/Typewriter'


### PR DESCRIPTION
Reverts microsoftgraph/MSGraph-SDK-Code-Generator#1140

(temp revert of that change because it seems to be causing over-expansion, currently investigating)
https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=131797&view=results
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1141)