### PR TITLE
Fixes generation pipeline

### DIFF
--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -1,7 +1,5 @@
 steps:
 - template: use-dotnet-sdk.yml
-  parameters:
-    version: '8.x' # Kiota is a NET8 app
 
 - checkout: kiota
   displayName: checkout kiota

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -115,7 +115,7 @@ steps:
 
 - template: use-dotnet-sdk.yml
   parameters:
-    version: '6.x' # verify tool is NET6 app
+    version: '7.x' # Hidi tool is NET7 app
 
 # verify that generated metadata is parsable as an Edm model
 - pwsh: $(Build.SourcesDirectory)/msgraph-metadata/scripts/run-metadata-validation.ps1 -repoDirectory "$(Build.SourcesDirectory)/msgraph-metadata/" -version "${{ parameters.endpoint }}"

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -62,6 +62,8 @@ jobs:
 
   - template: checkout-metadata.yml
   - template: use-dotnet-sdk.yml
+    parameters:
+    version: '7.x' # Hidi tool is NET7 app
 
   - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
     displayName: install hidi

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -63,7 +63,7 @@ jobs:
   - template: checkout-metadata.yml
   - template: use-dotnet-sdk.yml
     parameters:
-    version: '7.x' # Hidi tool is NET7 app
+      version: '7.x' # Hidi tool is NET7 app
 
   - pwsh: dotnet tool install -g Microsoft.OpenApi.Hidi --prerelease
     displayName: install hidi

--- a/.azure-pipelines/generation-templates/set-up-for-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation-kiota.yml
@@ -10,8 +10,7 @@ parameters:
 steps:
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
-  parameters:
-    version: '8.x' # Kiota is a NET8 app
+
 - ${{ parameters.downloadSteps }}
 
 # checkout metadata repo if capture and clean step is skipped


### PR DESCRIPTION
Hidi is a net 7.0 app causing failure in metadata generation

Sample run at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=138236&view=logs&j=0c914960-8b50-5299-c9aa-dd3c9595168e

Will rerun SDK generation pipeline after merge. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1183)