### PR TITLE
Add incrementMinorVersion script to java again

### DIFF
--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -1,5 +1,5 @@
-parameters: 
-- name: repoName 
+parameters:
+- name: repoName
   type: string
 - name: namespacePath
   type: string
@@ -10,9 +10,13 @@ steps:
   env:
     MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/
 
+- pwsh : $(Build.SourcesDirectory)/${{ parameters.repoName }}/Scripts/incrementMinorVersion.ps1
+  displayName: 'Increment minor version number'
+  workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.repoName }}/Scripts'
+
 - pwsh: '$(scriptsDirectory)/copy-java-models-kiota.ps1'
   displayName: 'Update with new models'
-  env: 
-    BuildConfiguration: $(buildConfiguration) 
+  env:
+    BuildConfiguration: $(buildConfiguration)
     OutputFullPath: $(kiotaDirectory)/output/${{ parameters.namespacePath }}/*
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/


### PR DESCRIPTION
Part of the Java pipeline included the incrementMinorVersion script, this was never added to the Kiota versions since preview never required a version bump. This should be reintroduced now that iv6 is GA. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1168)