### PR TITLE
Fix conditional insertion syntax in kiota generation template

### DIFF
--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -70,7 +70,7 @@ steps:
     cleanMetadataFolder: ${{ parameters.cleanMetadataFolder }}
 
 # Default path: check out the target repo via its service connection.
-${{ if eq(parameters.useGitHubAppAuth, false) }}:
+- ${{ if eq(parameters.useGitHubAppAuth, false) }}:
   - checkout: ${{ parameters.repoName }}
     displayName: 'checkout ${{ parameters.repoName }}'
     fetchDepth: 1
@@ -85,7 +85,7 @@ ${{ if eq(parameters.useGitHubAppAuth, false) }}:
 
 # App-auth path: the target repo is public, so clone it anonymously (no PAT). The push
 # remote is switched to a GitHub App token in a later step before the push happens.
-${{ if eq(parameters.useGitHubAppAuth, true) }}:
+- ${{ if eq(parameters.useGitHubAppAuth, true) }}:
   - pwsh: |
       $repoDir = "$(Build.SourcesDirectory)/${{ parameters.repoName }}"
       if (Test-Path $repoDir) { Remove-Item $repoDir -Recurse -Force }
@@ -125,7 +125,7 @@ ${{ if eq(parameters.useGitHubAppAuth, true) }}:
 
 # App-auth path: fetch the App secrets and switch the push remote to the App token
 # BEFORE pushing.
-${{ if eq(parameters.useGitHubAppAuth, true) }}:
+- ${{ if eq(parameters.useGitHubAppAuth, true) }}:
   - task: AzureKeyVault@2
     displayName: "Azure Key Vault: Get Secrets"
     inputs:
@@ -153,7 +153,7 @@ ${{ if eq(parameters.useGitHubAppAuth, true) }}:
 
 # Default path: secrets are fetched after the push, just before PR creation. On the
 # App-auth path the secrets were already fetched above and persist for the PR step.
-${{ if eq(parameters.useGitHubAppAuth, false) }}:
+- ${{ if eq(parameters.useGitHubAppAuth, false) }}:
   - task: AzureKeyVault@2
     displayName: "Azure Key Vault: Get Secrets"
     inputs:


### PR DESCRIPTION
## Problem
Running `.azure-pipelines/generation-pipeline.yml` failed with:

`
 The 'stages' parameter is not a valid StageList.
 language-generation-kiota.yml (Line: 73): A template expression is not allowed in this context
 language-generation-kiota.yml (Line: 81): While parsing a block mapping, did not find expected key.
`

## Cause
The `${{ if ... }}:` conditional-insertion blocks live inside the `steps:` **sequence**, but were written as bare mapping keys without a leading `- `. In Azure Pipelines, a conditional insertion into a sequence must itself be a sequence item.

## Fix
Added the leading `- ` to the four conditional blocks (checkout, anonymous clone, App-auth Key Vault, default-path Key Vault).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1443)