### PR TITLE
feat: remove manual version bump, rely on release please for go

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -342,6 +342,7 @@ stages:
         targetClassName: "GraphBaseServiceClient"
         targetNamespace: "github.com/microsoftgraph/msgraph-sdk-go/"
         customArguments: "-b -e '/me' -e '/me/**'" # Exclude me and Enable the backing store
+        commitMessagePrefix: "feat(generation): update request builders and models"
         cleanMetadataFolder: $(cleanOpenAPIFolderV1)
         languageSpecificSteps:
         - template: generation-templates/go.yml
@@ -370,6 +371,7 @@ stages:
         targetClassName: "GraphBaseServiceClient"
         targetNamespace: "github.com/microsoftgraph/msgraph-beta-sdk-go/"
         customArguments: "-b -e '/me' -e '/me/**'" # Exclude me and Enable the backing store
+        commitMessagePrefix: "feat(generation): update request builders and models"
         cleanMetadataFolder: $(cleanOpenAPIFolderBeta)
         languageSpecificSteps:
         - template: generation-templates/go.yml

--- a/.azure-pipelines/generation-templates/go.yml
+++ b/.azure-pipelines/generation-templates/go.yml
@@ -8,10 +8,6 @@ steps:
   env:
     MainDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/
 
-- pwsh : $(Build.SourcesDirectory)/${{ parameters.repoName }}/scripts/incrementMinorVersion.ps1
-  displayName: 'Increment minor version number'
-  workingDirectory: '$(Build.SourcesDirectory)/${{ parameters.repoName }}/scripts'
-
 - pwsh: '$(scriptsDirectory)/copy-go-models.ps1'
   displayName: 'Update models'
   env:


### PR DESCRIPTION
## Summary

Removes the manual version bump script for go and rely on `release please` configured in the repo


## Links to issues or work items this PR addresses

Follow up to PR's https://github.com/microsoftgraph/msgraph-sdk-go/pull/713 and https://github.com/microsoftgraph/msgraph-beta-sdk-go/pull/418
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1236)