### PR TITLE
ci: remove old reference to objc repo which was archived almost 2 years ago now

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -43,11 +43,6 @@ resources:
      endpoint: microsoftgraph (22)
      name: microsoftgraph/msgraph-beta-typescript-typings
      ref: main
-   - repository: msgraph-sdk-objc-models
-     type: github
-     endpoint: microsoftgraph (22)
-     name: microsoftgraph/msgraph-sdk-objc-models
-     ref: dev
    - repository: msgraph-sdk-java
      type: github
      endpoint: microsoftgraph (22)


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1348)