### PR TITLE
forcing hidi to use the last stable version

### DIFF
--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -72,7 +72,7 @@ jobs:
     parameters:
       version: '9.x'
 
-  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi
+  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.6.24 
     displayName: install hidi
 
   - pwsh: |


### PR DESCRIPTION
## Summary

Current Hidi version (2.0) generates some a openapi descriptions that does not translates well to kiota. Causing some issue like entities not being generated with their properties even if they are on the description and metadata

## Generated code differences

Pull requests that result in changes to generated code and/or directory structures should include example diffs of the resulting changes. This makes code review much easier.

## Command line arguments to run these changes

Provide the command line arguments here so that reviewers can quickly repro the results of changes.

## Links to issues or work items this PR addresses
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1373)