### PR TITLE
fix: overwrite existing file if present.

### DIFF
--- a/.azure-pipelines/generation-templates/java-kiota.yml
+++ b/.azure-pipelines/generation-templates/java-kiota.yml
@@ -18,6 +18,6 @@ steps:
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/
 
 - pwsh: |
-    Move-Item -Path "*.txt","*.json" -Destination "$(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/"
+    Move-Item -Path "*.txt","*.json" -Destination "$(Build.SourcesDirectory)/${{ parameters.repoName }}/src/main/java/${{ parameters.namespacePath }}/generated/" -Force
   displayName: Move kiota specific metadata to expected location (txt for export file, json for lock or workspace file)
   workingDirectory: $(kiotaDirectory)/output/

--- a/.azure-pipelines/generation-templates/typescript-sdk.yml
+++ b/.azure-pipelines/generation-templates/typescript-sdk.yml
@@ -18,6 +18,6 @@ steps:
 
 
 - pwsh: |
-    Move-Item -Path "*.txt","*.json" -Destination "$(Build.SourcesDirectory)/${{ parameters.repoName }}/packages/"
+    Move-Item -Path "*.txt","*.json" -Destination "$(Build.SourcesDirectory)/${{ parameters.repoName }}/packages/" -Force
   displayName: Move kiota specific metadata to expected location (txt for export file, json for lock or workspace file)
   workingDirectory: $(kiotaDirectory)/output/


### PR DESCRIPTION
Fixes failing copy of dom export file in TS pipeline

https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=162820&view=logs&j=b56651c9-d0cc-5029-fad3-f9889cfa9c40&t=f95306b9-2fa1-54d2-3f1c-886a1f224e7f