### PR TITLE
ci: fixes another instance of the wrong version of dotnet being used for hidi

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -61,7 +61,11 @@ jobs:
     persistCredentials: true
 
   - template: checkout-metadata.yml
+
+  # required for the hidi installation validation
   - template: use-dotnet-sdk.yml
+    parameters:
+      version: '9.x'
 
   - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi
     displayName: install hidi

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -62,6 +62,11 @@ jobs:
 
   - template: checkout-metadata.yml
 
+  # required for the hidi to run
+  - template: use-dotnet-sdk.yml
+    parameters:
+      version: '8.x'
+
   # required for the hidi installation validation
   - template: use-dotnet-sdk.yml
     parameters:


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1352)