### PR TITLE
Fix pipeline checkout branches for java

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -52,12 +52,12 @@ resources:
      type: github
      endpoint: microsoftgraph (22)
      name: microsoftgraph/msgraph-sdk-java
-     ref: dev
+     ref: main
    - repository: msgraph-beta-sdk-java
      type: github
      endpoint: microsoftgraph (22)
      name: microsoftgraph/msgraph-beta-sdk-java
-     ref: dev
+     ref: main
    - repository: msgraph-sdk-go
      type: github
      endpoint: microsoftgraph (22)


### PR DESCRIPTION
`dev` branches no longer exists so pipelines cannot perform checkouts.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1234)