### PR TITLE
Fix PR creation on GitHub App auth path (pass --head to gh pr create)

### DIFF
--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -166,6 +166,7 @@ steps:
   displayName: 'Create Pull Request for the generated build for ${{ parameters.repoName }}'
   env:
     BaseBranch: ${{ parameters.baseBranchName}}
+    BranchName: ${{ parameters.branchName }}
     GeneratePullRequest: ${{ parameters.generatePullRequest}}
     GhAppId: $(microsoft-graph-devx-bot-appid)
     GhAppKey: $(microsoft-graph-devx-bot-privatekey)

--- a/scripts/create-pull-request.ps1
+++ b/scripts/create-pull-request.ps1
@@ -30,6 +30,18 @@ if (![string]::IsNullOrEmpty($env:BaseBranch))
     $baseBranchParameter = "-B $env:BaseBranch" # optionally pass the base branch if provided as the PR will target the default branch otherwise
 }
 
+$headBranchParameter = ""
+
+if (![string]::IsNullOrEmpty($env:BranchName))
+{
+    # Explicitly set the head branch. On the GitHub App auth path the repository is cloned with
+    # 'git clone --depth 1', which implies --single-branch and only tracks the base branch. As a
+    # result no 'refs/remotes/origin/<branch>' tracking ref exists after pushing, so 'gh pr create'
+    # cannot auto-detect that the branch was pushed and aborts with "you must first push the current
+    # branch to a remote, or use the --head flag". Passing --head bypasses that detection.
+    $headBranchParameter = "-H $env:BranchName"
+}
+
 # The installed application is required to have the following permissions: read/write on pull requests/
 $tokenGenerationScript = "$env:ScriptsDirectory\Generate-Github-Token.ps1"
 $env:GITHUB_TOKEN = & $tokenGenerationScript -AppClientId $env:GhAppId -AppPrivateKeyContents $env:GhAppKey -Repository $env:RepoName
@@ -37,6 +49,11 @@ Write-Host "Fetched Github Token for PR generation and set as environment variab
 
 # No need to specify reviewers as code owners should be added automatically.
 Invoke-Expression "gh auth login" # login to GitHub
-Invoke-Expression "gh pr create -t ""$title"" -b ""$body"" $baseBranchParameter | Write-Host"
+Invoke-Expression "gh pr create -R ""$env:RepoName"" -t ""$title"" -b ""$body"" $baseBranchParameter $headBranchParameter | Write-Host"
+
+if ($LASTEXITCODE -ne 0)
+{
+    throw "Failed to create pull request for $env:RepoName (branch '$env:BranchName'). 'gh pr create' exited with code $LASTEXITCODE."
+}
 
 Write-Host "Pull Request Created successfully."


### PR DESCRIPTION
## Problem

Build **225234** failed on all 6 `microsoft/Agents-M365Copilot` generation jobs at the *Create Pull Request* step with:

```
aborted: you must first push the current branch to a remote, or use the --head flag
Pull Request Created successfully.
##[error]PowerShell exited with code '1'.
```

The push actually **succeeded** — the branches (`ccs-{dotnet,python,typescript}/{v1.0,beta}/pipelinebuild/225234`) exist on the remote, each ahead of `main` with the generated commit — but no PRs were created, and the log misleadingly printed "Pull Request Created successfully."

## Root cause

The GitHub App auth path (`useGitHubAppAuth: true`, used only by Agents-M365Copilot) clones with `git clone --depth 1`. `--depth 1` implies `--single-branch`, so `remote.origin.fetch` only tracks the base branch. After pushing the generated feature branch, **no `refs/remotes/origin/<branch>` tracking ref exists locally**. `gh pr create` (invoked without `--head`) detects the pushed head via that tracking ref, doesn't find it, and aborts — even though the branch is on the remote. The other SDK repos use the ADO `checkout:` task, which wires up full tracking refs, so they were unaffected.

## Fix

- **`scripts/create-pull-request.ps1`**: pass `-H $env:BranchName` (bypasses the tracking-ref auto-detection) and `-R $env:RepoName` to `gh pr create`; fail the step on a non-zero exit code instead of unconditionally printing success.
- **`language-generation-kiota.yml`**: thread `BranchName` into the `create-pull-request.ps1` step `env:` so the head branch is available (shared step — both auth paths get the more robust `--head`/`-R` invocation).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1445)