### PR TITLE
ci: use wildcard version for Microsoft.OpenApi.Hidi install

### DIFF
--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -153,7 +153,7 @@ steps:
   parameters:
     version: '9.x'
 
-- pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.6.24
+- pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.*
   displayName: 'Install hidi tool'
 
 # verify that generated metadata is parsable as an Edm model

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -71,7 +71,7 @@ jobs:
     parameters:
       version: '9.x'
 
-  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.6.24
+  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.*
     displayName: install hidi
 
   - pwsh: |


### PR DESCRIPTION
## Summary
Update the Microsoft.OpenApi.Hidi dotnet tool install command from a pinned version (1.6.24) to a \1.*\ wildcard so pipelines automatically resolve to the latest stable v1.x release.

## Changes
- **capture-metadata.yml**: \--version 1.6.24\ → \--version 1.*\
- **capture-openapi.yml**: \--version 1.6.24\ → \--version 1.*\

Closes #1439
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1440)