### PR TITLE
Fix Go generation deleting non-generated repo tooling (.config, .azure-pipelines)

### DIFF
--- a/scripts/clean-go-files.ps1
+++ b/scripts/clean-go-files.ps1
@@ -1,4 +1,8 @@
-$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", ".github" , "tests")
+# Only generated model/request-builder directories should be removed before regeneration.
+# Exclude hand-maintained folders and ALL dot-directories (".*" matches .github, .config,
+# .azure-pipelines, .vscode, .devcontainer, etc.) so repo tooling, CI and security-baseline
+# config are not deleted by generation runs.
+$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", "tests", ".*")
 foreach ($directory in $directories) {
 	Remove-Item -Path $directory.FullName -Recurse -Force -Verbose -Exclude *change_notification*, "change_type.go", "lifecycle_event_type.go", "resource_data.go", "resource_permission.go" , "resource_permission_collection_response.go"
 }


### PR DESCRIPTION
## Problem

`scripts/clean-go-files.ps1` deletes **every top-level directory** in the target repo except a hardcoded allow-list — `core`, `scripts`, `.github`, `tests` — before regenerating:

```powershell
$directories = Get-ChildItem -Path $env:MainDirectory -Directory -Exclude @("core", "scripts", ".github" , "tests")
```

That allow-list hasn't changed since **2023-06-12**, so any directory added since then is deleted wholesale on every Go generation run (kiota only regenerates the model/request-builder dirs, so anything else just vanishes from the branch).

`msgraph-sdk-go` / `msgraph-beta-sdk-go` recently gained repo tooling that isn't in the list:
- `.azure-pipelines/` — added 2026-05-15 (`daily-ci-build.yml`)
- `.config/` — added 2026-05-27 (1ES autobaselining + **Guardian `.gdnbaselines`**)

So the first generation PRs created after those files were added delete them:
- `microsoftgraph/msgraph-sdk-go#1013`, `#1014`
- `microsoftgraph/msgraph-beta-sdk-go#649`

Each drops `.azure-pipelines/daily-ci-build.yml`, `.config/1espt/PipelineAutobaseliningConfig.yml`, and `.config/guardian/.gdnbaselines` — removing CI config and security-scan baselines.

## Fix

Exclude **all dot-directories** via the `.*` wildcard (matches `.github`, `.config`, `.azure-pipelines`, `.vscode`, `.devcontainer`, …) in addition to `core`/`scripts`/`tests`. Generated model/request-builder directories never start with a dot, so they are still cleaned.

Verified in isolation: with `-Exclude @("core","scripts","tests",".*")`, `models`/`applications` are still returned for deletion while `.github`/`.config`/`.azure-pipelines`/`.vscode` are protected.

Both the v1.0 and beta Go stages share this script (`go.yml@self`), so this single change fixes both repos.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1446)