### PR TITLE
feat: exclude TCP APIs from language generation.

### DIFF
--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -48,6 +48,10 @@ parameters:
   type: boolean
   default: true
 
+- name: pathExclusionArguments
+  type: string
+  default: "-e '/copilot' -e '/copilot/**'"
+
 steps:
 - template: set-up-for-generation-kiota.yml
   parameters:
@@ -82,7 +86,7 @@ steps:
     BranchName: ${{ parameters.branchName }}
   workingDirectory: ${{ parameters.repoName }}
 
-- bash: '$(kiotaDirectory)/kiota generate --openapi $(Build.SourcesDirectory)/msgraph-metadata/${{ parameters.cleanMetadataFolder }}/openapi.yaml --language ${{ parameters.language }} -o $(kiotaDirectory)/output -n ${{ parameters.targetNamespace }} -c ${{ parameters.targetClassName }} ${{ parameters.customArguments }}'
+- bash: '$(kiotaDirectory)/kiota generate --openapi $(Build.SourcesDirectory)/msgraph-metadata/${{ parameters.cleanMetadataFolder }}/openapi.yaml --language ${{ parameters.language }} -o $(kiotaDirectory)/output -n ${{ parameters.targetNamespace }} -c ${{ parameters.targetClassName }} ${{ parameters.customArguments }} ${{ parameters.pathExclusionArguments }}'
   displayName: 'Run Kiota for ${{ parameters.language }} ${{ parameters.version }}'
   env:
     KIOTA_GENERATION:EXPORTPUBLICAPI: ${{ parameters.exportDom }}

--- a/scripts/copy-typescript-sdk-models.ps1
+++ b/scripts/copy-typescript-sdk-models.ps1
@@ -18,8 +18,13 @@ Invoke-Expression "$PSScriptRoot\remove-typescript-fluent-api-from-main-package.
 $packagesDirectories = Get-ChildItem $targetDirectory -Directory -Exclude $mainPackageDirectoryName | Where-Object { -not($_.Name.EndsWith("-tests")) }
 foreach ($directory in $packagesDirectories) {
     $fluentAPISegmentName = $directory.Name.Replace("$mainPackageDirectoryName-", "")
-    Copy-Item (Join-Path $sourceDirectory -ChildPath $fluentAPISegmentName) -Destination $directory.FullName -Recurse -Force
-    Invoke-Expression "$PSScriptRoot\fix-typescript-fluent-packages-imports.ps1 -targetDirectory $($directory.FullName) -packageName $packageName"
+    if (Test-Path -Path (Join-Path $sourceDirectory -ChildPath $fluentAPISegmentName)) {
+        Copy-Item (Join-Path $sourceDirectory -ChildPath $fluentAPISegmentName) -Destination $directory.FullName -Recurse -Force
+        Invoke-Expression "$PSScriptRoot\fix-typescript-fluent-packages-imports.ps1 -targetDirectory $($directory.FullName) -packageName $packageName"
+    }
+    else {
+        Write-Host "Skipping the fluent API segment: $fluentAPISegmentName as it does not exist in the generated models" -ForegroundColor Yellow
+    }
 }
 
 Write-Host "Copied the generated files into the repo. From: $sourceDirectory to: $targetDirectory" -ForegroundColor Green

--- a/scripts/copy-typescript-sdk-models.ps1
+++ b/scripts/copy-typescript-sdk-models.ps1
@@ -23,7 +23,8 @@ foreach ($directory in $packagesDirectories) {
         Invoke-Expression "$PSScriptRoot\fix-typescript-fluent-packages-imports.ps1 -targetDirectory $($directory.FullName) -packageName $packageName"
     }
     else {
-        Write-Host "Skipping the fluent API segment: $fluentAPISegmentName as it does not exist in the generated models" -ForegroundColor Yellow
+        Remove-Item $directory.FullName -Force -Recurse -ErrorAction SilentlyContinue
+        Write-Host "Removing folder for the fluent API segment: $fluentAPISegmentName as it does not exist in the generated models" -ForegroundColor Yellow
     }
 }
 


### PR DESCRIPTION
Fixes #1293 
Also fixes TS generation failure due to non existent paths.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1298)