### PR TITLE
Route Generation pipeline package restores through CFS feeds (CFSClean)

### DIFF
--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -130,6 +130,14 @@ parameters:
   displayName: Skip Open API PR Generation.
 variables:
   buildConfiguration: 'Release'
+  # dotnet CLI hygiene for 1ES network isolation (CFSClean): stop the CLI from reaching the
+  # public .NET CDN (builds.dotnet.microsoft.com) for workload/advertising-manifest and
+  # first-run/telemetry checks that piggyback on any `dotnet` invocation (e.g. the hidi tool
+  # install). Pipeline variables are surfaced as environment variables to every step.
+  DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 'true'
+  DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK: 'true'
+  DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+  DOTNET_NOLOGO: 'true'
   cleanMetadataFileBeta: '$(Build.SourcesDirectory)/msgraph-metadata/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml'
   cleanMetadataFileV1: '$(Build.SourcesDirectory)/msgraph-metadata/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml'
   cleanMetadataFileWithAnnotationsV1: '$(Build.SourcesDirectory)/msgraph-metadata/clean_v10_metadata/cleanMetadataWithDescriptionsAndAnnotationsv1.0.xml'

--- a/.azure-pipelines/generation-pipeline.yml
+++ b/.azure-pipelines/generation-pipeline.yml
@@ -201,20 +201,6 @@ extends:
             targetPath: '$(Build.ArtifactStagingDirectory)'
             artifactName: typewriter
         steps:
-        - task: NuGetAuthenticate@1
-          displayName: 'Authenticate to Azure Artifacts'
-
-        - pwsh: |
-            @"
-            <?xml version="1.0" encoding="utf-8"?>
-            <configuration>
-              <packageSources>
-                <clear />
-                <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
-              </packageSources>
-            </configuration>
-            "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
-          displayName: 'Create nuget.config (central feed)'
         - template: /.azure-pipelines/generation-templates/build-and-publish-typewriter.yml@self
     - stage: stage_build_and_publish_kiota
       dependsOn: [] # remove the implicit dependency to any previous stage
@@ -226,20 +212,7 @@ extends:
             targetPath: '$(Build.ArtifactStagingDirectory)'
             artifactName: kiota
         steps:
-        - task: NuGetAuthenticate@1
-          displayName: 'Authenticate to Azure Artifacts'
-
-        - pwsh: |
-            @"
-            <?xml version="1.0" encoding="utf-8"?>
-            <configuration>
-              <packageSources>
-                <clear />
-                <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
-              </packageSources>
-            </configuration>
-            "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
-          displayName: 'Create nuget.config (central feed)'
+        - template: /.azure-pipelines/generation-templates/create-cfs-nuget-config.yml@self
         - template: /.azure-pipelines/generation-templates/build-and-publish-kiota.yml@self
 # Downloads the latest public beta metadata. If there are changes, we checkin
 # the public metadata into microsoftgraph/msgraph-metadata, and then run the

--- a/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-kiota.yml
@@ -1,5 +1,6 @@
 steps:
 - pwsh: |
     dotnet tool install Microsoft.OpenApi.Kiota `
-          --tool-path "$(Build.ArtifactStagingDirectory)"
+          --tool-path "$(Build.ArtifactStagingDirectory)" `
+          --configfile "$(Agent.TempDirectory)/nuget.config"
   displayName: 'Install Kiota via dotnet tool'

--- a/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
+++ b/.azure-pipelines/generation-templates/build-and-publish-typewriter.yml
@@ -6,7 +6,11 @@ steps:
   submodules: recursive
   persistCredentials: true
 
-- pwsh: dotnet build $(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj --configuration $(buildConfiguration)
+# Create the CFS nuget.config AFTER checkout (a checkout clean would wipe a config written
+# into the sources dir) and restore against it, so dotnet build does not reach nuget.org.
+- template: /.azure-pipelines/generation-templates/create-cfs-nuget-config.yml@self
+
+- pwsh: dotnet build $(Build.SourcesDirectory)/src/Typewriter/Typewriter.csproj --configuration $(buildConfiguration) -p:RestoreConfigFile="$(Agent.TempDirectory)/nuget.config"
   displayName: 'Build Typewriter'
 
 - task: CopyFiles@2

--- a/.azure-pipelines/generation-templates/capture-metadata.yml
+++ b/.azure-pipelines/generation-templates/capture-metadata.yml
@@ -48,6 +48,11 @@ steps:
 - template: /.azure-pipelines/generation-templates/checkout-metadata.yml@self
 - template: /.azure-pipelines/generation-templates/set-user-config.yml@self
 
+# Route NuGet and npm through the CFS central feed for 1ES network isolation (CFSClean).
+# Placed after all checkouts so the generated config files are not wiped by a checkout clean.
+- template: /.azure-pipelines/generation-templates/create-cfs-nuget-config.yml@self
+- template: /.azure-pipelines/generation-templates/create-cfs-npmrc.yml@self
+
 # required for TypeSpec
 - task: UseNode@1
   inputs:
@@ -153,7 +158,7 @@ steps:
   parameters:
     version: '9.x'
 
-- pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.*
+- pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.* --configfile "$(Agent.TempDirectory)/nuget.config"
   displayName: 'Install hidi tool'
 
 # verify that generated metadata is parsable as an Edm model

--- a/.azure-pipelines/generation-templates/capture-openapi.yml
+++ b/.azure-pipelines/generation-templates/capture-openapi.yml
@@ -61,6 +61,9 @@ jobs:
     persistCredentials: true
 
   - template: /.azure-pipelines/generation-templates/checkout-metadata.yml@self
+  # Route NuGet through the CFS central feed for 1ES network isolation (CFSClean).
+  # Placed after all checkouts so the generated config is not wiped by a checkout clean.
+  - template: /.azure-pipelines/generation-templates/create-cfs-nuget-config.yml@self
   # required for the hidi to run
   - template: /.azure-pipelines/generation-templates/use-dotnet-sdk.yml@self
     parameters:
@@ -71,7 +74,7 @@ jobs:
     parameters:
       version: '9.x'
 
-  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.*
+  - pwsh: dotnet tool install --global Microsoft.OpenApi.Hidi --version 1.* --configfile "$(Agent.TempDirectory)/nuget.config"
     displayName: install hidi
 
   - pwsh: |

--- a/.azure-pipelines/generation-templates/create-cfs-npmrc.yml
+++ b/.azure-pipelines/generation-templates/create-cfs-npmrc.yml
@@ -1,0 +1,20 @@
+# Routes npm through the CFS central feed (GraphDeveloperExperiences_Public, which upstreams
+# npmjs.org) instead of hitting registry.npmjs.org directly, for 1ES network isolation (CFSClean).
+# The authenticated .npmrc is copied to the user profile so both global (`npm install -g`) and
+# project (`npm ci`) commands pick up the registry + credentials without per-step configuration.
+steps:
+- pwsh: |
+    @"
+    registry=https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/
+    always-auth=true
+    "@ | Set-Content -Path "$(Agent.TempDirectory)/.npmrc" -Encoding UTF8
+  displayName: 'Create .npmrc (CFS central feed)'
+
+- task: npmAuthenticate@0
+  displayName: 'Authenticate npm to CFS feed'
+  inputs:
+    workingFile: '$(Agent.TempDirectory)/.npmrc'
+
+- pwsh: |
+    Copy-Item -Path "$(Agent.TempDirectory)/.npmrc" -Destination (Join-Path $HOME '.npmrc') -Force
+  displayName: 'Apply CFS .npmrc to user profile'

--- a/.azure-pipelines/generation-templates/create-cfs-nuget-config.yml
+++ b/.azure-pipelines/generation-templates/create-cfs-nuget-config.yml
@@ -1,0 +1,20 @@
+# Routes dotnet/NuGet restore and tool installs through the CFS central package feed
+# (GraphDeveloperExperiences_Public) instead of public nuget.org, for 1ES network isolation
+# (CFSClean). The config is written to $(Agent.TempDirectory) so it survives any subsequent
+# `checkout` step (which cleans the sources directory and would wipe a config placed there).
+# Consumers must pass `--configfile "$(Agent.TempDirectory)/nuget.config"` to dotnet commands.
+steps:
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate to Azure Artifacts (CFS feed)'
+
+- pwsh: |
+    @"
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <clear />
+        <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+      </packageSources>
+    </configuration>
+    "@ | Set-Content -Path "$(Agent.TempDirectory)/nuget.config" -Encoding UTF8
+  displayName: 'Create nuget.config (CFS central feed)'


### PR DESCRIPTION
## What
Routes the `Generation` pipeline (definitionId 79) package restores through the **CFS central feed** (`GraphDeveloperExperiences_Public`) across the metadata-capture, OpenAPI-capture, typewriter, and kiota stages, and suppresses the dotnet CLI''s public-CDN checks — fixing the pipeline''s **CFSClean** network-isolation failures.

## Why
Telemetry for the last run (build 230485) shows CFSClean violations from public egress:
- `dotnet` -> `api.nuget.org` in `build_and_publish_typewriter`, `v1_metadata`, `beta_metadata`, and all 8 `Convert *` (OpenAPI) jobs.
- `npm` -> `registry.npmjs.org` in `v1_metadata` / `beta_metadata` (~60 hits) from `npm install -g @typespec/compiler typescript` and `npm ci`.
- `dotnet.exe` -> `builds.dotnet.microsoft.com` in `Convert v1.0-graphexplorer` (intermittent; the CLI workload/advertising-manifest check piggybacking on the hidi `dotnet tool install` — not `UseDotNet@2`, and not `generate-open-api.ps1`, which only runs `hidi` locally).

PR #1448 added a `nuget.config` to the typewriter/kiota stages but wrote it to `$(Build.SourcesDirectory)` **before** the typewriter template runs `checkout: self`, which cleans the sources dir and **wipes the untracked config** — so `dotnet build` still restored from nuget.org. The capture jobs were never covered.

## Changes
- **New** `create-cfs-nuget-config.yml`: `NuGetAuthenticate@1` + writes `nuget.config` (`<clear/>` + CFS feed) to `$(Agent.TempDirectory)` so it **survives checkout cleans**.
- **New** `create-cfs-npmrc.yml`: `npmAuthenticate@0` + CFS npm-registry `.npmrc` applied to the user profile (covers `npm install -g` and `npm ci`).
- `capture-metadata.yml`: include both templates after the checkouts; `--configfile` on the hidi install.
- `capture-openapi.yml` (`convert_openapi`): include the nuget-config template after checkouts; `--configfile` on the hidi install.
- `build-and-publish-typewriter.yml`: create the CFS config **after** `checkout: self`; restore via `-p:RestoreConfigFile`.
- `build-and-publish-kiota.yml`: `--configfile` on the kiota tool install.
- `generation-pipeline.yml`: remove the now-redundant inline `NuGetAuthenticate`/create-config steps; add pipeline `variables` `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE`, `DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`, `DOTNET_CLI_TELEMETRY_OPTOUT`, `DOTNET_NOLOGO` (surfaced as env vars to every step) to stop the dotnet CLI CDN checks.

## Notes / follow-ups
- **npm lockfile caveat:** `npm ci` restores from resolved URLs pinned in the lockfile; if those point at `registry.npmjs.org` the registry override may not fully redirect. The global `npm install -g` calls (the bulk of the hits) route to CFS immediately; a lockfile refresh against the feed may be needed to fully clean `npm ci`.
- **Out of scope:** `go_beta` git-lfs -> `github-cloud.s3.amazonaws.com` (DefaultDeny tier, not CFSClean).

Relates to S360 KPI 527fb616-07aa-8198-6419-50d04ef1c2f3 (Vulnerability Management / 1ES network isolation).
