### PR TITLE
ci: enable git core.longpaths before anonymous clone in app-auth path

### DIFF
--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -89,6 +89,7 @@ steps:
   - pwsh: |
       $repoDir = "$(Build.SourcesDirectory)/${{ parameters.repoName }}"
       if (Test-Path $repoDir) { Remove-Item $repoDir -Recurse -Force }
+      git config --global core.longpaths true
       git clone --depth 1 "https://github.com/${{ parameters.orgName }}/${{ parameters.repoName }}.git" "$repoDir"
       if ($LASTEXITCODE -ne 0) { throw "Failed to clone ${{ parameters.orgName }}/${{ parameters.repoName }}" }
     displayName: 'Clone ${{ parameters.repoName }} (anonymous, public repo)'


### PR DESCRIPTION
## Summary

Fixes the `Filename too long` / `unable to checkout working tree` failure when the generation pipeline clones **Agents-M365Copilot** on the Windows agent (e.g. [build 225181](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=225181)).

## Root cause

PR #1442 switched the 6 Agents-M365Copilot stages to the GitHub App auth path, which replaced the built-in `checkout:` task with a manual `git clone` (anonymous, public repo). The built-in `checkout:` task implicitly enables `core.longpaths`; the manual `git clone` does not.

## Change

`language-generation-kiota.yml`: set `git config --global core.longpaths true` immediately before the anonymous clone in the `useGitHubAppAuth: true` path. This restores the long-path support the built-in checkout previously provided.

## Scope

Only affects the app-auth clone path (the 6 Agents-M365Copilot stages). The `useGitHubAppAuth: false` SDK repos are untouched and continue to use the `checkout:` task, which already enables long paths.

> Automated change authored with GitHub Copilot CLI.
