### PR TITLE
Fix missing new lines in openapi doc

### DIFF
--- a/scripts/generate-open-api.ps1
+++ b/scripts/generate-open-api.ps1
@@ -57,7 +57,7 @@ Write-Host $command
 try {
     Invoke-Expression "$command"
     # temporary fix for the server url https://github.com/microsoftgraph/msgraph-metadata/issues/124
-    $content = get-content $outputFile
+    $content = Get-Content $outputFile -Raw
     $updatedContent = $content -replace "http://localhost", "https://graph.microsoft.com/$endpointVersion"
     Set-Content $outputFile $updatedContent -NoNewline
     if(Test-Path $oldOutputFile)


### PR DESCRIPTION
Changes in https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1142 added the `-NoNewline` parameter to the `Set-Content` command.

However, as `Get-Content` is called without `-Raw` parameter, the content is split to multiple strings therefore results to all the newlines in the file removed causing parsing errors. 

This PR ensures the file content is read appropriately to prevent an unparsable yaml
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1149)