### PR TITLE
chore: unpins hidi

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -63,7 +63,7 @@ jobs:
   - template: checkout-metadata.yml
   - template: use-dotnet-sdk.yml
 
-  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.4.14
+  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi
     displayName: install hidi
 
   - pwsh: |


### PR DESCRIPTION
hidi v2 is now published on a -preview version.
defective hidi v1 versions have been deprecated
a new version of hidi v1 has been published, to benefit from recent changes in yoko but also for sanity

related #1295
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1306)