### PR TITLE
Fix S360 open-source vulnerabilities (SFI-ES5.2)

### DIFF
--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="9.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.18" />
     <PackageReference Include="Nito.AsyncEx">
       <Version>5.1.2</Version>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Pins `System.Security.Cryptography.Xml` in `src/Typewriter/Typewriter.csproj` from transitive 9.0.3 to 9.0.18.
- Addresses CVE-2026-26171 and CVE-2026-33116 for S360 KPI `[SFI-ES5.2] 1ES Open Source Vulnerabilities (Operational)`.

## Validation
- `dotnet restore .\Typewriter.sln --verbosity minimal`
- `dotnet build .\Typewriter.sln --no-restore --configuration Debug --verbosity minimal`
- `dotnet test .\GraphODataTemplateWriter.Test\GraphODataTemplateWriter.Test.csproj --no-build --configuration Debug --verbosity minimal`
- `dotnet test .\test\Typewriter.Test\Typewriter.Test.csproj --no-build --configuration Debug --verbosity minimal`
- `dotnet list .\src\Typewriter\Typewriter.csproj package --vulnerable --include-transitive` reports no vulnerable packages.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/1449)