### PR TITLE
docs(ci): clarify why GitHub App auth is used for cross-org repos

### DIFF
--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -61,12 +61,6 @@ parameters:
 # needed their own separate PAT-backed one. This flag removes that PAT by reusing the
 # GitHub App identity (which already creates the PRs) for the push as well.
 #
-# NOTE: repo visibility is NOT what selects this path - the SDK repos on the default path
-# are public too. Visibility only affects HOW the target is read: when the repo is public
-# we can clone it anonymously and avoid needing any read credential at all, leaving the
-# App token needed only for the push. A private repo could still use App auth, but would
-# need a read credential instead of an anonymous clone.
-#
 # Defaults to false, which keeps the other SDK repos on their existing service-connection
 # checkout/push flow, unchanged.
 - name: useGitHubAppAuth

--- a/.azure-pipelines/generation-templates/language-generation-kiota.yml
+++ b/.azure-pipelines/generation-templates/language-generation-kiota.yml
@@ -56,10 +56,19 @@ parameters:
   type: string
   default: "-e '/copilot' -e '/copilot/**'"
 
-# When true, the target repository is read anonymously (public repo) and the generated
-# files are pushed using a GitHub App installation token instead of a PAT-backed service
-# connection. PR creation is App-based regardless. Defaults to false to preserve the
-# existing service connection based behaviour for the microsoftgraph SDK repos.
+# Set this to true for target repos that live in a different GitHub org than the shared
+# service connection covers. Those repos can't ride on that connection and historically
+# needed their own separate PAT-backed one. This flag removes that PAT by reusing the
+# GitHub App identity (which already creates the PRs) for the push as well.
+#
+# NOTE: repo visibility is NOT what selects this path - the SDK repos on the default path
+# are public too. Visibility only affects HOW the target is read: when the repo is public
+# we can clone it anonymously and avoid needing any read credential at all, leaving the
+# App token needed only for the push. A private repo could still use App auth, but would
+# need a read credential instead of an anonymous clone.
+#
+# Defaults to false, which keeps the other SDK repos on their existing service-connection
+# checkout/push flow, unchanged.
 - name: useGitHubAppAuth
   type: boolean
   default: false
@@ -83,8 +92,9 @@ steps:
   fetchDepth: 1
   persistCredentials: true
 
-# App-auth path: the target repo is public, so clone it anonymously (no PAT). The push
-# remote is switched to a GitHub App token in a later step before the push happens.
+# App-auth path: read the target with no credential. This is possible because the repo is
+# public - it is not why App auth is used (see the useGitHubAppAuth param notes). The push
+# remote is switched to a GitHub App token in a later step, before the push happens.
 - ${{ if eq(parameters.useGitHubAppAuth, true) }}:
   - pwsh: |
       $repoDir = "$(Build.SourcesDirectory)/${{ parameters.repoName }}"

--- a/scripts/set-app-token-push-url.ps1
+++ b/scripts/set-app-token-push-url.ps1
@@ -6,10 +6,8 @@
 # App identity (the same one that opens the PRs), which removes the need for a dedicated
 # PAT when the repo isn't covered by the pipeline's shared service connection.
 #
-# Only the push URL is changed; the fetch URL is left untouched. That is a deliberate
-# optimization for public repos (their initial clone was anonymous, so reads never needed
-# a credential) - it is not a requirement of using App auth.
-#
+# Only the push URL is changed; the fetch URL is left untouched (repos are public hence reads  
+# can be maintained as anonymous). 
 # Required environment variables:
 #   GhAppId          - GitHub App client ID (from AKV)
 #   GhAppKey         - GitHub App private key (from AKV)

--- a/scripts/set-app-token-push-url.ps1
+++ b/scripts/set-app-token-push-url.ps1
@@ -2,8 +2,13 @@
 # Licensed under the MIT License.
 
 # Configure the 'origin' push URL of an already-cloned repository to authenticate with a
-# GitHub App installation token instead of a PAT. The fetch URL is left untouched so reads
-# stay anonymous for public repositories.
+# GitHub App installation token instead of a PAT. This lets a repo be pushed to using the
+# App identity (the same one that opens the PRs), which removes the need for a dedicated
+# PAT when the repo isn't covered by the pipeline's shared service connection.
+#
+# Only the push URL is changed; the fetch URL is left untouched. That is a deliberate
+# optimization for public repos (their initial clone was anonymous, so reads never needed
+# a credential) - it is not a requirement of using App auth.
 #
 # Required environment variables:
 #   GhAppId          - GitHub App client ID (from AKV)


### PR DESCRIPTION
## Summary

Follow-up to #1442. Clarifies the comments/documentation around the `useGitHubAppAuth` path so the distinctions we landed on are explicit and not misleading.

> Note: this is a doc-only follow-up to #1442. The original comments implied the target repo being **public** is what drives the switch to GitHub App auth. It isn't - the other SDK repos are public too. The real driver is that the target repo lives in a **different GitHub org** than the shared service connection covers, which historically required its own PAT-backed connection; the flag removes that PAT by reusing the GitHub App identity that already opens the PRs. Public visibility only enables the anonymous, credential-free clone - it is not why App auth is used.

## Changes
- **`language-generation-kiota.yml`**: rewrote the `useGitHubAppAuth` param comment to lead with the cross-org / PAT-elimination rationale and add an explicit note that repo visibility is not the selector; reworded the anonymous-clone step comment to frame public visibility as the enabler of credential-free reads rather than the reason for App auth.
- **`scripts/set-app-token-push-url.ps1`**: reframed the header so push-only URL rewriting reads as a deliberate optimization for public repos, not a requirement of App auth.

No behavioral changes - comments/documentation only.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1447)