### PR TITLE
ci: removes dotnet build as it's redudant with the PR CI and often pushes us over the 1 hour time limit for the generation

### DIFF
--- a/.azure-pipelines/generation-templates/dotnet-kiota.yml
+++ b/.azure-pipelines/generation-templates/dotnet-kiota.yml
@@ -10,11 +10,3 @@ steps:
     OutputFullPath: $(kiotaDirectory)/output/*
     RepoModelsDir: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/Generated/
 
-- pwsh: 'dotnet restore'
-  displayName: Restore dependencies for ${{ parameters.repoName }}
-  workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}
-
-- pwsh: 'dotnet build --configuration $(buildConfiguration) -f netstandard2.0 --no-restore'
-  displayName: Build dll for ${{ parameters.repoName }}
-  workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repoName }}/src/Microsoft.Graph/
-


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1338)