### PR TITLE
chore: Fix SDK generation

### DIFF
--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -12,7 +12,7 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/src/kiota/bin/$(BuildConfiguration)/net8.0'
+    sourceFolder: '$(Build.SourcesDirectory)/src/kiota/bin/$(BuildConfiguration)/net9.0'
     contents: '**/*'
     targetFolder: '$(Build.ArtifactStagingDirectory)'
   displayName: Copy Kiota executable

--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -1,5 +1,7 @@
 steps:
 - template: use-dotnet-sdk.yml
+  parameters:
+    version: "9.x" #kiota uses a net9 target
 
 - checkout: kiota
   displayName: checkout kiota

--- a/.azure-pipelines/generation-templates/set-up-for-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/set-up-for-generation-kiota.yml
@@ -10,6 +10,8 @@ parameters:
 steps:
 - template: set-user-config.yml
 - template: use-dotnet-sdk.yml
+  parameters:
+    version: "9.x" #kiota uses a net9 target
 
 - ${{ parameters.downloadSteps }}
 


### PR DESCRIPTION
Related to changes in https://github.com/microsoft/kiota/pull/6006

Kiota needs a NET 9 target for it to be built/run.