### PR TITLE
[Java] Fix increment version

### DIFF
--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -13,6 +13,7 @@ steps:
 - pwsh : $(Build.SourcesDirectory)/${{ parameters.repoName }}/Scripts/incrementMinorVersion.ps1
   displayName: 'Increment minor version number'
   workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.repoName }}/Scripts'
+  condition: ne( '${{ parameters.repoName }}' , 'msgraph-sdk-java') # The msgraph-sdk-java repo already has a versioning strategy
 
 - pwsh: '$(scriptsDirectory)/copy-java-models-kiota.ps1'
   displayName: 'Update with new models'


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-java/pull/1939

Removes the increment version step for java as the script is removed in the above change. This unlbocks java sdk generation on the weekly pipeline.

https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=144721&view=logs&jobId=c52f3745-d4e6-5486-f10a-a43ce9aa535b&j=c52f3745-d4e6-5486-f10a-a43ce9aa535b&t=71b229cf-4300-5726-07d9-c4fd33aeb191

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1219)